### PR TITLE
CVSL-313: Revert to page render for map. Crop the borders away.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ExclusionZoneService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ExclusionZoneService.kt
@@ -2,7 +2,7 @@ package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service
 
 import org.apache.pdfbox.pdmodel.PDDocument
 import org.apache.pdfbox.pdmodel.encryption.InvalidPasswordException
-import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject
+import org.apache.pdfbox.rendering.PDFRenderer
 import org.apache.pdfbox.text.PDFTextStripper
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
@@ -146,15 +146,15 @@ class ExclusionZoneService(
     var pdfDoc: PDDocument? = null
     try {
       pdfDoc = PDDocument.load(fileStream)
-      val page = pdfDoc.pages.first()
-      page.resources.xObjectNames.forEach {
-        val o = page.resources.getXObject(it)
-        if (o is PDImageXObject) {
-          val baos = ByteArrayOutputStream()
-          ImageIO.write(o.image, "jpg", baos)
-          return baos.toByteArray()
-        }
-      }
+      val renderer = PDFRenderer(pdfDoc)
+      val firstImage = renderer.renderImage(0)
+      val croppedImage = firstImage.getSubimage(50, 50,firstImage.width - 100, firstImage.height - 100)
+      val baos = ByteArrayOutputStream()
+      ImageIO.write(croppedImage, "jpg", baos)
+
+      // Scale it back up to original size without the borders ?
+
+      return baos.toByteArray()
     } catch (e: IOException) {
       log.error("Extracting full size image - IO error ${e.message}")
     } catch (ipe: InvalidPasswordException) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ExclusionZoneService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ExclusionZoneService.kt
@@ -148,7 +148,7 @@ class ExclusionZoneService(
       pdfDoc = PDDocument.load(fileStream)
       val renderer = PDFRenderer(pdfDoc)
       val firstImage = renderer.renderImage(0)
-      val croppedImage = firstImage.getSubimage(50, 50,firstImage.width - 100, firstImage.height - 100)
+      val croppedImage = firstImage.getSubimage(50, 50, firstImage.width - 100, firstImage.height - 100)
       val baos = ByteArrayOutputStream()
       ImageIO.write(croppedImage, "jpg", baos)
 


### PR DESCRIPTION
Extracting the full-size image from the PDF produces a better/bigger image, but loses the zone overlay shape - which is kind of the point of the map! This change reverts to rendering page-1 of the PDF as an image, but then cropping away the borders so that we produce a reasonable map + overlay zone.