### PR TITLE
CVSL-450: Embedded self-referencing (env-specific) links into the email notifications

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -11,6 +11,7 @@ generic-service:
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
     HMPPS_AUTH_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
+    SELF_LINK: "https://create-and-vary-a-licence-dev.hmpps.service.justice.gov.uk"
 
 # CloudPlatform AlertManager receiver to route promethues alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -11,6 +11,7 @@ generic-service:
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
     HMPPS_AUTH_URL: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth
+    SELF_LINK: "https://create-and-vary-a-licence-preprod.hmpps.service.justice.gov.uk"
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -11,6 +11,7 @@ generic-service:
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json
     HMPPS_AUTH_URL: https://sign-in.hmpps.service.justice.gov.uk/auth
+    SELF_LINK: "https://create-and-vary-a-licence.hmpps.service.justice.gov.uk"
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/NotifyService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/NotifyService.kt
@@ -14,6 +14,7 @@ import java.time.format.DateTimeFormatter
 @Service
 class NotifyService(
   @Value("\${notify.enabled}") private val enabled: Boolean,
+  @Value("\${self.link}") private val selfLink: String,
   @Value("\${notify.templates.licenceApproved}") private val licenceApprovedTemplateId: String,
   @Value("\${notify.templates.variationForApproval}") private val variationForApprovalTemplateId: String,
   @Value("\${notify.templates.initialLicencePrompt}") private val initialLicencePromptTemplateId: String,
@@ -27,7 +28,6 @@ class NotifyService(
     sendEmail(licenceApprovedTemplateId, "", values, reference)
   }
 
-  // TODO: Add environment-specific link to approval cases or specific page to approve this variation
   fun sendVariationForApprovalEmail(pduCode: String, licenceId: String, firstName: String, lastName: String) {
     val pduHead = pduHeadProperties.contacts
       .getOrDefault(pduCode, EmailConfig(forename = "", surname = "", email = "", description = ""))
@@ -37,6 +37,7 @@ class NotifyService(
         Pair("pduHeadFirstName", pduHead.forename),
         Pair("licenceFirstName", firstName),
         Pair("licenceLastName", lastName),
+        Pair("approvalCasesLink", selfLink.plus("/licence/vary-approve/list"))
       )
       sendEmail(variationForApprovalTemplateId, pduHead.email, values, null)
     } else {
@@ -67,6 +68,7 @@ class NotifyService(
             "${prisoner.name} who will leave custody on ${prisoner.releaseDate.format(DateTimeFormatter.ofPattern("dd LLLL yyyy"))}"
           }
         ),
+        Pair("createLicenceLink", selfLink.plus("/licence/create/caseload"))
       ),
       null
     )

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -90,6 +90,7 @@ management:
       cache:
         time-to-live: 2000ms
 
+# Template IDs for the test Notify account (overridden in production)
 notify:
   enabled: true
   templates:
@@ -132,3 +133,8 @@ pdu:
       surname: 'Cardiff'
       description: 'Cardiff and Vale'
       email: 'cardiff@test.co.uk'
+
+# Overridden in real environments
+self:
+  link: "http://localhost:3000"
+

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/NotifyIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/NotifyIntegrationTest.kt
@@ -19,6 +19,7 @@ class NotifyIntegrationTest : IntegrationTestBase() {
   fun `check that PDU head contact info is injected from the spring context`() {
     val notifyService = NotifyService(
       enabled = true,
+      selfLink = "http://somewhere",
       licenceApprovedTemplateId = "licence-approved",
       variationForApprovalTemplateId = "variation-for-approval",
       initialLicencePromptTemplateId = "initial-prompt",
@@ -36,6 +37,7 @@ class NotifyIntegrationTest : IntegrationTestBase() {
         Pair("pduHeadFirstName", "Test"),
         Pair("licenceFirstName", "Ryan"),
         Pair("licenceLastName", "Smith"),
+        Pair("approvalCasesLink", "http://somewhere/licence/vary-approve/list"),
       ),
       null,
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/NotifyServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/NotifyServiceTest.kt
@@ -29,6 +29,7 @@ class NotifyServiceTest {
 
   private val notifyService = NotifyService(
     enabled = true,
+    selfLink = "http://somewhere",
     licenceApprovedTemplateId = TEMPLATE_ID,
     variationForApprovalTemplateId = TEMPLATE_ID,
     initialLicencePromptTemplateId = TEMPLATE_ID,
@@ -57,7 +58,8 @@ class NotifyServiceTest {
     )
     val expectedMap = mapOf(
       Pair("comName", "Joe Bloggs"),
-      Pair("prisonersForRelease", listOf("John Smith who will leave custody on 20 November 2022"))
+      Pair("prisonersForRelease", listOf("John Smith who will leave custody on 20 November 2022")),
+      Pair("createLicenceLink", "http://somewhere/licence/create/caseload"),
     )
 
     notifyService.sendInitialLicenceCreateEmails(listOf(comToEmail))
@@ -74,7 +76,8 @@ class NotifyServiceTest {
     )
     val expectedMap = mapOf(
       Pair("comName", "Joe Bloggs"),
-      Pair("prisonersForRelease", listOf("John Smith who will leave custody on 20 November 2022"))
+      Pair("prisonersForRelease", listOf("John Smith who will leave custody on 20 November 2022")),
+      Pair("createLicenceLink", "http://somewhere/licence/create/caseload"),
     )
 
     notifyService.sendInitialLicenceCreateEmails(listOf(comToEmail))
@@ -85,6 +88,7 @@ class NotifyServiceTest {
   fun `No email is sent when notify is not enabled`() {
     NotifyService(
       enabled = false,
+      selfLink = "http://somewhere",
       licenceApprovedTemplateId = TEMPLATE_ID,
       variationForApprovalTemplateId = TEMPLATE_ID,
       initialLicencePromptTemplateId = TEMPLATE_ID,
@@ -120,6 +124,7 @@ class NotifyServiceTest {
         Pair("pduHeadFirstName", "Bill"),
         Pair("licenceFirstName", "First"),
         Pair("licenceLastName", "Last"),
+        Pair("approvalCasesLink", "http://somewhere/licence/vary-approve/list"),
       ),
       null,
     )
@@ -135,6 +140,7 @@ class NotifyServiceTest {
         Pair("pduHeadFirstName", "Ted"),
         Pair("licenceFirstName", "First"),
         Pair("licenceLastName", "Last"),
+        Pair("approvalCasesLink", "http://somewhere/licence/vary-approve/list"),
       ),
       null,
     )


### PR DESCRIPTION
Configures environment-specific email links for notifications.
The Gov Uk Notify templates have been updated to include the links for the following emails:
* Initial prompt to create a licence (12-week)
* Reminder to create a licence (4-week)
* PDU head licence notification of a licence awaiting approval
