### PR TITLE
CVSL-457 Variation approval status

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/Licence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/Licence.kt
@@ -209,4 +209,7 @@ data class Licence(
 
   @Schema(description = "The licence Id which this licence is a variation of")
   val variationOf: Long? = null,
+
+  @Schema(description = "The full name of the person who created licence or variation", example = "Gordon Sumner")
+  val createdByFullName: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceService.kt
@@ -680,7 +680,7 @@ class LicenceService(
     val user = this.communityOffenderManagerRepository.findByUsernameIgnoreCase(username)
 
     val updatedLicenceEntity = licenceEntity.copy(
-      statusCode = ACTIVE,
+      statusCode = VARIATION_APPROVED,
       dateLastUpdated = LocalDateTime.now(),
       updatedByUsername = username,
       approvedByUsername = username,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/TransformFunctions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/TransformFunctions.kt
@@ -152,6 +152,7 @@ fun transform(licence: EntityLicence): ModelLicence {
     bespokeConditions = licence.bespokeConditions.transformToModelBespoke(),
     isVariation = licence.variationOfId != null,
     variationOf = licence.variationOfId,
+    createdByFullName = "${licence.createdBy?.firstName} ${licence.createdBy?.lastName}",
   )
 }
 

--- a/src/main/resources/migration/common/V19__create_extra_licence_index.sql
+++ b/src/main/resources/migration/common/V19__create_extra_licence_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_licence_variation_of_id ON licence(variation_of_id);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceServiceTest.kt
@@ -120,6 +120,15 @@ class LicenceServiceTest {
   }
 
   @Test
+  fun `service returns a licence with the full name of the user who created it`() {
+    whenever(licenceRepository.findById(1L)).thenReturn(Optional.of(aLicenceEntity))
+
+    val licence = service.getLicenceById(1L)
+
+    assertThat(licence.createdByFullName).isEqualTo("X Y")
+  }
+
+  @Test
   fun `service transforms key fields of a licence object correctly`() {
     whenever(licenceRepository.findById(1L)).thenReturn(Optional.of(aLicenceEntity))
 
@@ -1003,7 +1012,7 @@ class LicenceServiceTest {
 
     assertThat(licenceCaptor.allValues[0])
       .extracting("id", "statusCode", "updatedByUsername", "approvedByUsername", "approvedByName")
-      .isEqualTo(listOf(2L, LicenceStatus.ACTIVE, "smills", "smills", "X Y"))
+      .isEqualTo(listOf(2L, LicenceStatus.VARIATION_APPROVED, "smills", "smills", "X Y"))
 
     assertThat(licenceCaptor.allValues[1])
       .extracting("id", "statusCode", "updatedByUsername")


### PR DESCRIPTION
3 minor changes:
* When a licence variation is approved by the ACO the status is changed to VARIATION_APPROVED instead of ACTIVE.
* I've added an index to the licence column `variation_of_id` so that we can quickly find discarded variations later.
* Added a new field `createdByFullName` into the licence model object, and populated this from the createdBy join column.