### PR TITLE
Cvsl 596 com update id changes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/repository/CommunityOffenderManagerRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/repository/CommunityOffenderManagerRepository.kt
@@ -7,5 +7,6 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.CommunityOff
 @Repository
 interface CommunityOffenderManagerRepository : JpaRepository<CommunityOffenderManager, Long> {
   fun findByStaffIdentifier(staffIdentifier: Long): CommunityOffenderManager?
+  fun findByStaffIdentifierOrUsername(staffIdentifier: Long, username: String): List<CommunityOffenderManager>?
   fun findByUsernameIgnoreCase(username: String): CommunityOffenderManager?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ComService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ComService.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service
 
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.CommunityOffenderManager
@@ -11,27 +12,65 @@ import java.time.LocalDateTime
 class ComService(
   private val communityOffenderManagerRepository: CommunityOffenderManagerRepository,
 ) {
+  companion object {
+    private val log = LoggerFactory.getLogger(this::class.java)
+  }
 
+  /**
+   * Check if record already exists. If so, check if any of the details have changed before performing an update.
+   * Check if the username and staffId do not match. This should not happen, unless a Delius account is updated to point
+   * at another linked account using the staffId. In this scenario, we should update the existing record to reflect
+   * the new username and or staffId.
+   */
   @Transactional
   fun updateComDetails(comDetails: UpdateComRequest): CommunityOffenderManager {
-    val com = this.communityOffenderManagerRepository.findByStaffIdentifier(comDetails.staffIdentifier)
-    val updatedCom = if (com !== null) {
-      com.copy(
-        email = comDetails.staffEmail,
-        firstName = comDetails.firstName,
-        lastName = comDetails.lastName,
-        lastUpdatedTimestamp = LocalDateTime.now()
-      )
-    } else {
-      CommunityOffenderManager(
-        username = comDetails.staffUsername,
-        staffIdentifier = comDetails.staffIdentifier,
-        email = comDetails.staffEmail,
-        firstName = comDetails.firstName,
-        lastName = comDetails.lastName
+    val comResult = this.communityOffenderManagerRepository.findByStaffIdentifierOrUsername(
+      comDetails.staffIdentifier, comDetails.staffUsername
+    )
+
+    if (comResult == null || comResult.isEmpty()) {
+      return this.communityOffenderManagerRepository.saveAndFlush(
+        CommunityOffenderManager(
+          username = comDetails.staffUsername,
+          staffIdentifier = comDetails.staffIdentifier,
+          email = comDetails.staffEmail,
+          firstName = comDetails.firstName,
+          lastName = comDetails.lastName
+        )
       )
     }
 
-    return this.communityOffenderManagerRepository.saveAndFlush(updatedCom)
+    if (comResult.count() > 1) {
+      log.warn(
+        "More then one COM record found for staffId {} username {}",
+        comDetails.staffIdentifier,
+        comDetails.staffUsername
+      )
+    }
+
+    val com = comResult.first()
+
+    // only update entity if data is different
+    if (
+      (comDetails.firstName != com.firstName) ||
+      (comDetails.lastName != com.lastName) ||
+      (comDetails.staffEmail != com.email) ||
+      (comDetails.staffUsername != com.username) ||
+      (comDetails.staffIdentifier != com.staffIdentifier)
+    ) {
+      return this.communityOffenderManagerRepository.saveAndFlush(
+        com.copy(
+          staffIdentifier = comDetails.staffIdentifier,
+          username = comDetails.staffUsername,
+          email = comDetails.staffEmail,
+          firstName = comDetails.firstName,
+          lastName = comDetails.lastName,
+          lastUpdatedTimestamp = LocalDateTime.now()
+        )
+      )
+    }
+
+    return com
   }
 }
+

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ComService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ComService.kt
@@ -12,6 +12,7 @@ import java.time.LocalDateTime
 class ComService(
   private val communityOffenderManagerRepository: CommunityOffenderManagerRepository,
 ) {
+
   companion object {
     private val log = LoggerFactory.getLogger(this::class.java)
   }
@@ -73,4 +74,3 @@ class ComService(
     return com
   }
 }
-

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ComServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ComServiceTest.kt
@@ -32,8 +32,8 @@ class ComServiceTest {
       lastName = "Y",
     )
 
-    whenever(communityOffenderManagerRepository.findByStaffIdentifier(any()))
-      .thenReturn(CommunityOffenderManager(staffIdentifier = 2000, username = "joebloggs", email = "jbloggs@probation.gov.uk", firstName = "A", lastName = "B"))
+    whenever(communityOffenderManagerRepository.findByStaffIdentifierOrUsername(any(), any()))
+      .thenReturn(listOf(CommunityOffenderManager(staffIdentifier = 2000, username = "joebloggs", email = "jbloggs@probation.gov.uk", firstName = "A", lastName = "B")))
 
     whenever(communityOffenderManagerRepository.saveAndFlush(any())).thenReturn(expectedCom)
 
@@ -47,8 +47,37 @@ class ComServiceTest {
 
     service.updateComDetails(comDetails)
 
-    verify(communityOffenderManagerRepository, times(1)).findByStaffIdentifier(3000)
+    verify(communityOffenderManagerRepository, times(1)).findByStaffIdentifierOrUsername(3000, "jbloggs")
     verify(communityOffenderManagerRepository, times(1)).saveAndFlush(any())
+  }
+
+  @Test
+  fun `does not update COM with same details`() {
+    val expectedCom = CommunityOffenderManager(
+      staffIdentifier = 2000,
+      username = "joebloggs",
+      email = "jbloggs123@probation.gov.uk",
+      firstName = "X",
+      lastName = "Y",
+    )
+
+    whenever(communityOffenderManagerRepository.findByStaffIdentifierOrUsername(any(), any()))
+      .thenReturn(listOf(CommunityOffenderManager(staffIdentifier = 2000, username = "joebloggs", email = "jbloggs123@probation.gov.uk", firstName = "X", lastName = "Y")))
+
+    whenever(communityOffenderManagerRepository.saveAndFlush(any())).thenReturn(expectedCom)
+
+    val comDetails = UpdateComRequest(
+      staffIdentifier = 2000,
+      staffUsername = "joebloggs",
+      staffEmail = "jbloggs123@probation.gov.uk",
+      firstName = "X",
+      lastName = "Y",
+    )
+
+    service.updateComDetails(comDetails)
+
+    verify(communityOffenderManagerRepository, times(1)).findByStaffIdentifierOrUsername(2000, "joebloggs")
+    verify(communityOffenderManagerRepository, times(0)).saveAndFlush(any())
   }
 
   @Test
@@ -61,7 +90,7 @@ class ComServiceTest {
       lastName = "Y",
     )
 
-    whenever(communityOffenderManagerRepository.findByStaffIdentifier(any())).thenReturn(null)
+    whenever(communityOffenderManagerRepository.findByStaffIdentifierOrUsername(any(), any())).thenReturn(null)
     whenever(communityOffenderManagerRepository.saveAndFlush(any())).thenReturn(expectedCom)
 
     val comDetails = UpdateComRequest(
@@ -74,7 +103,65 @@ class ComServiceTest {
 
     service.updateComDetails(comDetails)
 
-    verify(communityOffenderManagerRepository, times(1)).findByStaffIdentifier(3000)
+    verify(communityOffenderManagerRepository, times(1)).findByStaffIdentifierOrUsername(3000, "jbloggs")
     verify(communityOffenderManagerRepository, times(1)).saveAndFlush(expectedCom)
+  }
+
+  @Test
+  fun `updates existing COM with new username`() {
+    val expectedCom = CommunityOffenderManager(
+      staffIdentifier = 2000,
+      username = "joebloggs",
+      email = "jbloggs123@probation.gov.uk",
+      firstName = "X",
+      lastName = "Y",
+    )
+
+    whenever(communityOffenderManagerRepository.findByStaffIdentifierOrUsername(any(), any()))
+      .thenReturn(listOf(CommunityOffenderManager(staffIdentifier = 2000, username = "joebloggs", email = "jbloggs@probation.gov.uk", firstName = "A", lastName = "B")))
+
+    whenever(communityOffenderManagerRepository.saveAndFlush(any())).thenReturn(expectedCom)
+
+    val comDetails = UpdateComRequest(
+      staffIdentifier = 2000,
+      staffUsername = "jbloggsnew1",
+      staffEmail = "jbloggs123@probation.gov.uk",
+      firstName = "X",
+      lastName = "Y",
+    )
+
+    service.updateComDetails(comDetails)
+
+    verify(communityOffenderManagerRepository, times(1)).findByStaffIdentifierOrUsername(2000, "jbloggsnew1")
+    verify(communityOffenderManagerRepository, times(1)).saveAndFlush(any())
+  }
+
+  @Test
+  fun `updates existing COM with new staffIdentifier`() {
+    val expectedCom = CommunityOffenderManager(
+      staffIdentifier = 2001,
+      username = "joebloggs",
+      email = "jbloggs123@probation.gov.uk",
+      firstName = "X",
+      lastName = "Y",
+    )
+
+    whenever(communityOffenderManagerRepository.findByStaffIdentifierOrUsername(any(), any()))
+      .thenReturn(listOf(CommunityOffenderManager(staffIdentifier = 2000, username = "joebloggs", email = "jbloggs@probation.gov.uk", firstName = "A", lastName = "B")))
+
+    whenever(communityOffenderManagerRepository.saveAndFlush(any())).thenReturn(expectedCom)
+
+    val comDetails = UpdateComRequest(
+      staffIdentifier = 2001,
+      staffUsername = "joebloggs",
+      staffEmail = "jbloggs123@probation.gov.uk",
+      firstName = "X",
+      lastName = "Y",
+    )
+
+    service.updateComDetails(comDetails)
+
+    verify(communityOffenderManagerRepository, times(1)).findByStaffIdentifierOrUsername(2001, "joebloggs")
+    verify(communityOffenderManagerRepository, times(1)).saveAndFlush(any())
   }
 }


### PR DESCRIPTION
When updating a COM, check for a match against username or staffId. Its possible the staffId can be changed in nDelius to link to another account. If this instance, we should update the existing record in CVL to reflect the new username and or staffId.

Failing to do so will result in a key constraint failure; causing a crash.

Check the COM details have changed before performing any update.