### PR TITLE
CVSL-106: Update the list of additional conditions

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/entity/AdditionalCondition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/entity/AdditionalCondition.kt
@@ -2,13 +2,14 @@ package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity
 
 import org.hibernate.annotations.Fetch
 import org.hibernate.annotations.FetchMode
-import org.hibernate.annotations.LazyCollection
-import org.hibernate.annotations.LazyCollectionOption
+import javax.persistence.CascadeType
 import javax.persistence.Entity
+import javax.persistence.FetchType
 import javax.persistence.GeneratedValue
 import javax.persistence.GenerationType.IDENTITY
 import javax.persistence.Id
 import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
 import javax.persistence.OneToMany
 import javax.persistence.OrderBy
 import javax.persistence.Table
@@ -20,19 +21,18 @@ data class AdditionalCondition(
   @Id
   @GeneratedValue(strategy = IDENTITY)
   @NotNull
-  val id: Long = -1,
+  val id: Long? = null,
 
-  @NotNull
-  val licenceId: Long = -1,
+  @ManyToOne
+  @JoinColumn(name = "licence_id", nullable = false)
+  var licence: Licence? = null,
 
   val conditionCode: String? = null,
-  val conditionSequence: Int? = null,
-  val conditionText: String? = null,
+  var conditionSequence: Int? = null,
+  var conditionText: String? = null,
 
-  @JoinColumn(name = "additionalTermId")
+  @OneToMany(mappedBy = "additionalCondition", fetch = FetchType.EAGER, cascade = [CascadeType.ALL], orphanRemoval = true)
   @Fetch(FetchMode.SUBSELECT)
-  @LazyCollection(LazyCollectionOption.FALSE)
   @OrderBy("dataSequence")
-  @OneToMany
   val additionalConditionData: List<AdditionalConditionData> = emptyList(),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/entity/AdditionalCondition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/entity/AdditionalCondition.kt
@@ -21,11 +21,11 @@ data class AdditionalCondition(
   @Id
   @GeneratedValue(strategy = IDENTITY)
   @NotNull
-  val id: Long? = null,
+  val id: Long = -1,
 
   @ManyToOne
   @JoinColumn(name = "licence_id", nullable = false)
-  var licence: Licence? = null,
+  var licence: Licence,
 
   val conditionCode: String? = null,
   var conditionSequence: Int? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/entity/AdditionalConditionData.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/entity/AdditionalConditionData.kt
@@ -4,6 +4,8 @@ import javax.persistence.Entity
 import javax.persistence.GeneratedValue
 import javax.persistence.GenerationType
 import javax.persistence.Id
+import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
 import javax.persistence.Table
 import javax.validation.constraints.NotNull
 
@@ -15,8 +17,9 @@ data class AdditionalConditionData(
   @NotNull
   val id: Long = -1,
 
-  @NotNull
-  val additionalConditionId: Long = -1,
+  @ManyToOne
+  @JoinColumn(name = "additional_condition_id", nullable = false)
+  val additionalCondition: AdditionalCondition,
 
   @NotNull
   val dataSequence: Int = -1,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/entity/AdditionalConditionData.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/entity/AdditionalConditionData.kt
@@ -19,7 +19,7 @@ data class AdditionalConditionData(
 
   @ManyToOne
   @JoinColumn(name = "additional_condition_id", nullable = false)
-  val additionalCondition: AdditionalCondition? = null,
+  val additionalCondition: AdditionalCondition,
 
   @NotNull
   val dataSequence: Int = -1,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/entity/AdditionalConditionData.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/entity/AdditionalConditionData.kt
@@ -19,7 +19,7 @@ data class AdditionalConditionData(
 
   @ManyToOne
   @JoinColumn(name = "additional_condition_id", nullable = false)
-  val additionalCondition: AdditionalCondition,
+  val additionalCondition: AdditionalCondition? = null,
 
   @NotNull
   val dataSequence: Int = -1,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/entity/Licence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/entity/Licence.kt
@@ -10,9 +10,11 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceType
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceType.AP
 import java.time.LocalDate
 import java.time.LocalDateTime
+import javax.persistence.CascadeType
 import javax.persistence.Entity
 import javax.persistence.EnumType.STRING
 import javax.persistence.Enumerated
+import javax.persistence.FetchType
 import javax.persistence.GeneratedValue
 import javax.persistence.GenerationType
 import javax.persistence.Id
@@ -85,11 +87,9 @@ data class Licence(
   @OneToMany
   val standardConditions: List<StandardCondition> = emptyList(),
 
-  @JoinColumn(name = "licenceId")
+  @OneToMany(mappedBy = "licence", fetch = FetchType.EAGER, cascade = [CascadeType.ALL], orphanRemoval = true)
   @Fetch(value = FetchMode.SUBSELECT)
-  @LazyCollection(LazyCollectionOption.FALSE)
   @OrderBy("conditionSequence")
-  @OneToMany
   val additionalConditions: List<AdditionalCondition> = emptyList(),
 
   @JoinColumn(name = "licenceId")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/AdditionalCondition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/AdditionalCondition.kt
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 @Schema(description = "Describes an additional condition")
 data class AdditionalCondition(
   @Schema(description = "The internal ID for this additional condition for this licence", example = "98989")
-  val id: Long = -1,
+  val id: Long? = -1,
 
   @Schema(description = "Coded value for the additional condition", example = "meetingAddress")
   val code: String? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/AdditionalConditionsRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/AdditionalConditionsRequest.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model
+
+import io.swagger.v3.oas.annotations.media.Schema
+import javax.validation.constraints.NotNull
+
+@Schema(description = "Request object for updating the list of additional conditions on a licence")
+data class AdditionalConditionsRequest(
+  @Schema(description = "The list of additional conditions")
+  @field:NotNull
+  val additionalConditions: List<AdditionalCondition>,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceService.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service
 
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AdditionalConditionsRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AppointmentAddressRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AppointmentPersonRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AppointmentTimeRequest
@@ -99,6 +100,35 @@ class LicenceService(
         EntityBespokeCondition(licenceId = licenceId, conditionSequence = index, conditionText = condition)
       )
     }
+  }
+
+  fun updateAdditionalConditions(licenceId: Long, request: AdditionalConditionsRequest) {
+    val licenceEntity = licenceRepository
+      .findById(licenceId)
+      .orElseThrow { EntityNotFoundException("$licenceId") }
+
+    val additionalConditions = licenceEntity.additionalConditions.associateBy { it.conditionCode }.toMutableMap()
+    val newAdditionalConditions = request.additionalConditions.transformToEntityAdditional()
+
+    // Update any existing additional conditions with new values, or add the new condition if it doesn't exist.
+    newAdditionalConditions.forEach {
+      if (additionalConditions[it.conditionCode] != null) {
+        additionalConditions[it.conditionCode]?.conditionText = it.conditionText
+        additionalConditions[it.conditionCode]?.conditionSequence = it.conditionSequence
+      } else {
+        it.licence = licenceEntity
+        additionalConditions[it.conditionCode] = it
+      }
+    }
+
+    // Remove any additional conditions which exist on the licence, but were not specified in the request
+    val resultAdditionalConditionsList = additionalConditions.values.filter { condition ->
+      newAdditionalConditions.find { newAdditionalCondition -> newAdditionalCondition.conditionCode == condition.conditionCode } != null
+    }
+
+    val updatedLicence = licenceEntity.copy(additionalConditions = resultAdditionalConditionsList)
+
+    licenceRepository.save(updatedLicence)
   }
 
   @Transactional

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceService.kt
@@ -108,7 +108,7 @@ class LicenceService(
       .orElseThrow { EntityNotFoundException("$licenceId") }
 
     val additionalConditions = licenceEntity.additionalConditions.associateBy { it.conditionCode }.toMutableMap()
-    val newAdditionalConditions = request.additionalConditions.transformToEntityAdditional()
+    val newAdditionalConditions = request.additionalConditions.transformToEntityAdditional(licenceEntity)
 
     // Update any existing additional conditions with new values, or add the new condition if it doesn't exist.
     newAdditionalConditions.forEach {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/TransformFunctions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/TransformFunctions.kt
@@ -160,8 +160,19 @@ fun transform(entity: EntityStandardCondition): ModelStandardCondition {
   )
 }
 
+fun transform(model: ModelAdditionalCondition): EntityAdditionalCondition {
+  return EntityAdditionalCondition(
+    conditionCode = model.code,
+    conditionSequence = model.sequence,
+    conditionText = model.text
+  )
+}
+
 // Transform a list of entity additional conditions to model additional conditions
 fun List<EntityAdditionalCondition>.transformToModelAdditional(): List<ModelAdditionalCondition> = map(::transform)
+
+// Transform a list of model additional conditions to entity additional conditions
+fun List<ModelAdditionalCondition>.transformToEntityAdditional(): List<EntityAdditionalCondition> = map(::transform)
 
 fun transform(entity: EntityAdditionalCondition): ModelAdditionalCondition {
   return ModelAdditionalCondition(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/TransformFunctions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/TransformFunctions.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.BespokeCondit
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.Licence as ModelLicence
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.StandardCondition as ModelStandardCondition
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.TestData as ModelTestData
+import arrow.core.extensions.list.monad.map
 
 /*
 ** Functions which transform JPA entity objects into their API model equivalents and vice-versa.
@@ -160,11 +161,12 @@ fun transform(entity: EntityStandardCondition): ModelStandardCondition {
   )
 }
 
-fun transform(model: ModelAdditionalCondition): EntityAdditionalCondition {
+fun transform(model: ModelAdditionalCondition, licence: EntityLicence): EntityAdditionalCondition {
   return EntityAdditionalCondition(
     conditionCode = model.code,
     conditionSequence = model.sequence,
-    conditionText = model.text
+    conditionText = model.text,
+    licence = licence,
   )
 }
 
@@ -172,7 +174,7 @@ fun transform(model: ModelAdditionalCondition): EntityAdditionalCondition {
 fun List<EntityAdditionalCondition>.transformToModelAdditional(): List<ModelAdditionalCondition> = map(::transform)
 
 // Transform a list of model additional conditions to entity additional conditions
-fun List<ModelAdditionalCondition>.transformToEntityAdditional(): List<EntityAdditionalCondition> = map(::transform)
+fun List<ModelAdditionalCondition>.transformToEntityAdditional(licence: EntityLicence): List<EntityAdditionalCondition> = map { transform(it, licence) }
 
 fun transform(entity: EntityAdditionalCondition): ModelAdditionalCondition {
   return ModelAdditionalCondition(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/TransformFunctions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/TransformFunctions.kt
@@ -16,7 +16,6 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.BespokeCondit
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.Licence as ModelLicence
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.StandardCondition as ModelStandardCondition
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.TestData as ModelTestData
-import arrow.core.extensions.list.monad.map
 
 /*
 ** Functions which transform JPA entity objects into their API model equivalents and vice-versa.

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/LicenceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/LicenceIntegrationTest.kt
@@ -344,12 +344,14 @@ class LicenceIntegrationTest : IntegrationTestBase() {
 
     assertThat(result?.additionalConditions)
       .extracting<Tuple> { tuple(it.code, it.text, it.sequence) }
-      .containsAll(listOf(
-        tuple("code1", "text", 0),
-        tuple("code2", "text", 1),
-        tuple("code3", "text", 2),
-        tuple("code4", "text", 3)
-      ))
+      .containsAll(
+        listOf(
+          tuple("code1", "text", 0),
+          tuple("code2", "text", 1),
+          tuple("code3", "text", 2),
+          tuple("code4", "text", 3)
+        )
+      )
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/LicenceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/LicenceIntegrationTest.kt
@@ -344,7 +344,12 @@ class LicenceIntegrationTest : IntegrationTestBase() {
 
     assertThat(result?.additionalConditions)
       .extracting<Tuple> { tuple(it.code, it.text, it.sequence) }
-      .containsAll(listOf(tuple("code", "text", 0)))
+      .containsAll(listOf(
+        tuple("code1", "text", 0),
+        tuple("code2", "text", 1),
+        tuple("code3", "text", 2),
+        tuple("code4", "text", 3)
+      ))
   }
 
   @Test
@@ -484,7 +489,10 @@ class LicenceIntegrationTest : IntegrationTestBase() {
 
     val anAdditionalConditionsRequest = AdditionalConditionsRequest(
       additionalConditions = listOf(
-        AdditionalCondition(code = "code", sequence = 0, text = "text")
+        AdditionalCondition(code = "code1", sequence = 0, text = "text"),
+        AdditionalCondition(code = "code2", sequence = 1, text = "text"),
+        AdditionalCondition(code = "code3", sequence = 2, text = "text"),
+        AdditionalCondition(code = "code4", sequence = 3, text = "text")
       )
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/LicenceControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/LicenceControllerTest.kt
@@ -28,6 +28,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.config.ControllerAdvice
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AdditionalCondition
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AdditionalConditionData
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AdditionalConditionsRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AppointmentAddressRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AppointmentPersonRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AppointmentTimeRequest
@@ -326,6 +327,19 @@ class LicenceControllerTest {
   }
 
   @Test
+  fun `update the list of additional conditions`() {
+    mvc.perform(
+      put("/licence/id/4/additional-conditions")
+        .accept(APPLICATION_JSON)
+        .contentType(APPLICATION_JSON)
+        .content(mapper.writeValueAsBytes(anUpdateAdditionalConditionsListRequest))
+    )
+      .andExpect(status().isOk)
+
+    verify(licenceService, times(1)).updateAdditionalConditions(4, anUpdateAdditionalConditionsListRequest)
+  }
+
+  @Test
   fun `get a list of approval candidates by prisons`() {
     whenever(licenceService.findLicencesForApprovalByPrisonCaseload(listOf("MDI", "LEI"))).thenReturn(listOf(aLicenceSummary))
 
@@ -489,6 +503,8 @@ class LicenceControllerTest {
     val aBespokeConditionsRequest = BespokeConditionRequest(conditions = listOf("Bespoke 1", "Bespoke 2"))
 
     val aStatusUpdateRequest = StatusUpdateRequest(status = LicenceStatus.APPROVED, username = "X")
+
+    val anUpdateAdditionalConditionsListRequest = AdditionalConditionsRequest(additionalConditions = listOf(AdditionalCondition(code = "code", sequence = 0, text = "text")))
   }
 
   // Other test candidates:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceServiceTest.kt
@@ -452,8 +452,12 @@ class LicenceServiceTest {
           aLicenceEntity.copy(
             additionalConditions = listOf(
               EntityAdditionalCondition(
-                id = 1, conditionCode = "code", conditionSequence = 5, conditionText = "oldText",
-                additionalConditionData = listOf(AdditionalConditionData(dataDescription = "dataDescription"))
+                id = 1,
+                conditionCode = "code",
+                conditionSequence = 5,
+                conditionText = "oldText",
+                additionalConditionData = listOf(AdditionalConditionData(dataDescription = "dataDescription", additionalCondition = EntityAdditionalCondition(licence = aLicenceEntity))),
+                licence = aLicenceEntity
               )
             )
           )
@@ -471,7 +475,8 @@ class LicenceServiceTest {
     assertThat(licenceCaptor.value.additionalConditions).containsExactly(
       EntityAdditionalCondition(
         id = 1, conditionCode = "code", conditionSequence = 0, conditionText = "text",
-        additionalConditionData = listOf(AdditionalConditionData(dataDescription = "dataDescription"))
+        additionalConditionData = listOf(AdditionalConditionData(dataDescription = "dataDescription", additionalCondition = EntityAdditionalCondition(licence = aLicenceEntity))),
+        licence = aLicenceEntity
       )
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceServiceTest.kt
@@ -1,12 +1,5 @@
 package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service
 
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.AdditionalCondition as EntityAdditionalCondition
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.BespokeCondition as EntityBespokeCondition
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.Licence as EntityLicence
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.LicenceHistory as EntityLicenceHistory
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.StandardCondition as EntityStandardCondition
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.Licence as ModelLicence
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.StandardCondition as ModelStandardCondition
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.reset
@@ -41,6 +34,13 @@ import java.time.LocalDateTime
 import java.util.Optional
 import javax.persistence.EntityNotFoundException
 import javax.validation.ValidationException
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.AdditionalCondition as EntityAdditionalCondition
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.BespokeCondition as EntityBespokeCondition
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.Licence as EntityLicence
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.LicenceHistory as EntityLicenceHistory
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.StandardCondition as EntityStandardCondition
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.Licence as ModelLicence
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.StandardCondition as ModelStandardCondition
 
 class LicenceServiceTest {
   private val standardConditionRepository = mock<StandardConditionRepository>()
@@ -447,11 +447,18 @@ class LicenceServiceTest {
   @Test
   fun `update additional conditions`() {
     whenever(licenceRepository.findById(1L))
-      .thenReturn(Optional.of(
-        aLicenceEntity.copy(additionalConditions = listOf(
-          EntityAdditionalCondition(id = 1, conditionCode = "code", conditionSequence = 5, conditionText = "oldText",
-            additionalConditionData = listOf(AdditionalConditionData(dataDescription = "dataDescription")))
-        ))))
+      .thenReturn(
+        Optional.of(
+          aLicenceEntity.copy(
+            additionalConditions = listOf(
+              EntityAdditionalCondition(
+                id = 1, conditionCode = "code", conditionSequence = 5, conditionText = "oldText",
+                additionalConditionData = listOf(AdditionalConditionData(dataDescription = "dataDescription"))
+              )
+            )
+          )
+        )
+      )
 
     val request = AdditionalConditionsRequest(additionalConditions = listOf(AdditionalCondition(code = "code", text = "text", sequence = 0)))
 
@@ -462,8 +469,10 @@ class LicenceServiceTest {
     verify(licenceRepository, times(1)).save(licenceCaptor.capture())
 
     assertThat(licenceCaptor.value.additionalConditions).containsExactly(
-      EntityAdditionalCondition(id = 1, conditionCode = "code", conditionSequence = 0, conditionText = "text",
-      additionalConditionData = listOf(AdditionalConditionData(dataDescription = "dataDescription")))
+      EntityAdditionalCondition(
+        id = 1, conditionCode = "code", conditionSequence = 0, conditionText = "text",
+        additionalConditionData = listOf(AdditionalConditionData(dataDescription = "dataDescription"))
+      )
     )
   }
 


### PR DESCRIPTION
- Refactored the ManyToOne mapping for additional conditions to make use of Hibernates ability to manage the referential integrity for us. Should probably do this for bespoke and standard conditions too...
- Left the additional data endpoint for now.. needs some more thinking about