### PR TITLE
CVSL-113: Upgrade MoJ Springboot Library to resolve security vulnerability CVE-2020-0822

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Start up the docker dependencies using the docker-compose file in the `create-an
 There is a script to help, which sets local profiles, port and DB connection properties to the 
 values required.
 
-`$ ./run-full.sh`
+`$ ./run-local.sh`
 
 Or, to run with default properties set in the docker-compose file
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "3.3.7"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "3.3.8"
   kotlin("plugin.spring") version "1.5.30"
   kotlin("plugin.jpa") version "1.5.30"
 }


### PR DESCRIPTION
- From MoJ Springboot library 3.3.8 release notes

```
CVE-2020-0822 states: | An elevation of privilege vulnerability exists when the Windows Language Pack Installer improperly handles file operations, aka 'Windows Language Pack Installer Elevation of Privilege Vulnerability'.

This does not affect linux distributions so needs to be suppressed.
```