### PR TITLE
CVSL-111: Endpoint to update bespoke conditions for a licence

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/BespokeConditionRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/BespokeConditionRequest.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model
+
+import io.swagger.v3.oas.annotations.media.Schema
+import javax.validation.constraints.NotNull
+
+@Schema(description = "A list of bespoke conditions to add to a licence")
+data class BespokeConditionRequest(
+  @Schema(description = "A list of bespoke conditions to add to a licence", example = "['cond1', 'cond2']")
+  @field:NotNull
+  val conditions: List<String> = emptyList()
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/repository/BespokeConditionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/repository/BespokeConditionRepository.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.BespokeCondition
+
+@Repository
+interface BespokeConditionRepository : JpaRepository<BespokeCondition, Long> {
+  fun deleteByLicenceId(id: Long): Long
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/repository/LicenceRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/repository/LicenceRepository.kt
@@ -7,6 +7,5 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus
 
 @Repository
 interface LicenceRepository : JpaRepository<Licence, Long> {
-
   fun findAllByNomsIdAndStatusCodeIn(nomsId: String, status: List<LicenceStatus>): List<Licence>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/LicenceController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/LicenceController.kt
@@ -20,6 +20,7 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.config.ErrorRespons
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AppointmentAddressRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AppointmentPersonRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AppointmentTimeRequest
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.BespokeConditionRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.ContactNumberRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.CreateLicenceRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.CreateLicenceResponse
@@ -270,5 +271,47 @@ class LicenceController(private val licenceService: LicenceService) {
     @Valid @RequestBody request: AppointmentAddressRequest
   ) {
     licenceService.updateAppointmentAddress(licenceId, request)
+  }
+
+  @PutMapping(value = ["/id/{licenceId}/bespoke-conditions"])
+  @PreAuthorize("hasAnyRole('SYSTEM_USER', 'CVL_ADMIN')")
+  @Operation(
+    summary = "Add or replace the bespoke conditions for a licence.",
+    description = "Add or replace the bespoke conditions on a licence with the content of this request. Requires ROLE_SYSTEM_USER or ROLE_CVL_ADMIN.",
+    security = [SecurityRequirement(name = "ROLE_SYSTEM_USER"), SecurityRequirement(name = "ROLE_CVL_ADMIN")],
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Bespoke conditions added or replaced"
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Bad request, request body must be valid",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorised, requires a valid Oauth2 token",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires an appropriate role",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "The licence for this ID was not found.",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      )
+    ]
+  )
+  fun updateBespokeConditions(
+    @PathVariable("licenceId") licenceId: Long,
+    @Valid @RequestBody request: BespokeConditionRequest
+  ) {
+    licenceService.updateBespokeConditions(licenceId, request)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceService.kt
@@ -5,10 +5,12 @@ import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AppointmentAddressRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AppointmentPersonRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AppointmentTimeRequest
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.BespokeConditionRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.ContactNumberRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.CreateLicenceRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.CreateLicenceResponse
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.Licence
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.BespokeConditionRepository
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.LicenceRepository
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.StandardConditionRepository
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus.IN_PROGRESS
@@ -16,11 +18,13 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus.
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus.SUBMITTED
 import javax.persistence.EntityNotFoundException
 import javax.validation.ValidationException
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.BespokeCondition as EntityBespokeCondition
 
 @Service
 class LicenceService(
   private val licenceRepository: LicenceRepository,
   private val standardConditionRepository: StandardConditionRepository,
+  private val bespokeConditionRepository: BespokeConditionRepository,
 ) {
 
   @Transactional
@@ -72,6 +76,19 @@ class LicenceService(
 
     val updatedLicence = licenceEntity.copy(appointmentAddress = request.appointmentAddress)
     licenceRepository.saveAndFlush(updatedLicence)
+  }
+
+  @Transactional
+  fun updateBespokeConditions(licenceId: Long, request: BespokeConditionRequest) {
+    val licenceEntity = licenceRepository
+      .findById(licenceId)
+      .orElseThrow { EntityNotFoundException("$licenceId") }
+    bespokeConditionRepository.deleteByLicenceId(licenceId)
+    request.conditions.forEachIndexed { index, condition ->
+      bespokeConditionRepository.saveAndFlush(
+        EntityBespokeCondition(licenceId = licenceId, conditionSequence = index, conditionText = condition)
+      )
+    }
   }
 
   private fun offenderHasLicenceInFlight(nomsId: String): Boolean {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/LicenceControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/LicenceControllerTest.kt
@@ -45,6 +45,7 @@ import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
 import javax.persistence.EntityNotFoundException
 import javax.validation.ValidationException
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.BespokeConditionRequest
 
 @ExtendWith(SpringExtension::class)
 @ActiveProfiles("test")
@@ -254,6 +255,32 @@ class LicenceControllerTest {
       .andExpect(content().contentType(APPLICATION_JSON))
   }
 
+  @Test
+  fun `update bespoke conditions`() {
+    mvc.perform(
+      put("/licence/id/4/bespoke-conditions")
+        .accept(APPLICATION_JSON)
+        .contentType(APPLICATION_JSON)
+        .content(mapper.writeValueAsBytes(aBespokeConditionsRequest))
+    )
+      .andExpect(status().isOk)
+
+    verify(licenceService, times(1)).updateBespokeConditions(4, aBespokeConditionsRequest)
+  }
+
+  @Test
+  fun `update bespoke conditions with an empty request removes previous bespoke conditions`() {
+    mvc.perform(
+      put("/licence/id/4/bespoke-conditions")
+        .accept(APPLICATION_JSON)
+        .contentType(APPLICATION_JSON)
+        .content(mapper.writeValueAsBytes(BespokeConditionRequest()))
+    )
+      .andExpect(status().isOk)
+
+    verify(licenceService, times(1)).updateBespokeConditions(4, BespokeConditionRequest())
+  }
+
   private companion object {
 
     val someStandardConditions = listOf(
@@ -375,6 +402,8 @@ class LicenceControllerTest {
     val anAppointmentAddressRequest = AppointmentAddressRequest(
       appointmentAddress = "221B Baker Street, London, City of London, NW1 6XE",
     )
+
+    val aBespokeConditionsRequest = BespokeConditionRequest(conditions = listOf("Bespoke 1", "Bespoke 2"))
   }
 
   // Other test candidates:


### PR DESCRIPTION
New or empty bespoke conditions will entirely replace any bespoke conditions which currently exist on this licence.
This should satisfy the requirements to both create and update bespoke conditions for a licence.