### PR TITLE
CVSL-386: Refactoring audit to be within the API for change events

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/entity/CommunityOffenderManager.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/entity/CommunityOffenderManager.kt
@@ -27,6 +27,10 @@ data class CommunityOffenderManager(
 
   val email: String?,
 
+  val firstName: String?,
+
+  val lastName: String?,
+
   @OneToMany(mappedBy = "responsibleCom")
   val licencesResponsibleFor: List<Licence> = emptyList(),
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/UpdateComRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/UpdateComRequest.kt
@@ -17,4 +17,12 @@ data class UpdateComRequest(
   @Schema(description = "The email address of the COM", example = "jbloggs@probation.gov.uk")
   @field:NotNull
   val staffEmail: String,
+
+  @Schema(description = "The first name of the COM", example = "Joseph")
+  @field:NotNull
+  val firstName: String,
+
+  @Schema(description = "The last name of the COM", example = "Bloggs")
+  @field:NotNull
+  val lastName: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ComService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ComService.kt
@@ -16,9 +16,15 @@ class ComService(
   fun updateComDetails(comDetails: UpdateComRequest): CommunityOffenderManager {
     val com = this.communityOffenderManagerRepository.findByStaffIdentifier(comDetails.staffIdentifier)
     val updatedCom = if (com !== null) {
-      com.copy(email = comDetails.staffEmail, lastUpdatedTimestamp = LocalDateTime.now())
+      com.copy(email = comDetails.staffEmail, firstName = comDetails.firstName, lastName = comDetails.lastName, lastUpdatedTimestamp = LocalDateTime.now())
     } else {
-      CommunityOffenderManager(username = comDetails.staffUsername, staffIdentifier = comDetails.staffIdentifier, email = comDetails.staffEmail)
+      CommunityOffenderManager(
+        username = comDetails.staffUsername,
+        staffIdentifier = comDetails.staffIdentifier,
+        email = comDetails.staffEmail,
+        firstName = comDetails.firstName,
+        lastName = comDetails.lastName
+      )
     }
 
     return this.communityOffenderManagerRepository.saveAndFlush(updatedCom)

--- a/src/main/resources/migration/common/V10__create_com_details_table.sql
+++ b/src/main/resources/migration/common/V10__create_com_details_table.sql
@@ -4,6 +4,8 @@ CREATE TABLE community_offender_manager
     staff_identifier INTEGER NOT NULL UNIQUE,
     username VARCHAR(40) NOT NULL UNIQUE,
     email VARCHAR(200),
+    first_name VARCHAR(60),
+    last_name VARCHAR(60),
     created_timestamp TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     last_updated_timestamp TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/LicenceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/LicenceIntegrationTest.kt
@@ -24,6 +24,7 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.StatusUpdateR
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.UpdateAdditionalConditionDataRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.request.CreateLicenceRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.AdditionalConditionRepository
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.AuditEventRepository
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.LicenceRepository
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.StandardConditionRepository
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus
@@ -42,6 +43,9 @@ class LicenceIntegrationTest : IntegrationTestBase() {
 
   @Autowired
   lateinit var additionalConditionRepository: AdditionalConditionRepository
+
+  @Autowired
+  lateinit var auditEventRepository: AuditEventRepository
 
   @Test
   @Sql(
@@ -103,6 +107,7 @@ class LicenceIntegrationTest : IntegrationTestBase() {
   fun `Create a licence`() {
     assertThat(licenceRepository.count()).isEqualTo(0)
     assertThat(standardConditionRepository.count()).isEqualTo(0)
+    assertThat(auditEventRepository.count()).isEqualTo(0)
 
     val result = webTestClient.post()
       .uri("/licence/create")
@@ -123,6 +128,7 @@ class LicenceIntegrationTest : IntegrationTestBase() {
 
     assertThat(licenceRepository.count()).isEqualTo(1)
     assertThat(standardConditionRepository.count()).isEqualTo(6)
+    assertThat(auditEventRepository.count()).isEqualTo(1)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/LicenceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/LicenceIntegrationTest.kt
@@ -491,7 +491,7 @@ class LicenceIntegrationTest : IntegrationTestBase() {
     assertThat(licenceRepository.count()).isEqualTo(2)
 
     val newLicence = webTestClient.get()
-      .uri("/licence/id/${result.licenceId}")
+      .uri("/licence/id/${result?.licenceId}")
       .accept(MediaType.APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_CVL_ADMIN")))
       .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/OffenderIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/OffenderIntegrationTest.kt
@@ -17,7 +17,13 @@ class OffenderIntegrationTest : IntegrationTestBase() {
 
   @Test
   fun `Get forbidden (403) when incorrect roles are supplied`() {
-    val requestBody = UpdateComRequest(staffIdentifier = 2000, staffUsername = "joebloggs", staffEmail = "joebloggs@probation.gov.uk")
+    val requestBody = UpdateComRequest(
+      staffIdentifier = 2000,
+      staffUsername = "joebloggs",
+      staffEmail = "joebloggs@probation.gov.uk",
+      firstName = "X",
+      lastName = "Y",
+    )
 
     val result = webTestClient.put()
       .uri("/offender/crn/CRN1/responsible-com")
@@ -47,7 +53,13 @@ class OffenderIntegrationTest : IntegrationTestBase() {
     "classpath:test_data/seed-licence-id-1.sql"
   )
   fun `Update an offender's inflight licences with new COM details`() {
-    val requestBody = UpdateComRequest(staffIdentifier = 3000, staffUsername = "joebloggs", staffEmail = "joebloggs@probation.gov.uk")
+    val requestBody = UpdateComRequest(
+      staffIdentifier = 3000,
+      staffUsername = "joebloggs",
+      staffEmail = "joebloggs@probation.gov.uk",
+      firstName = "Joseph",
+      lastName = "Bloggs",
+    )
 
     webTestClient.put()
       .uri("/offender/crn/CRN1/responsible-com")
@@ -57,8 +69,9 @@ class OffenderIntegrationTest : IntegrationTestBase() {
       .exchange()
       .expectStatus().isOk
 
-    assertThat(licenceRepository.findById(1).get().responsibleCom!!.staffIdentifier).isEqualTo(3000)
-    assertThat(licenceRepository.findById(1).get().responsibleCom!!.username).isEqualTo("joebloggs")
-    assertThat(licenceRepository.findById(1).get().responsibleCom!!.email).isEqualTo("joebloggs@probation.gov.uk")
+    val licence = licenceRepository.findById(1L).orElseThrow()
+    assertThat(licence.responsibleCom)
+      .extracting("staffIdentifier", "username", "email", "firstName", "lastName")
+      .isEqualTo(listOf(3000L, "joebloggs", "joebloggs@probation.gov.uk", "Joseph", "Bloggs"))
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/OffenderControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/OffenderControllerTest.kt
@@ -60,9 +60,9 @@ class OffenderControllerTest {
 
   @Test
   fun `update offender with new offender manager`() {
-    val body = UpdateComRequest(staffIdentifier = 2000, staffUsername = "joebloggs", staffEmail = "joebloggs@probation.gov.uk")
+    val body = UpdateComRequest(staffIdentifier = 2000, staffUsername = "joebloggs", staffEmail = "joebloggs@probation.gov.uk", firstName = "Joseph", lastName = "Bloggs")
 
-    val expectedCom = CommunityOffenderManager(staffIdentifier = 2000, username = "joebloggs", email = "joebloggs@probation.gov.uk")
+    val expectedCom = CommunityOffenderManager(staffIdentifier = 2000, username = "joebloggs", email = "joebloggs@probation.gov.uk", firstName = "Joseph", lastName = "Bloggs")
     whenever(comService.updateComDetails(any())).thenReturn(expectedCom)
 
     val request = put("/offender/crn/exampleCrn/responsible-com")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ComServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ComServiceTest.kt
@@ -24,16 +24,25 @@ class ComServiceTest {
 
   @Test
   fun `updates existing COM with new details - email only`() {
-    val expectedCom = CommunityOffenderManager(staffIdentifier = 2000, username = "joebloggs", email = "jbloggs123@probation.gov.uk")
+    val expectedCom = CommunityOffenderManager(
+      staffIdentifier = 2000,
+      username = "joebloggs",
+      email = "jbloggs123@probation.gov.uk",
+      firstName = "X",
+      lastName = "Y",
+    )
 
     whenever(communityOffenderManagerRepository.findByStaffIdentifier(any()))
-      .thenReturn(CommunityOffenderManager(staffIdentifier = 2000, username = "joebloggs", email = "jbloggs@probation.gov.uk"))
+      .thenReturn(CommunityOffenderManager(staffIdentifier = 2000, username = "joebloggs", email = "jbloggs@probation.gov.uk", firstName = "A", lastName = "B"))
+
     whenever(communityOffenderManagerRepository.saveAndFlush(any())).thenReturn(expectedCom)
 
     val comDetails = UpdateComRequest(
       staffIdentifier = 3000,
       staffUsername = "jbloggs",
-      staffEmail = "jbloggs123@probation.gov.uk"
+      staffEmail = "jbloggs123@probation.gov.uk",
+      firstName = "X",
+      lastName = "Y",
     )
 
     service.updateComDetails(comDetails)
@@ -44,14 +53,23 @@ class ComServiceTest {
 
   @Test
   fun `adds a new existing COM if it doesnt exist`() {
-    val expectedCom = CommunityOffenderManager(staffIdentifier = 3000, username = "jbloggs", email = "jbloggs123@probation.gov.uk")
+    val expectedCom = CommunityOffenderManager(
+      staffIdentifier = 3000,
+      username = "jbloggs",
+      email = "jbloggs123@probation.gov.uk",
+      firstName = "X",
+      lastName = "Y",
+    )
+
     whenever(communityOffenderManagerRepository.findByStaffIdentifier(any())).thenReturn(null)
     whenever(communityOffenderManagerRepository.saveAndFlush(any())).thenReturn(expectedCom)
 
     val comDetails = UpdateComRequest(
       staffIdentifier = 3000,
       staffUsername = "jbloggs",
-      staffEmail = "jbloggs123@probation.gov.uk"
+      staffEmail = "jbloggs123@probation.gov.uk",
+      firstName = "X",
+      lastName = "Y",
     )
 
     service.updateComDetails(comDetails)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceServiceTest.kt
@@ -34,6 +34,7 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.UpdateAdditio
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.request.CreateLicenceRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.AdditionalConditionRepository
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.AdditionalConditionUploadDetailRepository
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.AuditEventRepository
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.BespokeConditionRepository
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.CommunityOffenderManagerRepository
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.LicenceHistoryRepository
@@ -48,6 +49,7 @@ import java.util.Optional
 import javax.persistence.EntityNotFoundException
 import javax.validation.ValidationException
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.AdditionalCondition as EntityAdditionalCondition
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.AuditEvent as EntityAuditEvent
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.BespokeCondition as EntityBespokeCondition
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.Licence as EntityLicence
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.LicenceHistory as EntityLicenceHistory
@@ -64,7 +66,9 @@ class LicenceServiceTest {
   private val communityOffenderManagerRepository = mock<CommunityOffenderManagerRepository>()
   private val licenceHistoryRepository = mock<LicenceHistoryRepository>()
   private val additionalConditionUploadDetailRepository = mock<AdditionalConditionUploadDetailRepository>()
+  private val auditEventRepository = mock<AuditEventRepository>()
   private val notifyService = mock<NotifyService>()
+
 
   private val service = LicenceService(
     licenceRepository,
@@ -74,6 +78,7 @@ class LicenceServiceTest {
     bespokeConditionRepository,
     licenceHistoryRepository,
     additionalConditionUploadDetailRepository,
+    auditEventRepository,
     notifyService,
   )
 
@@ -86,7 +91,14 @@ class LicenceServiceTest {
     whenever(securityContext.authentication).thenReturn(authentication)
     SecurityContextHolder.setContext(securityContext)
 
-    reset(licenceRepository, standardConditionRepository, bespokeConditionRepository, licenceHistoryRepository, additionalConditionUploadDetailRepository, notifyService)
+    reset(
+      licenceRepository,
+      standardConditionRepository,
+      bespokeConditionRepository,
+      licenceHistoryRepository,
+      additionalConditionUploadDetailRepository,
+      auditEventRepository,
+      notifyService)
   }
 
   @Test
@@ -129,12 +141,14 @@ class LicenceServiceTest {
 
   @Test
   fun `service creates a licence with standard conditions`() {
-    val expectedCom = CommunityOffenderManager(staffIdentifier = 2000, username = "smills", email = "testemail@probation.gov.uk")
+    val expectedCom = CommunityOffenderManager(staffIdentifier = 2000, username = "smills", email = "testemail@probation.gov.uk", firstName = "X", lastName = "Y")
 
     whenever(standardConditionRepository.saveAllAndFlush(anyList())).thenReturn(someEntityStandardConditions)
     whenever(licenceRepository.saveAndFlush(any())).thenReturn(aLicenceEntity)
     whenever(communityOffenderManagerRepository.findByStaffIdentifier(2000)).thenReturn(expectedCom)
     whenever(communityOffenderManagerRepository.findByUsernameIgnoreCase("smills")).thenReturn(expectedCom)
+
+    val auditCaptor = ArgumentCaptor.forClass(EntityAuditEvent::class.java)
 
     val createResponse = service.createLicence(aCreateLicenceRequest)
 
@@ -143,6 +157,11 @@ class LicenceServiceTest {
 
     verify(standardConditionRepository, times(1)).saveAllAndFlush(anyList())
     verify(licenceRepository, times(1)).saveAndFlush(any())
+    verify(auditEventRepository, times(1)).saveAndFlush(auditCaptor.capture())
+
+    assertThat(auditCaptor.value)
+      .extracting("licenceId", "username", "fullName", "summary")
+      .isEqualTo(listOf(1L, "smills", "X Y", "Licence created for ${aCreateLicenceRequest.forename} ${aCreateLicenceRequest.surname}"))
   }
 
   @Test
@@ -165,6 +184,7 @@ class LicenceServiceTest {
 
     verify(licenceRepository, times(0)).saveAndFlush(any())
     verify(standardConditionRepository, times(0)).saveAllAndFlush(anyList())
+    verify(auditEventRepository, times(0)).saveAndFlush(any())
   }
 
   @Test
@@ -396,13 +416,15 @@ class LicenceServiceTest {
   fun `update licence status persists the licence and history correctly`() {
     whenever(licenceRepository.findById(1L)).thenReturn(Optional.of(aLicenceEntity))
 
-    service.updateLicenceStatus(1L, StatusUpdateRequest(status = LicenceStatus.REJECTED, username = "X"))
+    service.updateLicenceStatus(1L, StatusUpdateRequest(status = LicenceStatus.REJECTED, username = "X", fullName = "Y"))
 
     val licenceCaptor = ArgumentCaptor.forClass(EntityLicence::class.java)
     val historyCaptor = ArgumentCaptor.forClass(EntityLicenceHistory::class.java)
+    val auditCaptor = ArgumentCaptor.forClass(EntityAuditEvent::class.java)
 
     verify(licenceRepository, times(1)).saveAndFlush(licenceCaptor.capture())
     verify(licenceHistoryRepository, times(1)).saveAndFlush(historyCaptor.capture())
+    verify(auditEventRepository, times(1)).saveAndFlush(auditCaptor.capture())
 
     assertThat(licenceCaptor.value)
       .extracting("id", "statusCode", "updatedByUsername")
@@ -411,6 +433,10 @@ class LicenceServiceTest {
     assertThat(historyCaptor.value)
       .extracting("licenceId", "statusCode", "actionUsername", "actionDescription")
       .isEqualTo(listOf(1L, LicenceStatus.REJECTED.name, "X", "Status changed to ${LicenceStatus.REJECTED.name}"))
+
+    assertThat(auditCaptor.value)
+      .extracting("licenceId", "username", "fullName", "summary")
+      .isEqualTo(listOf(1L, "X", "Y", "Licence rejected for ${aLicenceEntity.forename} ${aLicenceEntity.surname}"))
   }
 
   @Test
@@ -421,9 +447,11 @@ class LicenceServiceTest {
 
     val licenceCaptor = ArgumentCaptor.forClass(EntityLicence::class.java)
     val historyCaptor = ArgumentCaptor.forClass(EntityLicenceHistory::class.java)
+    val auditCaptor = ArgumentCaptor.forClass(EntityAuditEvent::class.java)
 
     verify(licenceRepository, times(1)).saveAndFlush(licenceCaptor.capture())
     verify(licenceHistoryRepository, times(1)).saveAndFlush(historyCaptor.capture())
+    verify(auditEventRepository, times(1)).saveAndFlush(auditCaptor.capture())
 
     assertThat(licenceCaptor.value.statusCode).isEqualTo(LicenceStatus.APPROVED)
     assertThat(licenceCaptor.value.approvedByUsername).isEqualTo("X")
@@ -432,6 +460,10 @@ class LicenceServiceTest {
 
     assertThat(historyCaptor.value.statusCode).isEqualTo(LicenceStatus.APPROVED.name)
     assertThat(historyCaptor.value.actionDescription).isEqualTo("Status changed to ${LicenceStatus.APPROVED.name}")
+
+    assertThat(auditCaptor.value)
+      .extracting("licenceId", "username", "fullName", "summary")
+      .isEqualTo(listOf(1L, "X", "Y", "Licence approved for ${aLicenceEntity.forename} ${aLicenceEntity.surname}"))
 
     verify(notifyService, times(1)).sendLicenceApprovedEmail(
       "testemail@probation.gov.uk",
@@ -448,13 +480,15 @@ class LicenceServiceTest {
     whenever(licenceRepository.findById(1L))
       .thenReturn(Optional.of(aLicenceEntity.copy(statusCode = LicenceStatus.APPROVED, approvedByUsername = "X", approvedByName = "Y")))
 
-    service.updateLicenceStatus(1L, StatusUpdateRequest(status = LicenceStatus.IN_PROGRESS, username = "X"))
+    service.updateLicenceStatus(1L, StatusUpdateRequest(status = LicenceStatus.IN_PROGRESS, username = "X", fullName = "Y"))
 
     val licenceCaptor = ArgumentCaptor.forClass(EntityLicence::class.java)
     val historyCaptor = ArgumentCaptor.forClass(EntityLicenceHistory::class.java)
+    val auditCaptor = ArgumentCaptor.forClass(EntityAuditEvent::class.java)
 
     verify(licenceRepository, times(1)).saveAndFlush(licenceCaptor.capture())
     verify(licenceHistoryRepository, times(1)).saveAndFlush(historyCaptor.capture())
+    verify(auditEventRepository, times(1)).saveAndFlush(auditCaptor.capture())
 
     assertThat(licenceCaptor.value.statusCode).isEqualTo(LicenceStatus.IN_PROGRESS)
     assertThat(licenceCaptor.value.updatedByUsername).isEqualTo("X")
@@ -463,6 +497,10 @@ class LicenceServiceTest {
 
     assertThat(historyCaptor.value.statusCode).isEqualTo(LicenceStatus.IN_PROGRESS.name)
     assertThat(historyCaptor.value.actionDescription).isEqualTo("Status changed to ${LicenceStatus.IN_PROGRESS.name}")
+
+    assertThat(auditCaptor.value)
+      .extracting("licenceId", "username", "fullName", "summary")
+      .isEqualTo(listOf(1L, "X", "Y", "Licence edited for ${aLicenceEntity.forename} ${aLicenceEntity.surname}"))
   }
 
   @Test
@@ -478,6 +516,7 @@ class LicenceServiceTest {
     verify(licenceRepository, times(1)).findById(1L)
     verify(licenceRepository, times(0)).saveAndFlush(any())
     verify(licenceHistoryRepository, times(0)).saveAndFlush(any())
+    verify(auditEventRepository, times(0)).saveAndFlush(any())
   }
 
   @Test
@@ -493,11 +532,12 @@ class LicenceServiceTest {
     verify(licenceRepository, times(1)).findById(1L)
     verify(licenceRepository, times(0)).saveAndFlush(any())
     verify(licenceHistoryRepository, times(0)).saveAndFlush(any())
+    verify(auditEventRepository, times(0)).saveAndFlush(any())
   }
 
   @Test
   fun `submit a licence saves new fields to the licence`() {
-    val expectedCom = CommunityOffenderManager(staffIdentifier = 2000, username = "smills", email = "testemail@probation.gov.uk")
+    val expectedCom = CommunityOffenderManager(staffIdentifier = 2000, username = "smills", email = "testemail@probation.gov.uk", firstName = "X", lastName = "Y")
 
     whenever(licenceRepository.findById(1L)).thenReturn(Optional.of(aLicenceEntity))
     whenever(communityOffenderManagerRepository.findByUsernameIgnoreCase("smills")).thenReturn(expectedCom)
@@ -506,9 +546,11 @@ class LicenceServiceTest {
 
     val licenceCaptor = ArgumentCaptor.forClass(EntityLicence::class.java)
     val historyCaptor = ArgumentCaptor.forClass(EntityLicenceHistory::class.java)
+    val auditCaptor = ArgumentCaptor.forClass(EntityAuditEvent::class.java)
 
     verify(licenceRepository, times(1)).saveAndFlush(licenceCaptor.capture())
     verify(licenceHistoryRepository, times(1)).saveAndFlush(historyCaptor.capture())
+    verify(auditEventRepository, times(1)).saveAndFlush(auditCaptor.capture())
 
     assertThat(licenceCaptor.value.statusCode).isEqualTo(LicenceStatus.SUBMITTED)
     assertThat(licenceCaptor.value.updatedByUsername).isEqualTo("smills")
@@ -516,6 +558,10 @@ class LicenceServiceTest {
 
     assertThat(historyCaptor.value.statusCode).isEqualTo(LicenceStatus.SUBMITTED.name)
     assertThat(historyCaptor.value.actionDescription).isEqualTo("Status changed to SUBMITTED")
+
+    assertThat(auditCaptor.value)
+      .extracting("licenceId", "username", "fullName", "summary")
+      .isEqualTo(listOf(1L, "smills", "X Y", "Licence submitted for ${aLicenceEntity.forename} ${aLicenceEntity.surname}"))
   }
 
   @Test
@@ -775,9 +821,9 @@ class LicenceServiceTest {
       probationTeamDescription = "Cardiff South Team A",
       dateCreated = LocalDateTime.now(),
       standardConditions = someEntityStandardConditions,
-      mailingList = mutableSetOf(CommunityOffenderManager(staffIdentifier = 2000, username = "smills", email = "testemail@probation.gov.uk")),
-      responsibleCom = CommunityOffenderManager(staffIdentifier = 2000, username = "smills", email = "testemail@probation.gov.uk"),
-      createdBy = CommunityOffenderManager(staffIdentifier = 2000, username = "smills", email = "testemail@probation.gov.uk"),
+      mailingList = mutableSetOf(CommunityOffenderManager(staffIdentifier = 2000, username = "smills", email = "testemail@probation.gov.uk", firstName = "X", lastName = "Y")),
+      responsibleCom = CommunityOffenderManager(staffIdentifier = 2000, username = "smills", email = "testemail@probation.gov.uk", firstName = "X", lastName = "Y"),
+      createdBy = CommunityOffenderManager(staffIdentifier = 2000, username = "smills", email = "testemail@probation.gov.uk", firstName = "X", lastName = "Y"),
     )
 
     val someAdditionalConditionData = listOf(AdditionalConditionData(id = 1, dataField = "dataField", dataValue = "dataValue", additionalCondition = EntityAdditionalCondition(licence = aLicenceEntity)))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceServiceTest.kt
@@ -834,7 +834,6 @@ class LicenceServiceTest {
     assertThat(auditCaptor.value)
       .extracting("licenceId", "username", "fullName", "summary")
       .isEqualTo(listOf(1L, "smills", "X Y", "Licence variation discarded for ${aLicenceEntity.forename} ${aLicenceEntity.surname}"))
-
   }
 
   private companion object {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceServiceTest.kt
@@ -69,7 +69,6 @@ class LicenceServiceTest {
   private val auditEventRepository = mock<AuditEventRepository>()
   private val notifyService = mock<NotifyService>()
 
-
   private val service = LicenceService(
     licenceRepository,
     communityOffenderManagerRepository,
@@ -98,7 +97,8 @@ class LicenceServiceTest {
       licenceHistoryRepository,
       additionalConditionUploadDetailRepository,
       auditEventRepository,
-      notifyService)
+      notifyService,
+    )
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/OffenderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/OffenderServiceTest.kt
@@ -30,7 +30,9 @@ class OffenderServiceTest {
     val comDetails = CommunityOffenderManager(
       staffIdentifier = 2000,
       username = "joebloggs",
-      email = "jbloggs@probation.gov.uk"
+      email = "jbloggs@probation.gov.uk",
+      firstName = "X",
+      lastName = "Y",
     )
 
     val expectedUpdatedLicences = listOf(Licence(responsibleCom = comDetails))

--- a/src/test/resources/test_data/clear-all-data.sql
+++ b/src/test/resources/test_data/clear-all-data.sql
@@ -8,3 +8,4 @@ DELETE from licence_history;
 DELETE from community_offender_manager_licence_mailing_list;
 DELETE from licence;
 DELETE from community_offender_manager;
+DELETE from audit_event;

--- a/src/test/resources/test_data/seed-community-offender-manager.sql
+++ b/src/test/resources/test_data/seed-community-offender-manager.sql
@@ -1,6 +1,6 @@
-insert into community_offender_manager(id, staff_identifier, username, email)
+insert into community_offender_manager(id, staff_identifier, username, email, first_name, last_name)
 values
-    (1, 2000, 'test-client', 'testClient@probation.gov.uk'),
-    (2, 125, 'AAA', 'testAAA@probation.gov.uk'),
-    (3, 126, 'BBB', 'testBBB@probation.gov.uk');
+    (1, 2000, 'test-client', 'testClient@probation.gov.uk', 'Test', 'Client'),
+    (2, 125, 'AAA', 'testAAA@probation.gov.uk', 'Adam', 'AAA'),
+    (3, 126, 'BBB', 'testBBB@probation.gov.uk', 'Brian', 'BBB');
 


### PR DESCRIPTION
PLEASE DO NOT MERGE - requires sequencing with UI changes & a DB drop/recreate

Caters for auditing change events within the API for:
* Create a licence
* Submit a licence
* Approve or reject a licence
* Edit a licence
* Set to Recall or Inactive
* Variation created
* Variated submitted
* Adds first_name, last_name into COM details table