### PR TITLE
CVSL-174: Add endpoint to activate licences in bulk

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/LicenceController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/LicenceController.kt
@@ -555,4 +555,40 @@ class LicenceController(private val licenceService: LicenceService) {
   ) {
     return licenceService.updateLicenceStatus(licenceId, request)
   }
+
+  @PostMapping(value = ["/activate-licences"])
+  @PreAuthorize("hasAnyRole('SYSTEM_USER', 'CVL_ADMIN')")
+  @Operation(
+    summary = "Activate licences in bulk",
+    description = "Set licence statuses to ACTIVE. Accepts a list of licence IDs. Requires ROLE_SYSTEM_USER or ROLE_CVL_ADMIN.",
+    security = [SecurityRequirement(name = "ROLE_SYSTEM_USER"), SecurityRequirement(name = "ROLE_CVL_ADMIN")],
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Licences activated"
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Bad request, request body must be valid",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorised, requires a valid Oauth2 token",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires an appropriate role",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      )
+    ]
+  )
+  fun activateLicences(
+    @Valid @RequestBody request: List<Long>
+  ) {
+    licenceService.activateLicences(request)
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceService.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.LicenceR
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.StandardConditionRepository
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.toSpecification
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus.ACTIVE
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus.APPROVED
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus.INACTIVE
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus.IN_PROGRESS
@@ -229,6 +230,12 @@ class LicenceService(
   fun findLicencesMatchingCriteria(licenceQueryObject: LicenceQueryObject): List<LicenceSummary> {
     val matchingLicences = licenceRepository.findAll(licenceQueryObject.toSpecification())
     return transformToListOfSummaries(matchingLicences)
+  }
+
+  fun activateLicences(licenceIds: List<Long>) {
+    val matchingLicences = licenceRepository.findAllById(licenceIds)
+    val activatedLicences = matchingLicences.map { licence -> licence.copy(statusCode = ACTIVE) }
+    licenceRepository.saveAllAndFlush(activatedLicences)
   }
 
   private fun offenderHasLicenceInFlight(nomsId: String): Boolean {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceServiceTest.kt
@@ -561,6 +561,16 @@ class LicenceServiceTest {
   }
 
   @Test
+  fun `activate licences sets licence statuses to ACTIVE`() {
+    whenever(licenceRepository.findAllById(listOf(1))).thenReturn(listOf(aLicenceEntity.copy()))
+
+    service.activateLicences(listOf(1L))
+
+    verify(licenceRepository, times(1)).findAllById(listOf(1L))
+    verify(licenceRepository, times(1)).saveAllAndFlush(listOf(aLicenceEntity.copy(statusCode = LicenceStatus.ACTIVE)))
+  }
+
+  @Test
   fun `update additional condition data`() {
     whenever(licenceRepository.findById(1L))
       .thenReturn(


### PR DESCRIPTION
New endpoint `/licence/activate-licences` which accepts a list of licence IDs, and changes the status of each of those licences to ACTIVE