### PR TITLE
CVSL-274: Add submit licence endpoint which saves the COMs details

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/CreateLicenceRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/CreateLicenceRequest.kt
@@ -4,10 +4,15 @@ import com.fasterxml.jackson.annotation.JsonFormat
 import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceType
 import java.time.LocalDate
+import javax.validation.constraints.NotBlank
 import javax.validation.constraints.NotNull
 
 @Schema(description = "Request object for creating a new licence")
 data class CreateLicenceRequest(
+
+  @Schema(description = "The username of the person who is creating the licence", example = "joebloggs")
+  @field:NotBlank
+  val username: String,
 
   @Schema(description = "Type of licence requested - one of AP, PSS or AP_PSS", example = "AP")
   @NotNull
@@ -97,23 +102,6 @@ data class CreateLicenceRequest(
   @Schema(description = "The date when the post sentence supervision period ends, from prison services", example = "06/06/2023")
   @JsonFormat(pattern = "dd/MM/yyyy")
   val topupSupervisionExpiryDate: LocalDate? = null,
-
-  @Schema(description = "The forename of the offender manager, from probation services", example = "Paula")
-  val comFirstName: String? = null,
-
-  @Schema(description = "The surname of the offender manager, from probation services", example = "Wells")
-  val comLastName: String? = null,
-
-  @Schema(description = "The username used in login for the person creating this licence", example = "X1233")
-  @NotNull
-  val comUsername: String? = null,
-
-  @Schema(description = "The staff identifier of the offender manager, from probation services", example = "44553343")
-  @NotNull
-  val comStaffId: Long? = null,
-
-  @Schema(description = "The email address of the offender manager, from probation services", example = "paula.wells@northeast.probation.gov.uk")
-  val comEmail: String? = null,
 
   @Schema(description = "The telephone contact number for the offender manager, from probation services", example = "07876 443554")
   val comTelephone: String? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/LicenceSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/LicenceSummary.kt
@@ -45,5 +45,11 @@ data class LicenceSummary(
 
   @Schema(description = "The offender's date of birth, from either prison or probation services", example = "12/12/2001")
   @JsonFormat(pattern = "dd/MM/yyyy")
-  val dateOfBirth: LocalDate?
+  val dateOfBirth: LocalDate?,
+
+  @Schema(description = "The first name of the responsible probation officer", example = "John")
+  val comFirstName: String?,
+
+  @Schema(description = "The first name of the responsible probation officer", example = "Smythe")
+  val comLastName: String?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/SubmitLicenceRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/SubmitLicenceRequest.kt
@@ -1,0 +1,27 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model
+
+import io.swagger.v3.oas.annotations.media.Schema
+import javax.validation.constraints.NotBlank
+import javax.validation.constraints.NotNull
+
+@Schema(description = "Request object for submitting a licence")
+data class SubmitLicenceRequest(
+  @Schema(description = "The username of the person who is updating this status", example = "ssmyth")
+  @field:NotBlank
+  val username: String,
+
+  @Schema(description = "The DELIUS staff identifier of the person who is submitting status", example = "3000")
+  @field:NotNull
+  val staffIdentifier: Long,
+
+  @Schema(description = "The first name of the person who is submitting the licence", example = "John")
+  @field:NotBlank
+  val firstName: String,
+
+  @Schema(description = "The last name of the person who is submitting the licence", example = "Smythe")
+  @field:NotBlank
+  val surname: String,
+
+  @Schema(description = "The email address of the person who is submitting the licence", example = "s.smyth@probation.gov.uk")
+  val email: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/repository/LicenceRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/repository/LicenceRepository.kt
@@ -9,6 +9,4 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus
 @Repository
 interface LicenceRepository : JpaRepository<Licence, Long>, JpaSpecificationExecutor<Licence> {
   fun findAllByNomsIdAndStatusCodeIn(nomsId: String, status: List<LicenceStatus>): List<Licence>
-  fun findAllByComStaffIdAndStatusCodeIn(staffId: Long, status: List<LicenceStatus>): List<Licence>
-  fun findAllByComStaffId(staffId: Long): List<Licence>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/LicenceController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/LicenceController.kt
@@ -29,6 +29,7 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.CreateLicence
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.Licence
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.LicenceSummary
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.StatusUpdateRequest
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.SubmitLicenceRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.UpdateAdditionalConditionDataRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.LicenceQueryObject
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.LicenceService
@@ -322,39 +323,6 @@ class LicenceController(private val licenceService: LicenceService) {
     licenceService.updateBespokeConditions(licenceId, request)
   }
 
-  @GetMapping(value = ["/staffId/{staffId}"])
-  @PreAuthorize("hasAnyRole('SYSTEM_USER', 'CVL_ADMIN')")
-  @Operation(
-    summary = "Licences by Staff Id",
-    description = "Find licences associated with a supervising probation officer. Can be filtered by licence status. Requires ROLE_SYSTEM_USER or ROLE_CVL_ADMIN.",
-    security = [SecurityRequirement(name = "ROLE_SYSTEM_USER"), SecurityRequirement(name = "ROLE_CVL_ADMIN")],
-  )
-  @ApiResponses(
-    value = [
-      ApiResponse(
-        responseCode = "200",
-        description = "Licence details returned",
-        content = [Content(mediaType = "application/json", array = ArraySchema(schema = Schema(implementation = LicenceSummary::class)))],
-      ),
-      ApiResponse(
-        responseCode = "401",
-        description = "Unauthorised, requires a valid Oauth2 token",
-        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
-      ),
-      ApiResponse(
-        responseCode = "403",
-        description = "Forbidden, requires an appropriate role",
-        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
-      )
-    ]
-  )
-  fun getLicencesByStaffIdAndStatuses(
-    @PathVariable("staffId") staffId: Long,
-    @RequestParam(name = "status", required = false) statuses: List<LicenceStatus>?
-  ): List<LicenceSummary> {
-    return licenceService.findLicencesByStaffIdAndStatuses(staffId, statuses)
-  }
-
   @GetMapping(value = ["/match"])
   @PreAuthorize("hasAnyRole('CVL_ADMIN')")
   @Operation(
@@ -560,5 +528,47 @@ class LicenceController(private val licenceService: LicenceService) {
     @Valid @RequestBody request: List<Long>
   ) {
     licenceService.activateLicences(request)
+  }
+
+  @PutMapping(value = ["/id/{licenceId}/submit"])
+  @PreAuthorize("hasAnyRole('SYSTEM_USER', 'CVL_ADMIN')")
+  @Operation(
+    summary = "Update the status of a licence to SUBMITTED, and record the details of the COM who submitted",
+    description = "Update the status of a licence to SUBMITTED, and record the details of the COM who submitted. Requires ROLE_SYSTEM_USER or ROLE_CVL_ADMIN.",
+    security = [SecurityRequirement(name = "ROLE_SYSTEM_USER"), SecurityRequirement(name = "ROLE_CVL_ADMIN")],
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Licence submitted for approval"
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Bad request, request body must be valid",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorised, requires a valid Oauth2 token",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires an appropriate role",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "The licence for this ID was not found.",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      )
+    ]
+  )
+  fun submitLicence(
+    @PathVariable("licenceId") licenceId: Long,
+    @Valid @RequestBody request: SubmitLicenceRequest
+  ) {
+    return licenceService.submitLicence(licenceId, request)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/TransformFunctions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/TransformFunctions.kt
@@ -42,7 +42,9 @@ fun transformToLicenceSummary(licence: EntityLicence): LicenceSummary {
     prisonCode = licence.prisonCode,
     prisonDescription = licence.prisonDescription,
     conditionalReleaseDate = licence.conditionalReleaseDate,
-    actualReleaseDate = licence.actualReleaseDate
+    actualReleaseDate = licence.actualReleaseDate,
+    comFirstName = licence.comFirstName,
+    comLastName = licence.comLastName,
   )
 }
 
@@ -76,16 +78,11 @@ fun transform(createRequest: CreateLicenceRequest): EntityLicence {
     licenceExpiryDate = createRequest.licenceExpiryDate,
     topupSupervisionStartDate = createRequest.topupSupervisionStartDate,
     topupSupervisionExpiryDate = createRequest.topupSupervisionExpiryDate,
-    comFirstName = createRequest.comFirstName,
-    comLastName = createRequest.comLastName,
-    comUsername = createRequest.comUsername,
-    comStaffId = createRequest.comStaffId,
-    comEmail = createRequest.comEmail,
     comTelephone = createRequest.comTelephone,
     probationAreaCode = createRequest.probationAreaCode,
     probationLduCode = createRequest.probationLduCode,
     dateCreated = LocalDateTime.now(),
-    createdByUsername = createRequest.comUsername,
+    createdByUsername = createRequest.username,
   )
 }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/LicenceControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/LicenceControllerTest.kt
@@ -40,6 +40,7 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.Licence
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.LicenceSummary
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.StandardCondition
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.StatusUpdateRequest
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.SubmitLicenceRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.UpdateAdditionalConditionDataRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.LicenceQueryObject
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.LicenceService
@@ -286,36 +287,6 @@ class LicenceControllerTest {
   }
 
   @Test
-  fun `get a list of licence summaries by staffId`() {
-    whenever(licenceService.findLicencesByStaffIdAndStatuses(1, null)).thenReturn(listOf(aLicenceSummary))
-
-    val result = mvc.perform(get("/licence/staffId/1").accept(APPLICATION_JSON))
-      .andExpect(status().isOk)
-      .andExpect(content().contentType(APPLICATION_JSON))
-      .andReturn()
-
-    assertThat(result.response.contentAsString)
-      .isEqualTo(mapper.writeValueAsString(listOf(aLicenceSummary)))
-
-    verify(licenceService, times(1)).findLicencesByStaffIdAndStatuses(1, null)
-  }
-
-  @Test
-  fun `get a list of licence summaries by staffId and filter by status`() {
-    whenever(licenceService.findLicencesByStaffIdAndStatuses(1, listOf(LicenceStatus.IN_PROGRESS, LicenceStatus.APPROVED))).thenReturn(listOf(aLicenceSummary))
-
-    val result = mvc.perform(get("/licence/staffId/1?status=IN_PROGRESS&status=APPROVED").accept(APPLICATION_JSON))
-      .andExpect(status().isOk)
-      .andExpect(content().contentType(APPLICATION_JSON))
-      .andReturn()
-
-    assertThat(result.response.contentAsString)
-      .isEqualTo(mapper.writeValueAsString(listOf(aLicenceSummary)))
-
-    verify(licenceService, times(1)).findLicencesByStaffIdAndStatuses(1, listOf(LicenceStatus.IN_PROGRESS, LicenceStatus.APPROVED))
-  }
-
-  @Test
   fun `match licences by prison code and status`() {
     val licenceQueryObject = LicenceQueryObject(prisonCodes = listOf("LEI"), statusCodes = listOf(LicenceStatus.APPROVED))
     whenever(licenceService.findLicencesMatchingCriteria(licenceQueryObject)).thenReturn(listOf(aLicenceSummary))
@@ -391,6 +362,19 @@ class LicenceControllerTest {
       .andExpect(status().isOk)
 
     verify(licenceService, times(1)).updateAdditionalConditionData(4, 1, anUpdateAdditionalConditionsDataRequest)
+  }
+
+  @Test
+  fun `submit a licence`() {
+    mvc.perform(
+      put("/licence/id/4/submit")
+        .accept(APPLICATION_JSON)
+        .contentType(APPLICATION_JSON)
+        .content(mapper.writeValueAsBytes(aSubmitLicenceRequest))
+    )
+      .andExpect(status().isOk)
+
+    verify(licenceService, times(1)).submitLicence(4, aSubmitLicenceRequest)
   }
 
   private companion object {
@@ -484,16 +468,12 @@ class LicenceControllerTest {
       licenceExpiryDate = LocalDate.of(2021, 10, 22),
       topupSupervisionStartDate = LocalDate.of(2021, 10, 22),
       topupSupervisionExpiryDate = LocalDate.of(2021, 10, 22),
-      comFirstName = "Stephen",
-      comLastName = "Mills",
-      comUsername = "X12345",
-      comStaffId = 12345,
-      comEmail = "stephen.mills@nps.gov.uk",
       comTelephone = "0116 2788777",
       probationAreaCode = "N01",
       probationLduCode = "LDU1",
       standardLicenceConditions = someStandardConditions,
-      standardPssConditions = someStandardConditions
+      standardPssConditions = someStandardConditions,
+      username = "jeobloggs"
     )
 
     val aLicenceSummary = LicenceSummary(
@@ -508,7 +488,9 @@ class LicenceControllerTest {
       prisonCode = "MDI",
       prisonDescription = "Moorland (HMP)",
       conditionalReleaseDate = LocalDate.of(2022, 12, 28),
-      actualReleaseDate = LocalDate.of(2022, 12, 30)
+      actualReleaseDate = LocalDate.of(2022, 12, 30),
+      comFirstName = "John",
+      comLastName = "Smythe",
     )
 
     val anUpdateAppointmentPersonRequest = AppointmentPersonRequest(
@@ -534,6 +516,8 @@ class LicenceControllerTest {
     val aBespokeConditionsRequest = BespokeConditionRequest(conditions = listOf("Bespoke 1", "Bespoke 2"))
 
     val aStatusUpdateRequest = StatusUpdateRequest(status = LicenceStatus.APPROVED, username = "X", fullName = "Jon Smith")
+
+    val aSubmitLicenceRequest = SubmitLicenceRequest(username = "jsmythe", staffIdentifier = 2000, firstName = "Jon", surname = "Smyth", email = "jsmith@probation.gov.uk")
 
     val anUpdateAdditionalConditionsListRequest = AdditionalConditionsRequest(additionalConditions = listOf(AdditionalCondition(code = "code", category = "category", sequence = 0, text = "text")), conditionType = "AP")
 


### PR DESCRIPTION
- Also removed the `getLicencesByStaffIdAndStatuses` endpoint as it's no longer used