### PR TITLE
CVSL-402: Update JPA specification methods for joined COM table

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/LicenceMatchingIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/LicenceMatchingIntegrationTest.kt
@@ -40,52 +40,52 @@ class LicenceMatchingIntegrationTest : IntegrationTestBase() {
       )
   }
 
-// FIXME After staff Id JPA specification has been fixed
-//  @Test
-//  @Sql(
-//    "classpath:test_data/seed-matching-candidates.sql"
-//  )
-//  fun `Get licences matches - by list of staff identifiers`() {
-//    val result = webTestClient.get()
-//      .uri("/licence/match?staffId=125&staffId=126")
-//      .accept(MediaType.APPLICATION_JSON)
-//      .headers(setAuthorisation(roles = listOf("ROLE_CVL_ADMIN")))
-//      .exchange()
-//      .expectStatus().isOk
-//      .expectHeader().contentType(MediaType.APPLICATION_JSON)
-//      .expectBodyList(LicenceSummary::class.java)
-//      .returnResult().responseBody
-//    assertThat(result?.size).isEqualTo(4)
-//    assertThat(result)
-//      .extracting<Tuple> { tuple(it.licenceId, it.nomisId, it.licenceStatus) }
-//      .contains(
-//        tuple(1L, "A1234AA", LicenceStatus.SUBMITTED),
-//        tuple(2L, "B1234BB", LicenceStatus.SUBMITTED),
-//        tuple(3L, "C1234CC", LicenceStatus.ACTIVE),
-//        tuple(4L, "C1234DD", LicenceStatus.APPROVED),
-//      )
-//  }
+  @Test
+  @Sql(
+    "classpath:test_data/seed-matching-candidates.sql"
+  )
+  fun `Get licences matches - by list of staff identifiers`() {
+    val result = webTestClient.get()
+      .uri("/licence/match?staffId=125&staffId=126")
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_CVL_ADMIN")))
+      .exchange()
+      .expectStatus().isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBodyList(LicenceSummary::class.java)
+      .returnResult().responseBody
 
-// FIXME After staff Id JPA specification has been fixed
-//  @Test
-//  @Sql(
-//    "classpath:test_data/seed-matching-candidates.sql"
-//  )
-//  fun `Get licence matches - by list of staff identifiers and statuses`() {
-//    val result = webTestClient.get()
-//      .uri("/licence/match?staffId=125&status=ACTIVE")
-//      .accept(MediaType.APPLICATION_JSON)
-//      .headers(setAuthorisation(roles = listOf("ROLE_CVL_ADMIN")))
-//      .exchange()
-//      .expectStatus().isOk
-//      .expectHeader().contentType(MediaType.APPLICATION_JSON)
-//      .expectBodyList(LicenceSummary::class.java)
-//      .returnResult().responseBody
-//    assertThat(result?.size).isEqualTo(1)
-//    assertThat(result)
-//      .extracting<Tuple> { tuple(it.licenceId, it.nomisId, it.licenceStatus, it.surname) }
-//      .containsExactly(tuple(3L, "C1234CC", LicenceStatus.ACTIVE, "Cookson"))
-//  }
+    assertThat(result?.size).isEqualTo(4)
+    assertThat(result)
+      .extracting<Tuple> { tuple(it.licenceId, it.nomisId, it.licenceStatus) }
+      .contains(
+        tuple(3L, "C1234CC", LicenceStatus.ACTIVE),
+        tuple(4L, "C1234DD", LicenceStatus.APPROVED),
+        tuple(5L, "C1234EE", LicenceStatus.IN_PROGRESS),
+        tuple(6L, "C1234FF", LicenceStatus.REJECTED),
+      )
+  }
+
+  @Test
+  @Sql(
+    "classpath:test_data/seed-matching-candidates.sql"
+  )
+  fun `Get licence matches - by list of staff identifiers and statuses`() {
+    val result = webTestClient.get()
+      .uri("/licence/match?staffId=125&status=ACTIVE")
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_CVL_ADMIN")))
+      .exchange()
+      .expectStatus().isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBodyList(LicenceSummary::class.java)
+      .returnResult().responseBody
+
+    assertThat(result?.size).isEqualTo(1)
+    assertThat(result)
+      .extracting<Tuple> { tuple(it.licenceId, it.nomisId, it.licenceStatus, it.surname) }
+      .containsExactly(tuple(3L, "C1234CC", LicenceStatus.ACTIVE, "Cookson"))
+  }
 
   @Test
   @Sql(

--- a/src/test/resources/test_data/seed-community-offender-manager.sql
+++ b/src/test/resources/test_data/seed-community-offender-manager.sql
@@ -1,4 +1,6 @@
 insert into community_offender_manager(id, staff_identifier, username, email)
 values
-  (1, 2000, 'test-client', 'testClient@probation.gov.uk');
+    (1, 2000, 'test-client', 'testClient@probation.gov.uk'),
+    (2, 125, 'AAA', 'testAAA@probation.gov.uk'),
+    (3, 126, 'BBB', 'testBBB@probation.gov.uk');
 

--- a/src/test/resources/test_data/seed-matching-candidates.sql
+++ b/src/test/resources/test_data/seed-matching-candidates.sql
@@ -13,7 +13,7 @@ insert into licence (
 ) values
 (1,'A1234AA','Alan','Alda','AP','SUBMITTED', 'MDI','Moorland HMP', '2031-04-28', 1, 1),
 (2,'B1234BB','Bob','Bobson','AP','SUBMITTED', 'MDI', 'Moorland HMP', '2032-04-28', 1, 1),
-(3,'C1234CC','Cath','Cookson','AP','ACTIVE', 'LEI', 'Leeds HMP', '2033-04-28', 1, 1),
-(4,'C1234DD','Kate','Harcourt','AP','APPROVED', 'BMI', 'Birmingham HMP', '2034-04-28', 1, 1),
-(5,'C1234EE','Mark','Royle','AP','IN_PROGRESS', 'BMI', 'Birmingham HMP', '2035-04-28', 1, 1),
-(6,'C1234FF','Harold','Biggs','AP','REJECTED', 'LEI', 'Leeds HMP', '2036-04-28', 1, 1);
+(3,'C1234CC','Cath','Cookson','AP','ACTIVE', 'LEI', 'Leeds HMP', '2033-04-28', 2, 1),
+(4,'C1234DD','Kate','Harcourt','AP','APPROVED', 'BMI', 'Birmingham HMP', '2034-04-28', 3, 1),
+(5,'C1234EE','Mark','Royle','AP','IN_PROGRESS', 'BMI', 'Birmingham HMP', '2035-04-28', 2, 1),
+(6,'C1234FF','Harold','Biggs','AP','REJECTED', 'LEI', 'Leeds HMP', '2036-04-28', 3, 1);


### PR DESCRIPTION
* Re-instates the commented-out tests for matching on staffIds
* Makes the JPA Specification methods look down into the joined tables for staff.
* Adds test data to filtering by various criteria