### PR TITLE
Fix deletion of bespoke conditions

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/repository/BespokeConditionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/repository/BespokeConditionRepository.kt
@@ -5,5 +5,4 @@ import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.BespokeCondition
 
 @Repository
-interface BespokeConditionRepository : JpaRepository<BespokeCondition, Long> {
-}
+interface BespokeConditionRepository : JpaRepository<BespokeCondition, Long>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/repository/BespokeConditionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/repository/BespokeConditionRepository.kt
@@ -6,5 +6,4 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.BespokeCondi
 
 @Repository
 interface BespokeConditionRepository : JpaRepository<BespokeCondition, Long> {
-  fun deleteByLicenceId(id: Long): Long
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceService.kt
@@ -188,11 +188,10 @@ class LicenceService(
       .orElseThrow { EntityNotFoundException("$licenceId") }
 
     val username = SecurityContextHolder.getContext().authentication.name
-    val updatedLicence = licenceEntity.copy(dateLastUpdated = LocalDateTime.now(), updatedByUsername = username)
+    val updatedLicence = licenceEntity.copy(bespokeConditions = emptyList(), dateLastUpdated = LocalDateTime.now(), updatedByUsername = username)
     licenceRepository.saveAndFlush(updatedLicence)
 
     // Replace the bespoke conditions
-    bespokeConditionRepository.deleteByLicenceId(licenceId)
     request.conditions.forEachIndexed { index, condition ->
       bespokeConditionRepository.saveAndFlush(
         EntityBespokeCondition(licence = licenceEntity, conditionSequence = index, conditionText = condition)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceServiceTest.kt
@@ -310,7 +310,6 @@ class LicenceServiceTest {
   @Test
   fun `update bespoke conditions persists multiple entities`() {
     whenever(licenceRepository.findById(1L)).thenReturn(Optional.of(aLicenceEntity))
-    whenever(bespokeConditionRepository.deleteByLicenceId(1L)).thenReturn(0)
 
     val bespokeEntities = listOf(
       EntityBespokeCondition(id = -1L, licence = aLicenceEntity, conditionSequence = 0, conditionText = "Condition 1"),
@@ -328,9 +327,7 @@ class LicenceServiceTest {
     val licenceCaptor = ArgumentCaptor.forClass(EntityLicence::class.java)
     verify(licenceRepository, times(1)).saveAndFlush(licenceCaptor.capture())
     assertThat(licenceCaptor.value).extracting("updatedByUsername").isEqualTo("smills")
-
-    // Verify old bespoke conditions are removed
-    verify(bespokeConditionRepository, times(1)).deleteByLicenceId(1L)
+    assertThat(licenceCaptor.value).extracting("bespokeConditions").isEqualTo(emptyList<EntityBespokeCondition>())
 
     // Verify new bespoke conditions are added in their place
     bespokeEntities.forEach { bespoke ->
@@ -341,11 +338,9 @@ class LicenceServiceTest {
   @Test
   fun `update bespoke conditions with an empty list - removes previously persisted entities`() {
     whenever(licenceRepository.findById(1L)).thenReturn(Optional.of(aLicenceEntity))
-    whenever(bespokeConditionRepository.deleteByLicenceId(1L)).thenReturn(0)
 
     service.updateBespokeConditions(1L, BespokeConditionRequest())
 
-    verify(bespokeConditionRepository, times(1)).deleteByLicenceId(1L)
     verify(bespokeConditionRepository, times(0)).saveAndFlush(any())
     verify(licenceRepository, times(1)).saveAndFlush(any())
   }
@@ -361,7 +356,6 @@ class LicenceServiceTest {
     assertThat(exception).isInstanceOf(EntityNotFoundException::class.java)
 
     verify(licenceRepository, times(1)).findById(1L)
-    verify(bespokeConditionRepository, times(0)).deleteByLicenceId(1L)
     verify(bespokeConditionRepository, times(0)).saveAndFlush(any())
   }
 


### PR DESCRIPTION
Because the bespoke conditions are now joined by hibernate, instead of a manual join by id, the deletion by ID no longer works. Instead, the entity should be updated with an empty list

Infact, the BespokeConditionRepository should not exist, and should be handled through the licence repository as a join, but this is a bigger piece of work to refactor