### PR TITLE
CVSL-361 add auditing features

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/entity/AuditEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/entity/AuditEvent.kt
@@ -1,5 +1,7 @@
 package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity
 
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.AuditEventType
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.AuditEventType.USER_EVENT
 import java.time.LocalDateTime
 import javax.persistence.Entity
 import javax.persistence.EnumType
@@ -9,8 +11,6 @@ import javax.persistence.GenerationType
 import javax.persistence.Id
 import javax.persistence.Table
 import javax.validation.constraints.NotNull
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.AuditEventType
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.AuditEventType.USER_EVENT
 
 @Entity
 @Table(name = "audit_event")
@@ -35,4 +35,3 @@ data class AuditEvent(
 
   val detail: String? = null,
 )
-

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/entity/AuditEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/entity/AuditEvent.kt
@@ -1,0 +1,38 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity
+
+import java.time.LocalDateTime
+import javax.persistence.Entity
+import javax.persistence.EnumType
+import javax.persistence.Enumerated
+import javax.persistence.GeneratedValue
+import javax.persistence.GenerationType
+import javax.persistence.Id
+import javax.persistence.Table
+import javax.validation.constraints.NotNull
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.AuditEventType
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.AuditEventType.USER_EVENT
+
+@Entity
+@Table(name = "audit_event")
+data class AuditEvent(
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @NotNull
+  val id: Long? = -1,
+
+  val licenceId: Long? = null,
+
+  val eventTime: LocalDateTime = LocalDateTime.now(),
+
+  val username: String? = null,
+
+  val fullName: String? = null,
+
+  @Enumerated(EnumType.STRING)
+  val eventType: AuditEventType = USER_EVENT,
+
+  val summary: String? = null,
+
+  val detail: String? = null,
+)
+

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/AuditEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/AuditEvent.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat
 import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.AuditEventType
 import java.time.LocalDateTime
