### PR TITLE
CVSL-390: Add new endpoints for licence variation, and an endpoint for discarding licences

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/entity/BespokeCondition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/entity/BespokeCondition.kt
@@ -4,6 +4,8 @@ import javax.persistence.Entity
 import javax.persistence.GeneratedValue
 import javax.persistence.GenerationType
 import javax.persistence.Id
+import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
 import javax.persistence.Table
 import javax.validation.constraints.NotNull
 
@@ -15,8 +17,9 @@ data class BespokeCondition(
   @NotNull
   val id: Long = -1,
 
-  @NotNull
-  val licenceId: Long = -1,
+  @ManyToOne
+  @JoinColumn(name = "licence_id", nullable = false)
+  var licence: Licence,
 
   val conditionSequence: Int? = null,
   val conditionText: String? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/entity/Licence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/entity/Licence.kt
@@ -2,8 +2,6 @@ package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity
 
 import org.hibernate.annotations.Fetch
 import org.hibernate.annotations.FetchMode
-import org.hibernate.annotations.LazyCollection
-import org.hibernate.annotations.LazyCollectionOption
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus.IN_PROGRESS
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceType
@@ -43,7 +41,7 @@ data class Licence(
 
   @NotNull
   @Enumerated(STRING)
-  val statusCode: LicenceStatus = IN_PROGRESS,
+  var statusCode: LicenceStatus = IN_PROGRESS,
 
   val nomsId: String? = null,
   val bookingNo: String? = null,
@@ -78,6 +76,9 @@ data class Licence(
   val appointmentTime: LocalDateTime? = null,
   val appointmentAddress: String? = null,
   val appointmentContact: String? = null,
+  val spoDiscussion: String? = null,
+  val vloDiscussion: String? = null,
+  val reasonForVariation: String? = null,
   val approvedDate: LocalDateTime? = null,
   val approvedByUsername: String? = null,
   val approvedByName: String? = null,
@@ -86,23 +87,19 @@ data class Licence(
   val dateLastUpdated: LocalDateTime? = null,
   var updatedByUsername: String? = null,
 
-  @JoinColumn(name = "licenceId")
+  @OneToMany(mappedBy = "licence", fetch = FetchType.EAGER, cascade = [CascadeType.ALL], orphanRemoval = true)
   @Fetch(value = FetchMode.SUBSELECT)
-  @LazyCollection(LazyCollectionOption.FALSE)
   @OrderBy("conditionSequence")
-  @OneToMany
-  val standardConditions: List<StandardCondition> = emptyList(),
+  var standardConditions: List<StandardCondition> = emptyList(),
 
   @OneToMany(mappedBy = "licence", fetch = FetchType.EAGER, cascade = [CascadeType.ALL], orphanRemoval = true)
   @Fetch(value = FetchMode.SUBSELECT)
   @OrderBy("conditionSequence")
   val additionalConditions: List<AdditionalCondition> = emptyList(),
 
-  @JoinColumn(name = "licenceId")
+  @OneToMany(mappedBy = "licence", fetch = FetchType.EAGER, cascade = [CascadeType.ALL], orphanRemoval = true)
   @Fetch(value = FetchMode.SUBSELECT)
-  @LazyCollection(LazyCollectionOption.FALSE)
   @OrderBy("conditionSequence")
-  @OneToMany
   val bespokeConditions: List<BespokeCondition> = emptyList(),
 
   @ManyToOne
@@ -123,5 +120,50 @@ data class Licence(
     joinColumns = [JoinColumn(name = "licence_id")],
     inverseJoinColumns = [JoinColumn(name = "community_offender_manager_id")]
   )
-  val mailingList: MutableSet<CommunityOffenderManager> = mutableSetOf()
-)
+  val mailingList: MutableSet<CommunityOffenderManager> = mutableSetOf(),
+
+  var variationOfId: Long? = null,
+) {
+  fun createVariation(): Licence {
+    return Licence(
+      typeCode = this.typeCode,
+      version = this.version,
+      statusCode = LicenceStatus.VARIATION_IN_PROGRESS,
+      nomsId = this.nomsId,
+      bookingNo = this.bookingNo,
+      bookingId = this.bookingId,
+      crn = this.crn,
+      pnc = this.pnc,
+      cro = this.cro,
+      prisonCode = this.prisonCode,
+      prisonDescription = this.prisonDescription,
+      prisonTelephone = this.prisonTelephone,
+      forename = this.forename,
+      middleNames = this.middleNames,
+      surname = this.surname,
+      dateOfBirth = this.dateOfBirth,
+      conditionalReleaseDate = this.conditionalReleaseDate,
+      actualReleaseDate = this.actualReleaseDate,
+      sentenceStartDate = this.sentenceStartDate,
+      sentenceEndDate = this.sentenceEndDate,
+      licenceStartDate = this.licenceStartDate,
+      licenceExpiryDate = this.licenceExpiryDate,
+      topupSupervisionStartDate = this.topupSupervisionStartDate,
+      topupSupervisionExpiryDate = this.topupSupervisionExpiryDate,
+      probationAreaCode = this.probationAreaCode,
+      probationAreaDescription = this.probationAreaDescription,
+      probationPduCode = this.probationPduCode,
+      probationPduDescription = this.probationPduDescription,
+      probationLauCode = this.probationLauCode,
+      probationLauDescription = this.probationLauDescription,
+      probationTeamCode = this.probationTeamCode,
+      probationTeamDescription = this.probationTeamDescription,
+      appointmentPerson = this.appointmentPerson,
+      appointmentTime = this.appointmentTime,
+      appointmentAddress = this.appointmentAddress,
+      appointmentContact = this.appointmentContact,
+      responsibleCom = this.responsibleCom,
+      variationOfId = this.id,
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/entity/StandardCondition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/entity/StandardCondition.kt
@@ -4,6 +4,8 @@ import javax.persistence.Entity
 import javax.persistence.GeneratedValue
 import javax.persistence.GenerationType
 import javax.persistence.Id
+import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
 import javax.persistence.Table
 import javax.validation.constraints.NotNull
 
@@ -15,8 +17,9 @@ data class StandardCondition(
   @NotNull
   val id: Long = -1,
 
-  @NotNull
-  val licenceId: Long = -1,
+  @ManyToOne
+  @JoinColumn(name = "licence_id", nullable = false)
+  var licence: Licence,
 
   val conditionCode: String? = null,
   val conditionSequence: Int? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/Licence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/Licence.kt
@@ -152,6 +152,15 @@ data class Licence(
   @Schema(description = "The UK telephone number to contact the person the offender should meet for their initial meeting", example = "0114 2557665")
   val appointmentContact: String? = null,
 
+  @Schema(description = "Have you have discussed this variation request with your SPO?", example = "Yes")
+  val spoDiscussion: String? = null,
+
+  @Schema(description = "Have you consulted with the victim liaison officer (VLO) for this case?", example = "Yes")
+  val vloDiscussion: String? = null,
+
+  @Schema(description = "The reason for the variation, in rich-text.")
+  val reasonForVariation: String? = null,
+
   @Schema(description = "The date and time that this prison approved this licence", example = "24/08/2022 11:30:33")
   @JsonFormat(pattern = "dd/MM/yyyy HH:mm:ss")
   val approvedDate: LocalDateTime? = null,
@@ -197,4 +206,10 @@ data class Licence(
 
   @Schema(description = "The list of bespoke conditions on this licence")
   val bespokeConditions: List<BespokeCondition> = emptyList(),
+
+  @Schema(description = "Is this licence a variation of another licence?")
+  val isVariation: Boolean,
+
+  @Schema(description = "The licence Id which this licence is a variation of")
+  val variationOf: Long? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/request/UpdateReasonForVariationRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/request/UpdateReasonForVariationRequest.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import javax.validation.constraints.NotBlank
+
+@Schema(description = "Request object for updating the reason for variation")
+data class UpdateReasonForVariationRequest(
+  @Schema(description = "A large string containing rich text markup. A reason for varying the licence.")
+  @field:NotBlank
+  val reasonForVariation: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/request/UpdateSpoDiscussionRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/request/UpdateSpoDiscussionRequest.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import javax.validation.constraints.NotBlank
+
+@Schema(description = "Request object for updating the SPO discussion")
+data class UpdateSpoDiscussionRequest(
+  @Schema(description = "Whether or not the licence variation has been discussed with an SPO", example = "Yes")
+  @field:NotBlank
+  val spoDiscussion: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/request/UpdateVloDiscussionRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/request/UpdateVloDiscussionRequest.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import javax.validation.constraints.NotBlank
+
+@Schema(description = "Request object for updating the VLO discussion")
+data class UpdateVloDiscussionRequest(
+  @Schema(description = "Whether or not the licence variation has been discussed with a VLO", example = "Yes")
+  @field:NotBlank
+  val vloDiscussion: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/LicenceController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/LicenceController.kt
@@ -36,7 +36,6 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.request.Updat
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.request.UpdateVloDiscussionRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.LicenceQueryObject
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.LicenceService
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.transformToLicenceSummary
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus
 import javax.validation.Valid
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/LicenceController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/LicenceController.kt
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -30,8 +31,12 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.LicenceSummar
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.StatusUpdateRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.UpdateAdditionalConditionDataRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.request.CreateLicenceRequest
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.request.UpdateReasonForVariationRequest
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.request.UpdateSpoDiscussionRequest
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.request.UpdateVloDiscussionRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.LicenceQueryObject
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.LicenceService
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.transformToLicenceSummary
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus
 import javax.validation.Valid
 
@@ -531,8 +536,8 @@ class LicenceController(private val licenceService: LicenceService) {
   @PutMapping(value = ["/id/{licenceId}/submit"])
   @PreAuthorize("hasAnyRole('SYSTEM_USER', 'CVL_ADMIN')")
   @Operation(
-    summary = "Update the status of a licence to SUBMITTED, and record the details of the COM who submitted",
-    description = "Update the status of a licence to SUBMITTED, and record the details of the COM who submitted. Requires ROLE_SYSTEM_USER or ROLE_CVL_ADMIN.",
+    summary = "Update the status of a licence to SUBMITTED or VARIATION_SUBMITTED.",
+    description = "Update the status of a licence to SUBMITTED or VARIATION_SUBMITTED, and record the details of the COM who submitted. Requires ROLE_SYSTEM_USER or ROLE_CVL_ADMIN.",
     security = [SecurityRequirement(name = "ROLE_SYSTEM_USER"), SecurityRequirement(name = "ROLE_CVL_ADMIN")],
   )
   @ApiResponses(
@@ -567,5 +572,216 @@ class LicenceController(private val licenceService: LicenceService) {
     @PathVariable("licenceId") licenceId: Long
   ) {
     return licenceService.submitLicence(licenceId)
+  }
+
+  @PostMapping(value = ["/id/{licenceId}/create-variation"])
+  @PreAuthorize("hasAnyRole('SYSTEM_USER', 'CVL_ADMIN')")
+  @Operation(
+    summary = "Create a variation of this licence",
+    description = "Create a variation of this licence. The new licence will have a new ID and have a statius VARIATION_IN_PROGRESS. Requires ROLE_SYSTEM_USER or ROLE_CVL_ADMIN.",
+    security = [SecurityRequirement(name = "ROLE_SYSTEM_USER"), SecurityRequirement(name = "ROLE_CVL_ADMIN")],
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Licence variation created",
+        content = [
+          Content(mediaType = "application/json", schema = Schema(implementation = LicenceSummary::class))
+        ],
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Bad request, request body must be valid",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorised, requires a valid Oauth2 token",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires an appropriate role",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "The licence for this ID was not found.",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ]
+  )
+  fun createVariation(
+    @PathVariable("licenceId") licenceId: Long
+  ): LicenceSummary {
+    return transformToLicenceSummary(licenceService.createVariation(licenceId))
+  }
+
+  @PutMapping(value = ["/id/{licenceId}/spo-discussion"])
+  @PreAuthorize("hasAnyRole('SYSTEM_USER', 'CVL_ADMIN')")
+  @Operation(
+    summary = "Sets whether the variation has been discussed with an SPO.",
+    description = "Sets whether the variation has been discussed with an SPO. Either Yes or No. Requires ROLE_SYSTEM_USER or ROLE_CVL_ADMIN.",
+    security = [SecurityRequirement(name = "ROLE_SYSTEM_USER"), SecurityRequirement(name = "ROLE_CVL_ADMIN")],
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "SPO discussion updated"
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Bad request, request body must be valid",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorised, requires a valid Oauth2 token",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires an appropriate role",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "The licence for this ID was not found.",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ]
+  )
+  fun updateSpoDiscussion(
+    @PathVariable("licenceId") licenceId: Long,
+    @Valid @RequestBody request: UpdateSpoDiscussionRequest
+  ) {
+    licenceService.updateSpoDiscussion(licenceId, request)
+  }
+
+  @PutMapping(value = ["/id/{licenceId}/vlo-discussion"])
+  @PreAuthorize("hasAnyRole('SYSTEM_USER', 'CVL_ADMIN')")
+  @Operation(
+    summary = "Sets whether the variation has been discussed with a VLO.",
+    description = "Sets whether the variation has been discussed with a VLO. Either Yes or Not applicable. Requires ROLE_SYSTEM_USER or ROLE_CVL_ADMIN.",
+    security = [SecurityRequirement(name = "ROLE_SYSTEM_USER"), SecurityRequirement(name = "ROLE_CVL_ADMIN")],
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "VLO discussion updated"
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Bad request, request body must be valid",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorised, requires a valid Oauth2 token",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires an appropriate role",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "The licence for this ID was not found.",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ]
+  )
+  fun updateVloDiscussion(
+    @PathVariable("licenceId") licenceId: Long,
+    @Valid @RequestBody request: UpdateVloDiscussionRequest
+  ) {
+    licenceService.updateVloDiscussion(licenceId, request)
+  }
+
+  @PutMapping(value = ["/id/{licenceId}/reason-for-variation"])
+  @PreAuthorize("hasAnyRole('SYSTEM_USER', 'CVL_ADMIN')")
+  @Operation(
+    summary = "Updates the reason for the licence variation.",
+    description = "Updates the reason for the licence variation. Requires ROLE_SYSTEM_USER or ROLE_CVL_ADMIN.",
+    security = [SecurityRequirement(name = "ROLE_SYSTEM_USER"), SecurityRequirement(name = "ROLE_CVL_ADMIN")],
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Reason for variation updated"
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Bad request, request body must be valid",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorised, requires a valid Oauth2 token",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires an appropriate role",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "The licence for this ID was not found.",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ]
+  )
+  fun updateReasonForVariation(
+    @PathVariable("licenceId") licenceId: Long,
+    @Valid @RequestBody request: UpdateReasonForVariationRequest
+  ) {
+    licenceService.updateReasonForVariation(licenceId, request)
+  }
+
+  @DeleteMapping(value = ["/id/{licenceId}/discard"])
+  @PreAuthorize("hasAnyRole('SYSTEM_USER', 'CVL_ADMIN')")
+  @Operation(
+    summary = "Discards a licence record.",
+    description = "Discards a licence record. Requires ROLE_SYSTEM_USER or ROLE_CVL_ADMIN.",
+    security = [SecurityRequirement(name = "ROLE_SYSTEM_USER"), SecurityRequirement(name = "ROLE_CVL_ADMIN")],
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Licence discarded"
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Bad request, request body must be valid",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorised, requires a valid Oauth2 token",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires an appropriate role",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "The licence for this ID was not found.",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ]
+  )
+  fun discard(
+    @PathVariable("licenceId") licenceId: Long,
+  ) {
+    licenceService.discardLicence(licenceId)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/LicenceController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/LicenceController.kt
@@ -615,7 +615,7 @@ class LicenceController(private val licenceService: LicenceService) {
   fun createVariation(
     @PathVariable("licenceId") licenceId: Long
   ): LicenceSummary {
-    return transformToLicenceSummary(licenceService.createVariation(licenceId))
+    return licenceService.createVariation(licenceId)
   }
 
   @PutMapping(value = ["/id/{licenceId}/spo-discussion"])

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceService.kt
@@ -367,7 +367,7 @@ class LicenceService(
   }
 
   @Transactional
-  fun createVariation(licenceId: Long): EntityLicence {
+  fun createVariation(licenceId: Long): LicenceSummary {
     val licenceEntity = licenceRepository
       .findById(licenceId)
       .orElseThrow { EntityNotFoundException("$licenceId") }
@@ -419,7 +419,7 @@ class LicenceService(
 
     additionalConditionRepository.saveAll(newAdditionalConditions)
 
-    return newLicence
+    return transformToLicenceSummary(newLicence)
   }
 
   fun updateSpoDiscussion(licenceId: Long, spoDiscussionRequest: UpdateSpoDiscussionRequest) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceService.kt
@@ -37,6 +37,11 @@ import javax.validation.ValidationException
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.BespokeCondition as EntityBespokeCondition
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.Licence as EntityLicence
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.LicenceHistory as EntityLicenceHistory
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.AdditionalCondition
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.request.UpdateReasonForVariationRequest
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.request.UpdateSpoDiscussionRequest
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.request.UpdateVloDiscussionRequest
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus.VARIATION_SUBMITTED
 
 @Service
 class LicenceService(
@@ -70,10 +75,11 @@ class LicenceService(
     licence.mailingList.add(createdBy)
     licence.updatedByUsername = username
 
-    val createLicenceResponse = transformToLicenceSummary(licenceRepository.saveAndFlush(licence))
+    val licenceEntity = licenceRepository.saveAndFlush(licence)
+    val createLicenceResponse = transformToLicenceSummary(licenceEntity)
 
-    val entityStandardLicenceConditions = request.standardLicenceConditions.transformToEntityStandard(createLicenceResponse.licenceId, "AP")
-    val entityStandardPssConditions = request.standardPssConditions.transformToEntityStandard(createLicenceResponse.licenceId, "PSS")
+    val entityStandardLicenceConditions = request.standardLicenceConditions.transformToEntityStandard(licenceEntity, "AP")
+    val entityStandardPssConditions = request.standardPssConditions.transformToEntityStandard(licenceEntity, "PSS")
     standardConditionRepository.saveAllAndFlush(entityStandardLicenceConditions + entityStandardPssConditions)
     return createLicenceResponse
   }
@@ -163,7 +169,7 @@ class LicenceService(
     bespokeConditionRepository.deleteByLicenceId(licenceId)
     request.conditions.forEachIndexed { index, condition ->
       bespokeConditionRepository.saveAndFlush(
-        EntityBespokeCondition(licenceId = licenceId, conditionSequence = index, conditionText = condition)
+        EntityBespokeCondition(licence = licenceEntity, conditionSequence = index, conditionText = condition)
       )
     }
   }
@@ -321,8 +327,10 @@ class LicenceService(
     val submitter = communityOffenderManagerRepository.findByUsernameIgnoreCase(username)
       ?: throw ValidationException("Staff with username $username not found")
 
+    val newStatus = if (licenceEntity.variationOfId == null) SUBMITTED else VARIATION_SUBMITTED
+
     val updatedLicence = licenceEntity.copy(
-      statusCode = SUBMITTED,
+      statusCode = newStatus,
       submittedBy = submitter,
       updatedByUsername = username,
       dateLastUpdated = LocalDateTime.now()
@@ -333,9 +341,9 @@ class LicenceService(
     licenceHistoryRepository.saveAndFlush(
       EntityLicenceHistory(
         licenceId = licenceId,
-        statusCode = SUBMITTED.name,
+        statusCode = newStatus.name,
         actionTime = LocalDateTime.now(),
-        actionDescription = "Status changed to SUBMITTED",
+        actionDescription = "Status changed to ${newStatus.name}",
         actionUsername = username,
       )
     )
@@ -356,6 +364,106 @@ class LicenceService(
     if (activatedLicences.isNotEmpty()) {
       licenceRepository.saveAllAndFlush(activatedLicences)
     }
+  }
+
+  @Transactional
+  fun createVariation(licenceId: Long): EntityLicence {
+    val licenceEntity = licenceRepository
+      .findById(licenceId)
+      .orElseThrow { EntityNotFoundException("$licenceId") }
+
+    val username = SecurityContextHolder.getContext().authentication.name
+    val createdBy = this.communityOffenderManagerRepository.findByUsernameIgnoreCase(username)
+
+    val licenceVariation = licenceEntity.createVariation()
+    licenceVariation.createdBy = createdBy
+    licenceVariation.mailingList.add(licenceVariation.responsibleCom!!)
+    licenceVariation.mailingList.add(createdBy!!)
+
+    val newLicence = licenceRepository.save(licenceVariation)
+    val standardConditions = licenceEntity.standardConditions.map {
+      it.copy(id=-1, licence = newLicence)
+    }
+    val bespokeConditions = licenceEntity.bespokeConditions.map {
+      it.copy(id=-1, licence = newLicence)
+    }
+
+    standardConditionRepository.saveAll(standardConditions)
+    bespokeConditionRepository.saveAll(bespokeConditions)
+
+    val additionalConditions = licenceEntity.additionalConditions.map {
+      val additionalConditionData = it.additionalConditionData.map {
+        it.copy(id = -1)
+      }
+      val additionalConditionUploadSummary = it.additionalConditionUploadSummary.map {
+        it.copy(id = -1)
+      }
+
+      it.copy(id=-1, licence = newLicence, additionalConditionData = additionalConditionData, additionalConditionUploadSummary = additionalConditionUploadSummary)
+    }
+
+    var newAdditionalConditions = additionalConditionRepository.saveAll(additionalConditions).toMutableList()
+
+    newAdditionalConditions = newAdditionalConditions.map { condition ->
+      val updatedAdditionalConditionData = condition.additionalConditionData.map {
+        it.copy(additionalCondition = condition)
+      }
+      val updatedAdditionalConditionUploadSummary = condition.additionalConditionUploadSummary.map {
+        var uploadDetail = additionalConditionUploadDetailRepository.getById(it.uploadDetailId)
+        uploadDetail = uploadDetail.copy(id = -1, licenceId = newLicence.id, additionalConditionId = condition.id)
+        uploadDetail = additionalConditionUploadDetailRepository.save(uploadDetail)
+        it.copy(additionalCondition = condition, uploadDetailId = uploadDetail.id)
+      }
+      condition.copy(additionalConditionData = updatedAdditionalConditionData, additionalConditionUploadSummary = updatedAdditionalConditionUploadSummary)
+    } as MutableList<AdditionalCondition>
+
+    additionalConditionRepository.saveAll(newAdditionalConditions)
+
+    return newLicence
+  }
+
+  fun updateSpoDiscussion(licenceId: Long, spoDiscussionRequest: UpdateSpoDiscussionRequest) {
+    val licenceEntity = licenceRepository
+      .findById(licenceId)
+      .orElseThrow { EntityNotFoundException("$licenceId") }
+
+    val username = SecurityContextHolder.getContext().authentication.name
+
+    val updatedLicenceEntity = licenceEntity.copy(spoDiscussion = spoDiscussionRequest.spoDiscussion, dateLastUpdated = LocalDateTime.now(), updatedByUsername = username)
+
+    licenceRepository.saveAndFlush(updatedLicenceEntity)
+  }
+
+  fun updateVloDiscussion(licenceId: Long, vloDiscussionRequest: UpdateVloDiscussionRequest) {
+    val licenceEntity = licenceRepository
+      .findById(licenceId)
+      .orElseThrow { EntityNotFoundException("$licenceId") }
+
+    val username = SecurityContextHolder.getContext().authentication.name
+
+    val updatedLicenceEntity = licenceEntity.copy(vloDiscussion = vloDiscussionRequest.vloDiscussion, dateLastUpdated = LocalDateTime.now(), updatedByUsername = username)
+
+    licenceRepository.saveAndFlush(updatedLicenceEntity)
+  }
+
+  fun updateReasonForVariation(licenceId: Long, reasonForVariationRequest: UpdateReasonForVariationRequest) {
+    val licenceEntity = licenceRepository
+      .findById(licenceId)
+      .orElseThrow { EntityNotFoundException("$licenceId") }
+
+    val username = SecurityContextHolder.getContext().authentication.name
+
+    val updatedLicenceEntity = licenceEntity.copy(reasonForVariation = reasonForVariationRequest.reasonForVariation, dateLastUpdated = LocalDateTime.now(), updatedByUsername = username)
+
+    licenceRepository.saveAndFlush(updatedLicenceEntity)
+  }
+
+  fun discardLicence(licenceId: Long) {
+    val licenceEntity = licenceRepository
+      .findById(licenceId)
+      .orElseThrow { EntityNotFoundException("$licenceId") }
+
+    licenceRepository.delete(licenceEntity)
   }
 
   private fun offenderHasLicenceInFlight(nomsId: String): Boolean {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceService.kt
@@ -4,6 +4,7 @@ import org.springframework.data.mapping.PropertyReferenceException
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.AdditionalCondition
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AdditionalConditionsRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AppointmentAddressRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AppointmentPersonRequest
@@ -15,6 +16,9 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.LicenceSummar
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.StatusUpdateRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.UpdateAdditionalConditionDataRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.request.CreateLicenceRequest
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.request.UpdateReasonForVariationRequest
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.request.UpdateSpoDiscussionRequest
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.request.UpdateVloDiscussionRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.AdditionalConditionRepository
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.AdditionalConditionUploadDetailRepository
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.BespokeConditionRepository
@@ -31,17 +35,13 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus.
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus.IN_PROGRESS
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus.REJECTED
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus.SUBMITTED
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus.VARIATION_SUBMITTED
 import java.time.LocalDateTime
 import javax.persistence.EntityNotFoundException
 import javax.validation.ValidationException
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.BespokeCondition as EntityBespokeCondition
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.Licence as EntityLicence
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.LicenceHistory as EntityLicenceHistory
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.AdditionalCondition
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.request.UpdateReasonForVariationRequest
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.request.UpdateSpoDiscussionRequest
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.request.UpdateVloDiscussionRequest
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus.VARIATION_SUBMITTED
 
 @Service
 class LicenceService(
@@ -382,10 +382,10 @@ class LicenceService(
 
     val newLicence = licenceRepository.save(licenceVariation)
     val standardConditions = licenceEntity.standardConditions.map {
-      it.copy(id=-1, licence = newLicence)
+      it.copy(id = -1, licence = newLicence)
     }
     val bespokeConditions = licenceEntity.bespokeConditions.map {
-      it.copy(id=-1, licence = newLicence)
+      it.copy(id = -1, licence = newLicence)
     }
 
     standardConditionRepository.saveAll(standardConditions)
@@ -399,7 +399,7 @@ class LicenceService(
         it.copy(id = -1)
       }
 
-      it.copy(id=-1, licence = newLicence, additionalConditionData = additionalConditionData, additionalConditionUploadSummary = additionalConditionUploadSummary)
+      it.copy(id = -1, licence = newLicence, additionalConditionData = additionalConditionData, additionalConditionUploadSummary = additionalConditionUploadSummary)
     }
 
     var newAdditionalConditions = additionalConditionRepository.saveAll(additionalConditions).toMutableList()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/TransformFunctions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/TransformFunctions.kt
@@ -133,6 +133,9 @@ fun transform(licence: EntityLicence): ModelLicence {
     appointmentTime = licence.appointmentTime,
     appointmentAddress = licence.appointmentAddress,
     appointmentContact = licence.appointmentContact,
+    spoDiscussion = licence.spoDiscussion,
+    vloDiscussion = licence.vloDiscussion,
+    reasonForVariation = licence.reasonForVariation,
     approvedDate = licence.approvedDate,
     approvedByUsername = licence.approvedByUsername,
     approvedByName = licence.approvedByName,
@@ -146,15 +149,17 @@ fun transform(licence: EntityLicence): ModelLicence {
     additionalLicenceConditions = licence.additionalConditions.transformToModelAdditional("AP"),
     additionalPssConditions = licence.additionalConditions.transformToModelAdditional("PSS"),
     bespokeConditions = licence.bespokeConditions.transformToModelBespoke(),
+    isVariation = licence.variationOfId != null,
+    variationOf = licence.variationOfId,
   )
 }
 
 // Transform a list of model standard conditions to a list of entity StandardConditions, setting the licenceId
-fun List<ModelStandardCondition>.transformToEntityStandard(id: Long, conditionType: String): List<EntityStandardCondition> = map { term -> transform(term, id, conditionType) }
+fun List<ModelStandardCondition>.transformToEntityStandard(licence: EntityLicence, conditionType: String): List<EntityStandardCondition> = map { term -> transform(term, licence, conditionType) }
 
-fun transform(model: ModelStandardCondition, id: Long, conditionType: String): EntityStandardCondition {
+fun transform(model: ModelStandardCondition, licence: EntityLicence, conditionType: String): EntityStandardCondition {
   return EntityStandardCondition(
-    licenceId = id,
+    licence = licence,
     conditionCode = model.code,
     conditionSequence = model.sequence,
     conditionText = model.text,

--- a/src/main/resources/migration/common/V11__create_licence_tables.sql
+++ b/src/main/resources/migration/common/V11__create_licence_tables.sql
@@ -46,6 +46,10 @@ CREATE TABLE licence (
   appointment_time timestamp with time zone,
   appointment_address varchar(240),
   appointment_contact varchar(20),
+  spo_discussion varchar(4),
+  vlo_discussion varchar(20),
+  reason_for_variation text,
+  variation_of_id integer references licence(id),
   approved_date timestamp with time zone,
   approved_by_username varchar(100),
   approved_by_name varchar(100),
@@ -107,8 +111,8 @@ CREATE INDEX idx_bespoke_condition_licence_id ON bespoke_condition(licence_id);
 
 CREATE TABLE licence_history (
   id serial NOT NULL constraint licence_history_pk PRIMARY KEY,
-  licence_id integer references licence(id),
-  status_code varchar(20) references licence_status(status_code),
+  licence_id integer references licence(id) ON DELETE CASCADE,
+  status_code varchar(40) references licence_status(status_code),
   action_time timestamp with time zone default CURRENT_TIMESTAMP,
   action_description varchar(80) NOT NULL,
   action_username varchar(100)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/LicenceControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/LicenceControllerTest.kt
@@ -445,6 +445,7 @@ class LicenceControllerTest {
       additionalLicenceConditions = someAdditionalConditions,
       additionalPssConditions = someAdditionalConditions,
       bespokeConditions = someBespokeConditions,
+      isVariation = false,
     )
 
     val aCreateLicenceRequest = CreateLicenceRequest(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/LicenceControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/LicenceControllerTest.kt
@@ -19,6 +19,7 @@ import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.context.web.WebAppConfiguration
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
@@ -41,6 +42,9 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.StandardCondi
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.StatusUpdateRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.UpdateAdditionalConditionDataRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.request.CreateLicenceRequest
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.request.UpdateReasonForVariationRequest
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.request.UpdateSpoDiscussionRequest
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.request.UpdateVloDiscussionRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.LicenceQueryObject
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.LicenceService
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus
@@ -373,6 +377,71 @@ class LicenceControllerTest {
       .andExpect(status().isOk)
 
     verify(licenceService, times(1)).submitLicence(4)
+  }
+
+  @Test
+  fun `create variation`() {
+    whenever(licenceService.createVariation(4L)).thenReturn(aLicenceSummary)
+
+    mvc.perform(
+      post("/licence/id/4/create-variation")
+        .accept(APPLICATION_JSON)
+        .contentType(APPLICATION_JSON)
+    )
+      .andExpect(status().isOk)
+
+    verify(licenceService, times(1)).createVariation(4)
+  }
+
+  @Test
+  fun `update spo discussion`() {
+    mvc.perform(
+      put("/licence/id/4/spo-discussion")
+        .accept(APPLICATION_JSON)
+        .contentType(APPLICATION_JSON)
+        .content(mapper.writeValueAsBytes(UpdateSpoDiscussionRequest(spoDiscussion = "Yes")))
+    )
+      .andExpect(status().isOk)
+
+    verify(licenceService, times(1)).updateSpoDiscussion(4, UpdateSpoDiscussionRequest(spoDiscussion = "Yes"))
+  }
+
+  @Test
+  fun `update vlo discussion`() {
+    mvc.perform(
+      put("/licence/id/4/vlo-discussion")
+        .accept(APPLICATION_JSON)
+        .contentType(APPLICATION_JSON)
+        .content(mapper.writeValueAsBytes(UpdateVloDiscussionRequest(vloDiscussion = "Yes")))
+    )
+      .andExpect(status().isOk)
+
+    verify(licenceService, times(1)).updateVloDiscussion(4, UpdateVloDiscussionRequest(vloDiscussion = "Yes"))
+  }
+
+  @Test
+  fun `update reason for variation`() {
+    mvc.perform(
+      put("/licence/id/4/reason-for-variation")
+        .accept(APPLICATION_JSON)
+        .contentType(APPLICATION_JSON)
+        .content(mapper.writeValueAsBytes(UpdateReasonForVariationRequest(reasonForVariation = "reason")))
+    )
+      .andExpect(status().isOk)
+
+    verify(licenceService, times(1)).updateReasonForVariation(4, UpdateReasonForVariationRequest(reasonForVariation = "reason"))
+  }
+
+  @Test
+  fun `discard a licence`() {
+    mvc.perform(
+      delete("/licence/id/4/discard")
+        .accept(APPLICATION_JSON)
+        .contentType(APPLICATION_JSON)
+    )
+      .andExpect(status().isOk)
+
+    verify(licenceService, times(1)).discardLicence(4)
   }
 
   private companion object {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ExclusionZoneServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ExclusionZoneServiceTest.kt
@@ -107,7 +107,8 @@ class ExclusionZoneServiceTest {
         id = 1,
         conditionCode = "goodBehaviour",
         conditionSequence = 1,
-        conditionText = "Be of good behaviour"
+        conditionText = "Be of good behaviour",
+        licence = mock()
       ),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceServiceTest.kt
@@ -32,6 +32,9 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.LicenceSummar
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.StatusUpdateRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.UpdateAdditionalConditionDataRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.request.CreateLicenceRequest
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.request.UpdateReasonForVariationRequest
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.request.UpdateSpoDiscussionRequest
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.request.UpdateVloDiscussionRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.AdditionalConditionRepository
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.AdditionalConditionUploadDetailRepository
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.BespokeConditionRepository
@@ -55,9 +58,6 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.StandardCond
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AdditionalConditionData as ModelAdditionalConditionData
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.Licence as ModelLicence
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.StandardCondition as ModelStandardCondition
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.request.UpdateReasonForVariationRequest
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.request.UpdateSpoDiscussionRequest
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.request.UpdateVloDiscussionRequest
 
 class LicenceServiceTest {
   private val standardConditionRepository = mock<StandardConditionRepository>()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceServiceTest.kt
@@ -1,5 +1,13 @@
 package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service
 
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.AdditionalCondition as EntityAdditionalCondition
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.BespokeCondition as EntityBespokeCondition
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.Licence as EntityLicence
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.LicenceHistory as EntityLicenceHistory
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.StandardCondition as EntityStandardCondition
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AdditionalConditionData as ModelAdditionalConditionData
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.Licence as ModelLicence
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.StandardCondition as ModelStandardCondition
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -47,14 +55,6 @@ import java.time.LocalDateTime
 import java.util.Optional
 import javax.persistence.EntityNotFoundException
 import javax.validation.ValidationException
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.AdditionalCondition as EntityAdditionalCondition
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.BespokeCondition as EntityBespokeCondition
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.Licence as EntityLicence
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.LicenceHistory as EntityLicenceHistory
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.StandardCondition as EntityStandardCondition
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AdditionalConditionData as ModelAdditionalConditionData
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.Licence as ModelLicence
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.StandardCondition as ModelStandardCondition
 
 class LicenceServiceTest {
   private val standardConditionRepository = mock<StandardConditionRepository>()
@@ -287,9 +287,9 @@ class LicenceServiceTest {
     whenever(bespokeConditionRepository.deleteByLicenceId(1L)).thenReturn(0)
 
     val bespokeEntities = listOf(
-      EntityBespokeCondition(id = -1L, licenceId = 1L, conditionSequence = 0, conditionText = "Condition 1"),
-      EntityBespokeCondition(id = -1L, licenceId = 1L, conditionSequence = 1, conditionText = "Condition 2"),
-      EntityBespokeCondition(id = -1L, licenceId = 1L, conditionSequence = 2, conditionText = "Condition 3"),
+      EntityBespokeCondition(id = -1L, licence = aLicenceEntity, conditionSequence = 0, conditionText = "Condition 1"),
+      EntityBespokeCondition(id = -1L, licence = aLicenceEntity, conditionSequence = 1, conditionText = "Condition 2"),
+      EntityBespokeCondition(id = -1L, licence = aLicenceEntity, conditionSequence = 2, conditionText = "Condition 3"),
     )
 
     bespokeEntities.forEach { bespoke ->
@@ -701,9 +701,9 @@ class LicenceServiceTest {
     )
 
     val someEntityStandardConditions = listOf(
-      EntityStandardCondition(id = 1, conditionCode = "goodBehaviour", conditionSequence = 1, conditionText = "Be of good behaviour"),
-      EntityStandardCondition(id = 2, conditionCode = "notBreakLaw", conditionSequence = 2, conditionText = "Do not break any law"),
-      EntityStandardCondition(id = 3, conditionCode = "attendMeetings", conditionSequence = 3, conditionText = "Attend meetings"),
+      EntityStandardCondition(id = 1, conditionCode = "goodBehaviour", conditionSequence = 1, conditionText = "Be of good behaviour", licence = mock()),
+      EntityStandardCondition(id = 2, conditionCode = "notBreakLaw", conditionSequence = 2, conditionText = "Do not break any law", licence = mock()),
+      EntityStandardCondition(id = 3, conditionCode = "attendMeetings", conditionSequence = 3, conditionText = "Attend meetings", licence = mock()),
     )
 
     val aCreateLicenceRequest = CreateLicenceRequest(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceServiceTest.kt
@@ -1,13 +1,5 @@
 package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service
 
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.AdditionalCondition as EntityAdditionalCondition
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.BespokeCondition as EntityBespokeCondition
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.Licence as EntityLicence
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.LicenceHistory as EntityLicenceHistory
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.StandardCondition as EntityStandardCondition
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AdditionalConditionData as ModelAdditionalConditionData
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.Licence as ModelLicence
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.StandardCondition as ModelStandardCondition
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -55,6 +47,14 @@ import java.time.LocalDateTime
 import java.util.Optional
 import javax.persistence.EntityNotFoundException
 import javax.validation.ValidationException
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.AdditionalCondition as EntityAdditionalCondition
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.BespokeCondition as EntityBespokeCondition
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.Licence as EntityLicence
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.LicenceHistory as EntityLicenceHistory
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.StandardCondition as EntityStandardCondition
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AdditionalConditionData as ModelAdditionalConditionData
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.Licence as ModelLicence
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.StandardCondition as ModelStandardCondition
 
 class LicenceServiceTest {
   private val standardConditionRepository = mock<StandardConditionRepository>()


### PR DESCRIPTION
- 5 new endpoints:
    - create variation
    - discard
    - update spo discussion
    - update vlo discussion
    - update reason for variation
- Requires DB re-create