### PR TITLE
CVSL-497: Update gradle plugin to fix vulnerabilities

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.1.2"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.1.3"
   kotlin("plugin.spring") version "1.6.10"
   kotlin("plugin.jpa") version "1.6.10"
   jacoco


### PR DESCRIPTION
v4.1.2 -> v4.1.3 to update spring boot and fix overnight vulnerabilities reported.