### PR TITLE
CVSL-464: Choosing SYSTEM or USER event more correctly in auditing

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceService.kt
@@ -355,11 +355,20 @@ class LicenceService(
           licenceId = licenceId,
           username = request.username,
           fullName = request.fullName,
+          eventType = getAuditEventType(request),
           summary = summaryText,
           detail = detailText,
         )
       )
     )
+  }
+
+  private fun getAuditEventType(request: StatusUpdateRequest): AuditEventType  {
+    return if (request.username == "SYSTEM") {
+      AuditEventType.SYSTEM_EVENT
+    } else {
+      AuditEventType.USER_EVENT
+    }
   }
 
   private fun recordLicenceEventForStatus(licenceId: Long, licenceEntity: EntityLicence, request: StatusUpdateRequest) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceService.kt
@@ -363,7 +363,7 @@ class LicenceService(
     )
   }
 
-  private fun getAuditEventType(request: StatusUpdateRequest): AuditEventType  {
+  private fun getAuditEventType(request: StatusUpdateRequest): AuditEventType {
     return if (request.username == "SYSTEM") {
       AuditEventType.SYSTEM_EVENT
     } else {


### PR DESCRIPTION
Small change - if no user present, or user.username == 'SYSTEM' then select the SYSTEM_EVENT for audit, otherwise USER_EVENT.