### PR TITLE
CVL-14: Corrected RDS secret name

### DIFF
--- a/helm_deploy/create-and-vary-a-licence-api/values.yaml
+++ b/helm_deploy/create-and-vary-a-licence-api/values.yaml
@@ -35,7 +35,7 @@ generic-service:
     rds-instance-output:
       DB_SERVER: "rds_instance_address"
       DB_NAME: "database_name"
-      DB_USER: "database_user"
+      DB_USER: "database_username"
       DB_PASS: "database_password"
 
   allowlist:


### PR DESCRIPTION
Corrected database_user to database_username within the rds-instance-output secret.