+import javax.validation.constraints.NotEmpty
 
 @Schema(description = "Describes an audit event request")
 data class AuditEvent(
@@ -18,15 +19,16 @@ data class AuditEvent(
   val eventTime: LocalDateTime = LocalDateTime.now(),
 
   @Schema(description = "Username who initiated the event, if a user event, or SYSTEM if an automated event", example = "X63533")
-  val username: String? = null,
+  val username: String? = "SYSTEM",
 
   @Schema(description = "The full name of the person who performed this auditable event, or SYSTEM if an automated event.", example = "Robert Mortimer")
-  val fullName: String? = null,
+  val fullName: String? = "SYSTEM",
 
   @Schema(description = "The event type. One of SYSTEM_EVENT or USER_EVENT", example = "USER_EVENT")
   val eventType: AuditEventType = AuditEventType.USER_EVENT,
 
   @Schema(description = "A summary of the action taken", example = "Updated a bespoke condition")
+  @NotEmpty
   val summary: String? = null,
 
   @Schema(description = "A detailed description of the action taken", example = "Updated a bespoke condition")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/AuditEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/AuditEvent.kt
@@ -1,0 +1,34 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.AuditEventType
+import java.time.LocalDateTime
+
+@Schema(description = "Describes an audit event request")
+data class AuditEvent(
+  @Schema(description = "The internal ID of the audit event", example = "1234")
+  val id: Long? = null,
+
+  @Schema(description = "The internal ID of the licence that this event related to, or null if unrelated to a licence", example = "1234")
+  val licenceId: Long? = null,
+
+  @Schema(description = "The date and time of the event", example = "12/01/2022 23:14:23")
+  @JsonFormat(pattern = "dd/MM/yyyy HH:mm:ss")
+  val eventTime: LocalDateTime = LocalDateTime.now(),
+
+  @Schema(description = "Username who initiated the event, if a user event, or SYSTEM if an automated event", example = "X63533")
+  val username: String? = null,
+
+  @Schema(description = "The full name of the person who performed this auditable event, or SYSTEM if an automated event.", example = "Robert Mortimer")
+  val fullName: String? = null,
+
+  @Schema(description = "The event type. One of SYSTEM_EVENT or USER_EVENT", example = "USER_EVENT")
+  val eventType: AuditEventType = AuditEventType.USER_EVENT ,
+
+  @Schema(description = "A summary of the action taken", example = "Updated a bespoke condition")
+  val summary: String? = null,
+
+  @Schema(description = "A detailed description of the action taken", example = "Updated a bespoke condition")
+  val detail: String? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/AuditEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/AuditEvent.kt
@@ -24,7 +24,7 @@ data class AuditEvent(
   val fullName: String? = null,
 
   @Schema(description = "The event type. One of SYSTEM_EVENT or USER_EVENT", example = "USER_EVENT")
-  val eventType: AuditEventType = AuditEventType.USER_EVENT ,
+  val eventType: AuditEventType = AuditEventType.USER_EVENT,
 
   @Schema(description = "A summary of the action taken", example = "Updated a bespoke condition")
   val summary: String? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/AuditRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/AuditRequest.kt
@@ -1,0 +1,22 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+@Schema(description = "Describes an audit event request")
+data class AuditRequest(
+  @Schema(description = "The internal ID of the licence to request audit events for", example = "1234")
+  val licenceId: Long? = null,
+
+  @Schema(description = "Username to request events for", example = "X63533")
+  val username: String? = null,
+
+  @Schema(description = "The start date and time to query for events (default is 1 month ago)", example = "13/11/2021 23:14:13")
+  @JsonFormat(pattern = "dd/MM/yyyy HH:mm:ss")
+  val startTime: LocalDateTime = LocalDateTime.now().minusMonths(1),
+
+  @Schema(description = "The end time to query for events (default is now)", example = "12/01/2022 23:14:13")
+  @JsonFormat(pattern = "dd/MM/yyyy HH:mm:ss")
+  val endTime: LocalDateTime = LocalDateTime.now(),
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/repository/AuditEventRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/repository/AuditEventRepository.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.AuditEvent
+import java.time.LocalDateTime
+
+@Repository
+interface AuditEventRepository : JpaRepository<AuditEvent, Long> {
+  fun findAllByLicenceIdAndEventTimeBetweenOrderByEventTimeDesc(licenceId: Long, startTime: LocalDateTime, endTime: LocalDateTime): List<AuditEvent>
+  fun findAllByUsernameAndEventTimeBetweenOrderByEventTimeDesc(username: String, startTime: LocalDateTime, endTime: LocalDateTime): List<AuditEvent>
+  fun findAllByLicenceIdAndUsernameAndEventTimeBetweenOrderByEventTimeDesc(licenceId: Long, username: String, startTime: LocalDateTime, endTime: LocalDateTime): List<AuditEvent>
+  fun findAllByEventTimeBetweenOrderByEventTimeDesc(startTime: LocalDateTime, endTime: LocalDateTime): List<AuditEvent>
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/AuditController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/AuditController.kt
@@ -1,0 +1,94 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import org.springframework.http.MediaType
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.config.ErrorResponse
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AuditEvent
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AuditRequest
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.AuditService
+
+@RestController
+@RequestMapping("/audit", produces = [MediaType.APPLICATION_JSON_VALUE])
+class AuditController(private val auditService: AuditService) {
+
+  @PutMapping(value = ["/save"], produces = [MediaType.APPLICATION_JSON_VALUE])
+  @PreAuthorize("hasAnyRole('CVL_ADMIN')")
+  @Operation(
+    summary = "Records an auditable event.",
+    description = "Records an auditable event related to an action taken by a user or an automated in-service process. Requires ROLE_CVL_ADMIN.",
+    security = [SecurityRequirement(name = "ROLE_CVL_ADMIN")],
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "The audit event was recorded",
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Bad request, request body must be valid",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorised, requires a valid Oauth2 token",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires an appropriate role",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      )
+    ]
+  )
+  fun recordAuditEvent(@RequestBody body: AuditEvent) {
+    this.auditService.recordAuditEvent(body)
+  }
+
+  @PostMapping(value = ["/retrieve"], produces = [MediaType.APPLICATION_JSON_VALUE])
+  @PreAuthorize("hasAnyRole('CVL_ADMIN')")
+  @Operation(
+    summary = "Retrieves a list of auditable events matching the criteria provided.",
+    description = "Retrieves a list of auditable events matching the criteria provided. Requires ROLE_CVL_ADMIN.",
+    security = [SecurityRequirement(name = "ROLE_CVL_ADMIN")],
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "The a list of matching auditable events is returned.",
+        content = [Content(mediaType = "application/json", array = ArraySchema(schema = Schema(implementation = AuditEvent::class)))],
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Bad request, request body must be valid",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorised, requires a valid Oauth2 token",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires an appropriate role",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      )
+    ]
+  )
+  fun requestAuditEvents(@RequestBody body: AuditRequest): List<AuditEvent> {
+    return this.auditService.getAuditEvents(body)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/AuditService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/AuditService.kt
@@ -1,0 +1,69 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AuditRequest
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.AuditEventRepository
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.LicenceRepository
+import javax.persistence.EntityNotFoundException
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AuditEvent as ModelAuditEvent
+
+@Service
+class AuditService(
+  private val auditEventRepository: AuditEventRepository,
+  private val licenceRepository: LicenceRepository,
+) {
+
+  fun recordAuditEvent(auditEvent: ModelAuditEvent) {
+    auditEventRepository.save(transform(auditEvent))
+  }
+
+  fun getAuditEvents(auditRequest: AuditRequest): List<ModelAuditEvent> {
+    return if (auditRequest.licenceId != null && auditRequest.username != null) {
+      getAuditEventsForLicenceAndUser(auditRequest)
+    } else if (auditRequest.licenceId != null) {
+      getAuditEventsForLicence(auditRequest)
+    } else if (auditRequest.username != null) {
+      getAuditEventsForUser(auditRequest)
+    } else {
+      getAllEvents(auditRequest)
+    }
+  }
+
+  private fun getAuditEventsForLicence(auditRequest: AuditRequest): List<ModelAuditEvent> {
+    licenceRepository
+      .findById(auditRequest.licenceId!!)
+      .orElseThrow { EntityNotFoundException("${auditRequest.licenceId}") }
+
+    return auditEventRepository
+      .findAllByLicenceIdAndEventTimeBetweenOrderByEventTimeDesc(
+        auditRequest.licenceId, auditRequest.startTime, auditRequest.endTime
+      )
+      .transformToModelAuditEvents()
+  }
+
+  private fun getAuditEventsForUser(auditRequest: AuditRequest): List<ModelAuditEvent> {
+    return auditEventRepository
+      .findAllByUsernameAndEventTimeBetweenOrderByEventTimeDesc(
+        auditRequest.username!!, auditRequest.startTime, auditRequest.endTime
+      )
+      .transformToModelAuditEvents()
+  }
+
+  private fun getAuditEventsForLicenceAndUser(auditRequest: AuditRequest): List<ModelAuditEvent> {
+    licenceRepository
+      .findById(auditRequest.licenceId!!)
+      .orElseThrow { EntityNotFoundException("${auditRequest.licenceId}") }
+
+    return auditEventRepository
+      .findAllByLicenceIdAndUsernameAndEventTimeBetweenOrderByEventTimeDesc(
+        auditRequest.licenceId, auditRequest.username!!, auditRequest.startTime, auditRequest.endTime
+      )
+      .transformToModelAuditEvents()
+  }
+
+  private fun getAllEvents(auditRequest: AuditRequest): List<ModelAuditEvent> {
+    return auditEventRepository
+      .findAllByEventTimeBetweenOrderByEventTimeDesc(auditRequest.startTime, auditRequest.endTime)
+      .transformToModelAuditEvents()
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/OffenderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/OffenderService.kt
@@ -7,9 +7,7 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.LicenceR
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus
 
 @Service
-class OffenderService(
-  private val licenceRepository: LicenceRepository,
-) {
+class OffenderService(private val licenceRepository: LicenceRepository) {
 
   @Transactional
   fun updateOffenderWithResponsibleCom(crn: String, newComDetails: UpdateResponsibleComRequest) {
@@ -21,7 +19,8 @@ class OffenderService(
       it.copy(comStaffId = newComDetails.staffIdentifier, comUsername = newComDetails.staffUsername, comEmail = newComDetails.staffEmail)
     }
 
-    // TODO: Create an audit log that offender managers were updated by the system
+    // TODO: Create an audit log
+
     this.licenceRepository.saveAllAndFlush(offenderLicences)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/TransformFunctions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/TransformFunctions.kt
@@ -8,12 +8,14 @@ import java.util.Base64
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.AdditionalCondition as EntityAdditionalCondition
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.AdditionalConditionData as EntityAdditionalConditionData
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.AdditionalConditionUploadSummary as EntityAdditionalConditionUploadSummary
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.AuditEvent as EntityAuditEvent
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.BespokeCondition as EntityBespokeCondition
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.Licence as EntityLicence
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.StandardCondition as EntityStandardCondition
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AdditionalCondition as ModelAdditionalCondition
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AdditionalConditionData as ModelAdditionalConditionData
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AdditionalConditionUploadSummary as ModelAdditionalConditionUploadSummary
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AuditEvent as ModelAuditEvent
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.BespokeCondition as ModelBespokeCondition
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.Licence as ModelLicence
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.StandardCondition as ModelStandardCondition
@@ -240,3 +242,30 @@ fun transform(entity: EntityAdditionalConditionUploadSummary): ModelAdditionalCo
 }
 
 fun ByteArray.toBase64(): String = String(Base64.getEncoder().encode(this))
+
+fun List<EntityAuditEvent>.transformToModelAuditEvents(): List<ModelAuditEvent> = map(::transform)
+
+fun transform(entity: EntityAuditEvent): ModelAuditEvent {
+  return ModelAuditEvent(
+    id = entity.id,
+    licenceId = entity.licenceId,
+    eventTime = entity.eventTime,
+    username = entity.username,
+    fullName = entity.fullName,
+    eventType = entity.eventType,
+    summary = entity.summary,
+    detail = entity.detail,
+  )
+}
+
+fun transform(model: ModelAuditEvent): EntityAuditEvent {
+  return EntityAuditEvent(
+    licenceId = model.licenceId,
+    eventTime = model.eventTime,
+    username = model.username,
+    fullName = model.fullName,
+    eventType = model.eventType,
+    summary = model.summary,
+    detail = model.detail,
+  )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/util/AuditEventType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/util/AuditEventType.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util
+
+enum class AuditEventType {
+  USER_EVENT,
+  SYSTEM_EVENT,
+}

--- a/src/main/resources/migration/common/V16__create_audit_event.sql
+++ b/src/main/resources/migration/common/V16__create_audit_event.sql
@@ -1,0 +1,16 @@
+CREATE TABLE audit_event(
+   id serial NOT NULL constraint audit_event_pk PRIMARY KEY,
+   licence_id integer,     -- Can be null when not related to a licence (so no FK relationship)
+   event_time timestamp with time zone default CURRENT_TIMESTAMP,
+   username varchar(100),  -- Long to cope with potential email address as username, and nullable
+   full_name varchar(80),  -- Nullable
+   event_type varchar(40) NOT NULL, -- Either SYSTEM_EVENT or USER_EVENT
+   summary text, -- shorter summary of event
+   details text -- detailed description of event
+);
+
+CREATE INDEX idx_audit_licence_id ON audit_event(licence_id);
+
+CREATE INDEX idx_audit_username ON audit_event(username);
+
+CREATE INDEX idx_audit_event_time ON audit_event(event_time);

--- a/src/main/resources/migration/common/V16__create_audit_event.sql
+++ b/src/main/resources/migration/common/V16__create_audit_event.sql
@@ -6,7 +6,7 @@ CREATE TABLE audit_event(
    full_name varchar(80),  -- Nullable
    event_type varchar(40) NOT NULL, -- Either SYSTEM_EVENT or USER_EVENT
    summary text, -- shorter summary of event
-   details text -- detailed description of event
+   detail text -- detailed description of event
 );
 
 CREATE INDEX idx_audit_licence_id ON audit_event(licence_id);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/AuditIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/AuditIntegrationTest.kt
@@ -1,0 +1,118 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.groups.Tuple
+import org.assertj.core.groups.Tuple.tuple
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.test.context.jdbc.Sql
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.config.ErrorResponse
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AuditEvent
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AuditRequest
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.AuditEventRepository
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.AuditEventType
+import java.time.LocalDateTime
+
+class AuditIntegrationTest : IntegrationTestBase() {
+
+  @Autowired
+  lateinit var auditEventRepository: AuditEventRepository
+
+  @Test
+  fun `Get forbidden (403) when incorrect roles are supplied`() {
+    val result = webTestClient.put()
+      .uri("/audit/save")
+      .bodyValue(anAuditEvent)
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_CVL_WRONG ROLE")))
+      .exchange()
+      .expectStatus().isForbidden
+      .expectStatus().isEqualTo(HttpStatus.FORBIDDEN.value())
+      .expectBody(ErrorResponse::class.java)
+      .returnResult().responseBody
+
+    assertThat(result?.userMessage).contains("Access is denied")
+  }
+
+  @Test
+  fun `Unauthorized (401) when no token is supplied`() {
+    webTestClient.put()
+      .uri("/audit/save")
+      .bodyValue(anAuditEvent)
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isUnauthorized
+  }
+
+  @Test
+  @Sql(
+    "classpath:test_data/clear-all-licences.sql",
+    "classpath:test_data/clear-audit-events.sql",
+    "classpath:test_data/seed-licence-id-1.sql"
+  )
+  fun `Create an audit event`() {
+    webTestClient.put()
+      .uri("/audit/save")
+      .bodyValue(anAuditEvent)
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_CVL_ADMIN")))
+      .exchange()
+      .expectStatus().isOk
+
+    assertThat(auditEventRepository.count()).isEqualTo(1)
+    assertThat(auditEventRepository.findAll())
+      .extracting<Tuple> { tuple(it.licenceId, it.username, it.summary, it.detail) }
+      .contains(tuple(1L, "USER", "Summary", "Detail"))
+  }
+
+  @Test
+  @Sql(
+    "classpath:test_data/clear-all-licences.sql",
+    "classpath:test_data/seed-licence-id-1.sql",
+    "classpath:test_data/clear-audit-events.sql",
+    "classpath:test_data/seed-audit-events.sql"
+  )
+  fun `Get audit events for a licence and user`() {
+    val result = webTestClient.post()
+      .uri("/audit/retrieve")
+      .bodyValue(aRequest)
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_CVL_ADMIN")))
+      .exchange()
+      .expectStatus().isOk
+      .expectBodyList(AuditEvent::class.java)
+      .returnResult().responseBody
+
+    log.info("Response was ${mapper.writeValueAsString(result)}")
+
+    assertThat(result).hasSize(3)
+    assertThat(result)
+      .extracting<Tuple> { tuple(it.licenceId, it.username, it.summary, it.detail) }
+      .contains(
+        tuple(1L, "USER", "Summary1", "Detail1"),
+        tuple(1L, "USER", "Summary2", "Detail2"),
+        tuple(1L, "USER", "Summary3", "Detail3"),
+      )
+  }
+
+  companion object {
+    val anAuditEvent = AuditEvent(
+      licenceId = 1L,
+      eventTime = LocalDateTime.now(),
+      username = "USER",
+      fullName = "Forename Surname",
+      eventType = AuditEventType.USER_EVENT,
+      summary = "Summary",
+      detail = "Detail",
+    )
+
+    val aRequest = AuditRequest(
+      username = "USER",
+      licenceId = 1L,
+      startTime = LocalDateTime.now().minusMonths(1),
+      endTime = LocalDateTime.now().plusMinutes(5),
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/AuditControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/AuditControllerTest.kt
@@ -1,0 +1,161 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.reset
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.springframework.test.context.web.WebAppConfiguration
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.post
+import org.springframework.test.web.servlet.put
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.config.ControllerAdvice
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AuditEvent
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AuditRequest
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.AuditService
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.AuditEventType
+import java.time.LocalDateTime
+
+@ExtendWith(SpringExtension::class)
+@ActiveProfiles("test")
+@WebMvcTest(controllers = [AuditController::class])
+@AutoConfigureMockMvc(addFilters = false)
+@ContextConfiguration(classes = [AuditController::class])
+@WebAppConfiguration
+class AuditControllerTest {
+
+  @MockBean
+  private lateinit var auditService: AuditService
+
+  @Autowired
+  private lateinit var mvc: MockMvc
+
+  @Autowired
+  private lateinit var mapper: ObjectMapper
+
+  @BeforeEach
+  fun reset() {
+    reset(auditService)
+
+    mvc = MockMvcBuilders
+      .standaloneSetup(AuditController(auditService))
+      .setControllerAdvice(ControllerAdvice())
+      .build()
+  }
+
+  @Test
+  fun `record an audit event`() {
+    val body = AuditEvent(
+      licenceId = 1L,
+      eventTime = LocalDateTime.now(),
+      username = "USER",
+      fullName = "Forename Surname",
+      eventType = AuditEventType.USER_EVENT,
+      summary = "Summary description",
+      detail = "Detail description",
+    )
+
+    mvc.put("/audit/save") {
+      accept = MediaType.APPLICATION_JSON
+      content = mapper.writeValueAsBytes(body)
+      contentType = MediaType.APPLICATION_JSON
+    }.andExpect {
+      status { isOk() }
+    }
+    verify(auditService, times(1)).recordAuditEvent(any())
+  }
+
+  @Test
+  fun `query for audit events for a licence`() {
+    val body = AuditRequest(
+      licenceId = 1L,
+      startTime = LocalDateTime.now().minusMonths(1),
+      endTime = LocalDateTime.now(),
+    )
+
+    whenever(auditService.getAuditEvents(body)).thenReturn(aListOfAuditEvents)
+
+    mvc.post("/audit/retrieve") {
+      accept = MediaType.APPLICATION_JSON
+      content = mapper.writeValueAsString(body)
+      contentType = MediaType.APPLICATION_JSON
+    }.andExpect {
+      status { isOk() }
+      content { contentType(MediaType.APPLICATION_JSON) }
+      content { mapper.writeValueAsString(aListOfAuditEvents) }
+    }
+
+    verify(auditService, times(1)).getAuditEvents(any())
+  }
+
+  @Test
+  fun `query for audit events for a user`() {
+    val body = AuditRequest(
+      username = "USER",
+      startTime = LocalDateTime.now().minusMonths(1),
+      endTime = LocalDateTime.now(),
+    )
+
+    whenever(auditService.getAuditEvents(body)).thenReturn(aListOfAuditEvents)
+
+    mvc.post("/audit/retrieve") {
+      accept = MediaType.APPLICATION_JSON
+      content = mapper.writeValueAsString(body)
+      contentType = MediaType.APPLICATION_JSON
+    }.andExpect {
+      status { isOk() }
+      content { contentType(MediaType.APPLICATION_JSON) }
+      content { mapper.writeValueAsString(aListOfAuditEvents) }
+    }
+
+    verify(auditService, times(1)).getAuditEvents(any())
+  }
+
+  companion object {
+    val aListOfAuditEvents = listOf(
+      AuditEvent(
+        id = 1L,
+        licenceId = 1L,
+        eventTime = LocalDateTime.now().minusDays(1L),
+        username = "USER",
+        fullName = "First Last",
+        eventType = AuditEventType.USER_EVENT,
+        summary = "Summary1",
+        detail = "Detail1"
+      ),
+      AuditEvent(
+        id = 2L,
+        licenceId = 1L,
+        eventTime = LocalDateTime.now().minusDays(2L),
+        username = "USER",
+        fullName = "First Last",
+        eventType = AuditEventType.USER_EVENT,
+        summary = "Summary2",
+        detail = "Detail2"
+      ),
+      AuditEvent(
+        id = 3L,
+        licenceId = 1L,
+        eventTime = LocalDateTime.now().minusDays(3L),
+        username = "CUSER",
+        fullName = "First Last",
+        eventType = AuditEventType.SYSTEM_EVENT,
+        summary = "Summary3",
+        detail = "Detail3"
+      ),
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/AuditServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/AuditServiceTest.kt
@@ -1,0 +1,166 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.reset
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AuditEvent
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AuditRequest
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.AuditEventRepository
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.LicenceRepository
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.AuditEventType
+import java.time.LocalDateTime
+import java.util.Optional
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.AuditEvent as EntityAuditEvent
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.Licence as EntityLicence
+
+class AuditServiceTest {
+  private val licenceRepository = mock<LicenceRepository>()
+  private val auditEventRepository = mock<AuditEventRepository>()
+
+  private val service = AuditService(auditEventRepository, licenceRepository)
+
+  @BeforeEach
+  fun reset() {
+    reset(auditEventRepository, licenceRepository)
+  }
+
+  @Test
+  fun `records an audit event`() {
+    whenever(auditEventRepository.save(transform(anEvent))).thenReturn(transform(anEvent))
+    service.recordAuditEvent(anEvent)
+    verify(auditEventRepository, times(1)).save(transform(anEvent))
+  }
+
+  @Test
+  fun `gets audit events relating to a specific licence`() {
+    val aUserRequest = aRequest.copy(username = null, licenceId = 1L)
+
+    whenever(licenceRepository.findById(1L)).thenReturn(Optional.of(aLicenceEntity))
+
+    whenever(
+      auditEventRepository
+        .findAllByLicenceIdAndEventTimeBetweenOrderByEventTimeDesc(
+          aUserRequest.licenceId!!,
+          aUserRequest.startTime,
+          aUserRequest.endTime,
+        )
+    ).thenReturn(aListOfEntities)
+
+    val response = service.getAuditEvents(aUserRequest)
+
+    assertThat(response).hasSize(3)
+    assertThat(response[0].summary).isEqualTo("Summary1")
+
+    verify(licenceRepository, times(1)).findById(1L)
+    verify(auditEventRepository, times(1)).findAllByLicenceIdAndEventTimeBetweenOrderByEventTimeDesc(
+      aUserRequest.licenceId!!,
+      aUserRequest.startTime,
+      aUserRequest.endTime,
+    )
+  }
+
+  @Test
+  fun `get audit events relating to a specific user`() {
+    val aUserRequest = aRequest.copy(licenceId = null)
+    whenever(
+      auditEventRepository
+        .findAllByUsernameAndEventTimeBetweenOrderByEventTimeDesc(
+          aUserRequest.username!!,
+          aUserRequest.startTime,
+          aUserRequest.endTime,
+        )
+    ).thenReturn(aListOfEntities)
+
+    val response = service.getAuditEvents(aUserRequest)
+
+    assertThat(response).hasSize(3)
+    assertThat(response[0].summary).isEqualTo("Summary1")
+
+    verify(auditEventRepository, times(1)).findAllByUsernameAndEventTimeBetweenOrderByEventTimeDesc(
+      aUserRequest.username!!,
+      aUserRequest.startTime,
+      aUserRequest.endTime,
+    )
+  }
+
+  @Test
+  fun `get all audit events`() {
+    val aUserRequest = aRequest.copy(username = null, licenceId = null)
+    whenever(
+      auditEventRepository
+        .findAllByEventTimeBetweenOrderByEventTimeDesc(
+          aUserRequest.startTime,
+          aUserRequest.endTime,
+        )
+    ).thenReturn(aListOfEntities)
+
+    val response = service.getAuditEvents(aUserRequest)
+
+    assertThat(response).hasSize(3)
+    assertThat(response[0].summary).isEqualTo("Summary1")
+
+    verify(auditEventRepository, times(1)).findAllByEventTimeBetweenOrderByEventTimeDesc(
+      aUserRequest.startTime,
+      aUserRequest.endTime,
+    )
+  }
+
+  companion object {
+    val anEvent = AuditEvent(
+      licenceId = 1L,
+      eventTime = LocalDateTime.now(),
+      username = "USER",
+      fullName = "Forename Surname",
+      eventType = AuditEventType.USER_EVENT,
+      summary = "Summary description",
+      detail = "Detail description",
+    )
+
+    val aRequest = AuditRequest(
+      username = "USER",
+      licenceId = 1L,
+      startTime = LocalDateTime.now().minusMonths(1),
+      endTime = LocalDateTime.now(),
+    )
+
+    val aLicenceEntity = EntityLicence(id = 1L)
+
+    val aListOfEntities = listOf(
+      EntityAuditEvent(
+        id = 1L,
+        licenceId = 1L,
+        eventTime = LocalDateTime.now().minusDays(1L),
+        username = "USER",
+        fullName = "First Last",
+        eventType = AuditEventType.USER_EVENT,
+        summary = "Summary1",
+        detail = "Detail1"
+      ),
+      EntityAuditEvent(
+        id = 2L,
+        licenceId = 1L,
+        eventTime = LocalDateTime.now().minusDays(2L),
+        username = "USER",
+        fullName = "First Last",
+        eventType = AuditEventType.USER_EVENT,
+        summary = "Summary2",
+        detail = "Detail2"
+      ),
+      EntityAuditEvent(
+        id = 3L,
+        licenceId = 1L,
+        eventTime = LocalDateTime.now().minusDays(3L),
+        username = "CUSER",
+        fullName = "First Last",
+        eventType = AuditEventType.SYSTEM_EVENT,
+        summary = "Summary3",
+        detail = "Detail3"
+      ),
+    )
+  }
+}

--- a/src/test/resources/test_data/clear-audit-events.sql
+++ b/src/test/resources/test_data/clear-audit-events.sql
@@ -1,0 +1,1 @@
+DELETE from audit_event;

--- a/src/test/resources/test_data/seed-audit-events.sql
+++ b/src/test/resources/test_data/seed-audit-events.sql
@@ -1,0 +1,5 @@
+insert into audit_event (id, licence_id, username, full_name, event_type, summary, detail)
+values
+  (1, 1, 'USER', 'Bob Smith', 'USER_EVENT', 'Summary1', 'Detail1'),
+  (2, 1, 'USER', 'Bob Smith', 'USER_EVENT', 'Summary2', 'Detail2'),
+  (3, 1, 'USER', 'Bob Smith', 'USER_EVENT', 'Summary3', 'Detail3');


### PR DESCRIPTION
*  Audited events can be related to a user, a licence, or both.
* They may not be in relation to a change to data - e.g. could be for when a user views a licence.
* They may not be related to a licence - so no referential integrity to licence data.
* Endpoints to create an audit event, get events for a user, get events for a licence, and get all events
* Events are queried between two dates (defaulted to 1 month if not supplied).