### PR TITLE
CVSL-339: Import kotlin JPA specification directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,16 +65,12 @@ that is seeded with data specific to each test suite.
 `$ ./gradlew dependencyCheckAnalyze`
 
 
-# Kotlin JPA specification dependency
+# Kotlin JPA specification
 
 This project makes use of `https://github.com/consoleau/kotlin-jpa-specification-dsl` to wrap the JPA specification
-in fluent style Kotlin and make it much more readable when creatig the JPA Specifications used in selecting licences
+in fluent style Kotlin and make it much more readable when creating the JPA Specifications used in selecting licences
 by criteria.
 
-As this dependency is not available in the Maven central repository yet (only in JCenter), and JCenter may be deprecated soon,
-it is possible to copy the single source file from the project and use it in our own stand-alone, retaining the copyright notices. 
-To do this, remove the dependency and Jcenter repo from build.gradle.kts and add the file. The project is open-source and 
-freely distributable/derivable under the Apache2 licence. For now, we can wait and see whether the dependency will soon become
-available in Maven central and decide what to do at a later date.
-
-
+As this dependency is not available in the Maven central repository yet, and JCenter has closed its
+services now, we have imported the single-file directly and kept the licence notification in the comments. 
+We can wait to see whether the dependency will soon become available in Maven central and import it from there.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,10 +35,6 @@ tasks.named<JacocoReport>("jacocoTestReport") {
   }
 }
 
