### PR TITLE
CVSL-119: Adding extra detail into the `LicenceSummary` object

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/LicenceSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/LicenceSummary.kt
@@ -23,6 +23,23 @@ data class LicenceSummary(
   @Schema(description = "The offender surname", example = "Smith")
   val surname: String?,
 
+  @Schema(description = "The offender forename", example = "Brian")
+  val forename: String?,
+
+  @Schema(description = "The prison code where this offender resides or was released from", example = "MDI")
+  val prisonCode: String?,
+
+  @Schema(description = "The prison where this offender resides or was released from", example = "Moorland (HMP)")
+  val prisonDescription: String?,
+
+  @Schema(description = "The conditional release date on the licence", example = "12/12/2022")
+  @JsonFormat(pattern = "dd/MM/yyyy")
+  val conditionalReleaseDate: LocalDate?,
+
+  @Schema(description = "The actual release date on the licence", example = "12/12/2022")
+  @JsonFormat(pattern = "dd/MM/yyyy")
+  val actualReleaseDate: LocalDate?,
+
   @Schema(description = "The case reference number (CRN) of this person, from either prison or probation service", example = "X12344")
   val crn: String?,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/TransformFunctions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/TransformFunctions.kt
@@ -30,7 +30,20 @@ fun transform(testData: EntityTestData): ModelTestData {
 }
 
 fun transformToLicenceSummary(licence: EntityLicence): LicenceSummary {
-  return LicenceSummary(licence.id, licence.typeCode, licence.statusCode, licence.nomsId, licence.surname, licence.crn, licence.dateOfBirth)
+  return LicenceSummary(
+    licenceId = licence.id,
+    licenceType = licence.typeCode,
+    licenceStatus = licence.statusCode,
+    nomisId = licence.nomsId,
+    surname = licence.surname,
+    forename = licence.forename,
+    crn = licence.crn,
+    dateOfBirth = licence.dateOfBirth,
+    prisonCode = licence.prisonCode,
+    prisonDescription = licence.prisonDescription,
+    conditionalReleaseDate = licence.conditionalReleaseDate,
+    actualReleaseDate = licence.actualReleaseDate
+  )
 }
 
 fun transformToListOfSummaries(licences: List<EntityLicence>): List<LicenceSummary> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/LicenceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/LicenceIntegrationTest.kt
@@ -384,8 +384,13 @@ class LicenceIntegrationTest : IntegrationTestBase() {
 
     assertThat(result?.size).isEqualTo(2)
     assertThat(result)
-      .extracting<Tuple> { tuple(it.licenceId, it.licenceStatus, it.nomisId) }
-      .contains(tuple(1L, LicenceStatus.SUBMITTED, "A1234AA"), tuple(2L, LicenceStatus.SUBMITTED, "B1234BB"))
+      .extracting<Tuple> {
+        tuple(it.licenceId, it.licenceStatus, it.nomisId, it.surname, it.forename, it.prisonCode, it.prisonDescription)
+      }
+      .contains(
+        tuple(1L, LicenceStatus.SUBMITTED, "A1234AA", "Alda", "Alan", "MDI", "Moorland HMP"),
+        tuple(2L, LicenceStatus.SUBMITTED, "B1234BB", "Bobson", "Bob", "MDI", "Moorland HMP"),
+      )
   }
 
   private companion object {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/LicenceControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/LicenceControllerTest.kt
@@ -456,9 +456,14 @@ class LicenceControllerTest {
       licenceType = LicenceType.AP,
       licenceStatus = LicenceStatus.IN_PROGRESS,
       nomisId = "A1234AA",
+      forename = "Bob",
       surname = "Mortimer",
       crn = "X12345",
-      dateOfBirth = LocalDate.of(1985, 12, 28)
+      dateOfBirth = LocalDate.of(1985, 12, 28),
+      prisonCode = "MDI",
+      prisonDescription = "Moorland (HMP)",
+      conditionalReleaseDate = LocalDate.of(2022, 12, 28),
+      actualReleaseDate = LocalDate.of(2022, 12, 30)
     )
 
     val anUpdateAppointmentPersonRequest = AppointmentPersonRequest(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceServiceTest.kt
@@ -514,9 +514,14 @@ class LicenceServiceTest {
       licenceType = LicenceType.AP,
       licenceStatus = LicenceStatus.IN_PROGRESS,
       nomisId = "A1234AA",
+      forename = "Bob",
       surname = "Mortimer",
       crn = "X12345",
-      dateOfBirth = LocalDate.of(1985, 12, 28)
+      dateOfBirth = LocalDate.of(1985, 12, 28),
+      prisonCode = "MDI",
+      prisonDescription = "Moorland (HMP)",
+      conditionalReleaseDate = LocalDate.of(2021, 10, 22),
+      actualReleaseDate = LocalDate.of(2021, 10, 22)
     )
   }
 }


### PR DESCRIPTION
This PR adds forename, prisonCode, prisonDescription, actualReleaseDate and conditionalReleaseDate into the LicenceSummary object, so that it can be used to populate the approvals list.