### PR TITLE
refs CVSL-540

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ ecr.repo
 
 #Helm
 **/Chart.lock
+
+# ignore local script containing env credentials
+run-local.sh

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Tools required:
 Start up the docker dependencies using the docker-compose file in the `create-and-vary-a-licence` service
 
 There is a script to help, which sets local profiles, port and DB connection properties to the 
-values required.
+values required. Rename run-local.dist to run-local.sh and enter the credentials for each env value where needed, then run:
 
 `$ ./run-local.sh`
 

--- a/run-local.dist
+++ b/run-local.dist
@@ -1,3 +1,4 @@
+#!/bin/bash
 #
 # This script is used to run the Create and Vary a licence API locally, to interact with
 # existing Postresql, localstack, prison-api and hmpps-auth containers.
@@ -17,6 +18,7 @@ export SERVER_PORT=8089
 # Matches with the seeded client details in hmpps-auth for its dev profile
 export SYSTEM_CLIENT_ID=create-and-vary-a-licence-admin
 export SYSTEM_CLIENT_SECRET=client_secret
+export NOTIFY_API_KEY=notify_key
 
 # Provide the DB connection details to local container-hosted Postgresql DB
 # Match with the credentials set in create-and-vary-a-licence/docker-compose.yml


### PR DESCRIPTION
Add a run-local.dist (no secrets, but placeholders to add them)
Add run-local.sh to .gitignore (this will be a copy of run-local.dist with secrets added locally)
Add the postgresql container to docker-compose-dev.yaml - so will run this and other required containers when using DEV for auth, prison, community APIs etc.