-repositories {
-  jcenter()
-}
-
 dependencies {
   annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 
@@ -67,9 +63,6 @@ dependencies {
   implementation("org.springdoc:springdoc-openapi-ui:1.6.3")
   implementation("org.springdoc:springdoc-openapi-data-rest:1.6.3")
   implementation("org.springdoc:springdoc-openapi-kotlin:1.6.3")
-
-  // JPA Kotlin query DSL
-  implementation("au.com.console:kotlin-jpa-specification-dsl:2.0.0")
 
   // Test dependencies
   testImplementation("com.github.tomakehurst:wiremock-standalone:2.27.2")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/kotlinjpaspecificationdsl/JPASpecificationDSL.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/kotlinjpaspecificationdsl/JPASpecificationDSL.kt
@@ -1,0 +1,104 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.kotlinjpaspecificationdsl
+
+/*
+Duplicated work under the Apache 2.0 licence http://www.apache.org/licenses/LICENSE-2.0
+Hats off to https://github.com/consoleau/kotlin-jpa-specification-dsl and contributors for the original.
+Implemented here as a result of the JCenter repository closing and it not being available in other repositories yet.
+*/
+
+import org.springframework.data.jpa.domain.Specification
+import javax.persistence.criteria.CriteriaBuilder
+import javax.persistence.criteria.From
+import javax.persistence.criteria.Join
+import javax.persistence.criteria.Path
+import javax.persistence.criteria.Predicate
+import javax.persistence.criteria.Root
+import kotlin.reflect.KProperty1
+
+// Helper to allow joining to Properties
+fun <Z, T, R> From<Z, T>.join(prop: KProperty1<T, R?>): Join<T, R> = this.join<T, R>(prop.name)
+
+// Helper to enable get by Property
+fun <R> Path<*>.get(prop: KProperty1<*, R?>): Path<R> = this.get<R>(prop.name)
+
+// Version of Specification.where that makes the CriteriaBuilder implicit
+fun <T> where(makePredicate: CriteriaBuilder.(Root<T>) -> Predicate): Specification<T> =
+  Specification { root, _, criteriaBuilder -> criteriaBuilder.makePredicate(root) }
+
+// helper function for defining Specification that take a Path to a property and send it to a CriteriaBuilder
+private fun <T, R> KProperty1<T, R?>.spec(makePredicate: CriteriaBuilder.(path: Path<R>) -> Predicate): Specification<T> =
+  let { property -> where { root -> makePredicate(root.get(property)) } }
+
+// Equality
+fun <T, R> KProperty1<T, R?>.equal(x: R): Specification<T> = spec { equal(it, x) }
+
+fun <T, R> KProperty1<T, R?>.notEqual(x: R): Specification<T> = spec { notEqual(it, x) }
+
+// Ignores empty collection otherwise an empty 'in' predicate will be generated which will never match any results
+fun <T, R : Any> KProperty1<T, R?>.`in`(values: Collection<R>): Specification<T> = if (values.isNotEmpty()) spec { path ->
+  `in`(path).apply { values.forEach { this.value(it) } }
+} else Specification.where(null)
+
+// Comparison
+fun <T> KProperty1<T, Number?>.le(x: Number) = spec { le(it, x) }
+
+fun <T> KProperty1<T, Number?>.lt(x: Number) = spec { lt(it, x) }
+fun <T> KProperty1<T, Number?>.ge(x: Number) = spec { ge(it, x) }
+fun <T> KProperty1<T, Number?>.gt(x: Number) = spec { gt(it, x) }
+fun <T, R : Comparable<R>> KProperty1<T, R?>.lessThan(x: R) = spec { lessThan(it, x) }
+fun <T, R : Comparable<R>> KProperty1<T, R?>.lessThanOrEqualTo(x: R) = spec { lessThanOrEqualTo(it, x) }
+fun <T, R : Comparable<R>> KProperty1<T, R?>.greaterThan(x: R) = spec { greaterThan(it, x) }
+fun <T, R : Comparable<R>> KProperty1<T, R?>.greaterThanOrEqualTo(x: R) = spec { greaterThanOrEqualTo(it, x) }
+fun <T, R : Comparable<R>> KProperty1<T, R?>.between(x: R, y: R) = spec { between(it, x, y) }
+
+// True/False
+fun <T> KProperty1<T, Boolean?>.isTrue() = spec { isTrue(it) }
+
+fun <T> KProperty1<T, Boolean?>.isFalse() = spec { isFalse(it) }
+
+// Collections
+fun <T, R : Collection<*>> KProperty1<T, R?>.isEmpty() = spec { isEmpty(it) }
+
+fun <T, R : Collection<*>> KProperty1<T, R?>.isNotEmpty() = spec { isNotEmpty(it) }
+fun <T, E, R : Collection<E>> KProperty1<T, R?>.isMember(elem: E) = spec { isMember(elem, it) }
+fun <T, E, R : Collection<E>> KProperty1<T, R?>.isNotMember(elem: E) = spec { isNotMember(elem, it) }
+
+// Strings
+fun <T> KProperty1<T, String?>.like(x: String): Specification<T> = spec { like(it, x) }
+
+fun <T> KProperty1<T, String?>.like(x: String, escapeChar: Char): Specification<T> = spec { like(it, x, escapeChar) }
+fun <T> KProperty1<T, String?>.notLike(x: String): Specification<T> = spec { notLike(it, x) }
+fun <T> KProperty1<T, String?>.notLike(x: String, escapeChar: Char): Specification<T> = spec { notLike(it, x, escapeChar) }
+
+// And
+infix fun <T> Specification<T>.and(other: Specification<T>): Specification<T> = this.and(other)
+
+inline fun <reified T> and(vararg specs: Specification<T>?): Specification<T> {
+  return and(specs.toList())
+}
+
+inline fun <reified T> and(specs: Iterable<Specification<T>?>): Specification<T> {
+  return combineSpecification(specs, Specification<T>::and)
+}
+
+// Or
+infix fun <T> Specification<T>.or(other: Specification<T>): Specification<T> = this.or(other)
+
+inline fun <reified T> or(vararg specs: Specification<T>?): Specification<T> {
+  return or(specs.toList())
+}
+
+inline fun <reified T> or(specs: Iterable<Specification<T>?>): Specification<T> {
+  return combineSpecification(specs, Specification<T>::or)
+}
+
+// Not
+operator fun <T> Specification<T>.not(): Specification<T> = Specification.not(this)
+
+// Combines Specification with an operation
+inline fun <reified T> combineSpecification(specs: Iterable<Specification<T>?>, operation: Specification<T>.(Specification<T>) -> Specification<T>): Specification<T> {
+  return specs.filterNotNull().fold(emptySpecification()) { existing, new -> existing.operation(new) }
+}
+
+// Empty Specification
+inline fun <reified T> emptySpecification(): Specification<T> = Specification.where(null)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/repository/LicenceSpecifications.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/repository/LicenceSpecifications.kt
@@ -1,10 +1,10 @@
 package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository
 
-import au.com.console.jpaspecificationdsl.and
-import au.com.console.jpaspecificationdsl.`in`
 import org.springframework.data.domain.Sort
 import org.springframework.data.jpa.domain.Specification
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.Licence
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.kotlinjpaspecificationdsl.and
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.kotlinjpaspecificationdsl.`in`
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus
 import javax.validation.ValidationException
 


### PR DESCRIPTION
This is no longer available from the JCenter repo now.
Imported the single file (Apache 2.0) licence conditions.