### PR TITLE
Cvsl 526 omu contact service

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/entity/OmuContact.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/entity/OmuContact.kt
@@ -1,0 +1,25 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity
+
+import java.time.LocalDateTime
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.GeneratedValue
+import javax.persistence.GenerationType
+import javax.persistence.Id
+import javax.persistence.Table
+import javax.validation.constraints.NotNull
+
+@Entity
+@Table(name = "omu_contact")
+data class OmuContact(
+  @Id
+  @NotNull
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "id", nullable = false)
+  var id: Long? = null,
+
+  val prisonCode: String,
+  val email: String,
+  var dateCreated: LocalDateTime,
+  val dateLastUpdated: LocalDateTime? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/request/UpdateOmuEmailRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/request/UpdateOmuEmailRequest.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.request
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Request object for updating / creating OMU email contact")
+class UpdateOmuEmailRequest(
+  @Schema(description = "The email used to contact the OMU", example = "test@omu.prison.com")
+  val email: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/request/UpdateOmuEmailRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/request/UpdateOmuEmailRequest.kt
@@ -1,8 +1,12 @@
 package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.request
 import io.swagger.v3.oas.annotations.media.Schema
+import javax.validation.constraints.Email
+import javax.validation.constraints.NotBlank
 
 @Schema(description = "Request object for updating / creating OMU email contact")
-class UpdateOmuEmailRequest(
+data class UpdateOmuEmailRequest(
   @Schema(description = "The email used to contact the OMU", example = "test@omu.prison.com")
+  @field:NotBlank
+  @field:Email
   val email: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/repository/OmuContactRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/repository/OmuContactRepository.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.OmuContact
+
+interface OmuContactRepository : JpaRepository<OmuContact, Long> {
+  fun findByPrisonCode(prisonCode: String): OmuContact?
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/OmuContactController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/OmuContactController.kt
@@ -1,0 +1,74 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import org.springframework.http.MediaType
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.config.ErrorResponse
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.OmuContact
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.request.UpdateOmuEmailRequest
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.OmuService
+import javax.validation.Valid
+
+@RestController
+@RequestMapping("/omu/{prisonCode}/contact/email", produces = [MediaType.APPLICATION_JSON_VALUE])
+class OmuContactController(private val omuService: OmuService) {
+
+  @GetMapping
+  fun getOmuContactByPrisonCode(@PathVariable("prisonCode") prisonCode: String): OmuContact? {
+    return this.omuService.getOmuContactEmail(prisonCode)
+  }
+
+  @PutMapping
+  @PreAuthorize("hasAnyRole('SYSTEM_USER', 'CVL_ADMIN')")
+  @Operation(
+    summary = "Updates the OMU email address.",
+    description = "Updates the OMU email address used to contact members of a prison OMU. Requires ROLE_SYSTEM_USER or ROLE_CVL_ADMIN.",
+    security = [SecurityRequirement(name = "ROLE_SYSTEM_USER"), SecurityRequirement(name = "ROLE_CVL_ADMIN")],
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "The OMU was updated",
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Bad request, request body must be valid",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorised, requires a valid Oauth2 token",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires an appropriate role",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      )
+    ]
+  )
+  fun updateOmuEmail(
+    @Valid @RequestBody body: UpdateOmuEmailRequest,
+    @PathVariable("prisonCode") prisonCode: String,
+  ): OmuContact? {
+    return this.omuService.updateOmuEmail(prisonCode = prisonCode, contactRequest = body)
+  }
+
+  @DeleteMapping()
+  fun deleteOmuContactByPrisonCode(@PathVariable("prisonCode") prisonCode: String) {
+    this.omuService.deleteOmuEmail(prisonCode)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/OmuContactController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/OmuContactController.kt
@@ -37,6 +37,7 @@ class OmuContactController(private val omuService: OmuService) {
       ApiResponse(
         responseCode = "200",
         description = "The OMU was found",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = OmuContact::class))]
       ),
       ApiResponse(
         responseCode = "404",
@@ -55,7 +56,7 @@ class OmuContactController(private val omuService: OmuService) {
       )
     ]
   )
-  fun getOmuContactByPrisonCode(@PathVariable("prisonCode") prisonCode: String): OmuContact? {
+  fun getOmuContactByPrisonCode(@PathVariable("prisonCode") prisonCode: String): OmuContact {
     return this.omuService.getOmuContactEmail(prisonCode)
   }
 
@@ -71,6 +72,7 @@ class OmuContactController(private val omuService: OmuService) {
       ApiResponse(
         responseCode = "200",
         description = "The OMU was updated",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = OmuContact::class))]
       ),
       ApiResponse(
         responseCode = "400",
@@ -92,7 +94,7 @@ class OmuContactController(private val omuService: OmuService) {
   fun updateOmuEmail(
     @Valid @RequestBody body: UpdateOmuEmailRequest,
     @PathVariable("prisonCode") prisonCode: String,
-  ): OmuContact? {
+  ): OmuContact {
     return this.omuService.updateOmuEmail(prisonCode = prisonCode, contactRequest = body)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/OmuContactController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/OmuContactController.kt
@@ -26,6 +26,35 @@ import javax.validation.Valid
 class OmuContactController(private val omuService: OmuService) {
 
   @GetMapping
+  @PreAuthorize("hasAnyRole('SYSTEM_USER', 'CVL_ADMIN')")
+  @Operation(
+    summary = "Get OMU email address.",
+    description = "Obtain prison Offender Management Unit email address. Requires ROLE_SYSTEM_USER or ROLE_CVL_ADMIN.",
+    security = [SecurityRequirement(name = "ROLE_SYSTEM_USER"), SecurityRequirement(name = "ROLE_CVL_ADMIN")],
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "The OMU was found",
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Not found, the OMU email was not found",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorised, requires a valid Oauth2 token",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires an appropriate role",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      )
+    ]
+  )
   fun getOmuContactByPrisonCode(@PathVariable("prisonCode") prisonCode: String): OmuContact? {
     return this.omuService.getOmuContactEmail(prisonCode)
   }
@@ -67,7 +96,31 @@ class OmuContactController(private val omuService: OmuService) {
     return this.omuService.updateOmuEmail(prisonCode = prisonCode, contactRequest = body)
   }
 
+  @PreAuthorize("hasAnyRole('SYSTEM_USER', 'CVL_ADMIN')")
   @DeleteMapping()
+  @Operation(
+    summary = "Delete the OMU email address.",
+    description = "Delete prison Offender Management Unit email address. Requires ROLE_SYSTEM_USER or ROLE_CVL_ADMIN.",
+    security = [SecurityRequirement(name = "ROLE_SYSTEM_USER"), SecurityRequirement(name = "ROLE_CVL_ADMIN")],
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "The OMU email address was deleted",
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorised, requires a valid Oauth2 token",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires an appropriate role",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      )
+    ]
+  )
   fun deleteOmuContactByPrisonCode(@PathVariable("prisonCode") prisonCode: String) {
     this.omuService.deleteOmuEmail(prisonCode)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/OmuService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/OmuService.kt
@@ -1,0 +1,44 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.OmuContact
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.request.UpdateOmuEmailRequest
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.OmuContactRepository
+import java.time.LocalDateTime
+import javax.persistence.EntityNotFoundException
+
+@Service
+class OmuService(private val omuRepository: OmuContactRepository) {
+  /**
+   * Get OMU email address belonging to the prison code
+   */
+  fun getOmuContactEmail(prisonCode: String): OmuContact? {
+    return omuRepository.findByPrisonCode(prisonCode) ?: throw EntityNotFoundException(prisonCode)
+  }
+
+  /**
+   * Create or update OMU contact email address belonging to the prison code
+   */
+  fun updateOmuEmail(prisonCode: String, contactRequest: UpdateOmuEmailRequest): OmuContact {
+    return this.omuRepository.saveAndFlush(
+      this.omuRepository.findByPrisonCode(prisonCode)?.copy(
+        email = contactRequest.email,
+        dateLastUpdated = LocalDateTime.now()
+      )
+        ?: OmuContact(
+          prisonCode = prisonCode,
+          email = contactRequest.email,
+          dateCreated = LocalDateTime.now()
+        )
+    )
+  }
+
+  /**
+   * delete an OMU contact email address if no longer valid
+   */
+  fun deleteOmuEmail(prisonCode: String) {
+    omuRepository.findByPrisonCode(prisonCode)?.let { this.omuRepository.delete(it) } ?: throw EntityNotFoundException(
+      prisonCode
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/OmuService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/OmuService.kt
@@ -12,7 +12,7 @@ class OmuService(private val omuRepository: OmuContactRepository) {
   /**
    * Get OMU email address belonging to the prison code
    */
-  fun getOmuContactEmail(prisonCode: String): OmuContact? {
+  fun getOmuContactEmail(prisonCode: String): OmuContact {
     return omuRepository.findByPrisonCode(prisonCode) ?: throw EntityNotFoundException(prisonCode)
   }
 

--- a/src/main/resources/migration/common/V21__store_omu_contact.sql
+++ b/src/main/resources/migration/common/V21__store_omu_contact.sql
@@ -1,0 +1,8 @@
+CREATE TABLE omu_contact
+(
+    id serial NOT NULL constraint omu_contact_pk PRIMARY KEY,
+    prison_code         VARCHAR(255),
+    email               VARCHAR(255),
+    date_created        TIMESTAMP WITHOUT TIME ZONE,
+    date_last_updated   TIMESTAMP WITHOUT TIME ZONE
+);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/OmuContactIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/OmuContactIntegrationTest.kt
@@ -1,0 +1,108 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.integration
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.test.context.jdbc.Sql
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.config.ErrorResponse
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.request.UpdateOmuEmailRequest
+
+class OmuContactIntegrationTest : IntegrationTestBase() {
+
+  @Test
+  fun `Get forbidden (403) when incorrect roles are supplied`() {
+    val result = webTestClient.put()
+      .uri("/omu/FPI/contact/email")
+      .bodyValue(UpdateOmuEmailRequest(email = "test@testing.com"))
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_CVL_WRONG ROLE")))
+      .exchange()
+      .expectStatus().isForbidden
+      .expectStatus().isEqualTo(HttpStatus.FORBIDDEN.value())
+      .expectBody(ErrorResponse::class.java)
+      .returnResult().responseBody
+
+    Assertions.assertThat(result?.userMessage).contains("Access is denied")
+  }
+
+  @Test
+  fun `Unauthorized (401) when no token is supplied`() {
+    webTestClient.put()
+      .uri("/omu/fpi/contact/email")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isEqualTo(HttpStatus.UNAUTHORIZED.value())
+  }
+
+  @Test
+  @Sql(
+    "classpath:test_data/seed-omu-contact-data.sql"
+  )
+  fun `query for OMU email address`() {
+    webTestClient.get()
+      .uri("/omu/FPI/contact/email")
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_CVL_ADMIN")))
+      .exchange()
+      .expectStatus().isOk
+  }
+
+  @Test
+  fun `query for none existent OMU email address`() {
+    webTestClient.get()
+      .uri("/omu/FPI/contact/email")
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_CVL_ADMIN")))
+      .exchange()
+      .expectStatus().isNotFound
+  }
+
+  @Test
+  fun `query for creating new OMU email address`() {
+    webTestClient.put()
+      .uri("/omu/FPI/contact/email")
+      .bodyValue(UpdateOmuEmailRequest(email = "test@testing.com"))
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_CVL_ADMIN")))
+      .exchange()
+      .expectStatus().isOk
+  }
+
+  @Test
+  @Sql(
+    "classpath:test_data/seed-omu-contact-data.sql"
+  )
+  fun `query for updating new OMU email address`() {
+    webTestClient.put()
+      .uri("/omu/FPI/contact/email")
+      .bodyValue(UpdateOmuEmailRequest(email = "test@testing.com"))
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_CVL_ADMIN")))
+      .exchange()
+      .expectStatus().isOk
+  }
+
+  @Test
+  @Sql(
+    "classpath:test_data/seed-omu-contact-data.sql"
+  )
+  fun `query for deleting OMU email address`() {
+    webTestClient.delete()
+      .uri("/omu/FPI/contact/email")
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_CVL_ADMIN")))
+      .exchange()
+      .expectStatus().isOk
+  }
+
+  @Test
+  fun `query for deleting none existent OMU email address`() {
+    webTestClient.delete()
+      .uri("/omu/FPI/contact/email")
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_CVL_ADMIN")))
+      .exchange()
+      .expectStatus().isNotFound
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/OmuContactControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/OmuContactControllerTest.kt
@@ -87,21 +87,6 @@ class OmuContactControllerTest {
   }
 
   @Test
-  fun `update OMU email with invalid email address`() {
-    val body = UpdateOmuEmailRequest(email = "test@tes!!ting.bom")
-
-    val expectedOmuEmail = OmuContact(email = "test@testing.com", prisonCode = "LEI", dateCreated = LocalDateTime.now())
-    whenever(omuService.updateOmuEmail("LEI", body)).thenReturn(expectedOmuEmail)
-
-    val request = put("/omu/LEI/contact/email")
-      .accept(MediaType.APPLICATION_JSON)
-      .contentType(MediaType.APPLICATION_JSON)
-      .content(mapper.writeValueAsBytes(body))
-
-    mvc.perform(request).andExpect(status().isBadRequest)
-  }
-
-  @Test
   fun `delete OMU email contact`() {
     val expectedOmuEmail = OmuContact(email = "test@testing.com", prisonCode = "LEI", dateCreated = LocalDateTime.now())
     whenever(omuService.getOmuContactEmail("LEI")).thenReturn(expectedOmuEmail)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/OmuContactControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/OmuContactControllerTest.kt
@@ -1,0 +1,76 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.kotlin.reset
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.springframework.test.context.web.WebAppConfiguration
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.config.ControllerAdvice
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.OmuContact
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.request.UpdateOmuEmailRequest
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.NotifyService
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.OmuService
+import java.time.LocalDateTime
+
+@ExtendWith(SpringExtension::class)
+@ActiveProfiles("test")
+@WebMvcTest(controllers = [OmuContactController::class])
+@AutoConfigureMockMvc(addFilters = false)
+@ContextConfiguration(classes = [OmuContactController::class])
+@WebAppConfiguration
+class OmuContactControllerTest {
+  @MockBean
+  private lateinit var notifyService: NotifyService
+
+  @MockBean
+  private lateinit var omuService: OmuService
+
+  @Autowired
+  private lateinit var mvc: MockMvc
+
+  @Autowired
+  private lateinit var mapper: ObjectMapper
+
+  @BeforeEach
+  fun reset() {
+    reset(omuService, notifyService)
+
+    mvc = MockMvcBuilders
+      .standaloneSetup(OmuContactController(omuService))
+      .setControllerAdvice(ControllerAdvice())
+      .build()
+  }
+
+  @Test
+  fun `update OMU email contact`() {
+    val body = UpdateOmuEmailRequest(email = "test@testing.com")
+
+    val expectedOmuEmail = OmuContact(email = "test@testing.com", prisonCode = "LEI", dateCreated = LocalDateTime.now())
+    whenever(omuService.updateOmuEmail("LEI", body)).thenReturn(expectedOmuEmail)
+
+    val request = put("/omu/LEI/contact/email")
+      .accept(MediaType.APPLICATION_JSON)
+      .contentType(MediaType.APPLICATION_JSON)
+      .content(mapper.writeValueAsBytes(body))
+
+    mvc.perform(request).andExpect(status().isOk)
+
+    verify(omuService, times(1)).updateOmuEmail("LEI", body)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/OmuServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/OmuServiceTest.kt
@@ -1,0 +1,104 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.reset
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.OmuContact
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.request.UpdateOmuEmailRequest
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.OmuContactRepository
+import java.time.LocalDateTime
+import javax.persistence.EntityNotFoundException
+
+class OmuServiceTest {
+  private val omuContactRepository = mock<OmuContactRepository>()
+  private val omuService = OmuService(omuContactRepository)
+
+  @BeforeEach
+  fun reset() {
+    reset(omuContactRepository)
+  }
+
+  @Test
+  fun `gets existing OMU email`() {
+    val expectedOmuContact =
+      OmuContact(email = "test.omu@testing.com", dateCreated = LocalDateTime.now(), prisonCode = "FPI")
+    whenever(omuContactRepository.findByPrisonCode("FPI")).thenReturn(expectedOmuContact)
+    val result = omuService.getOmuContactEmail("FPI")
+
+    verify(omuContactRepository, times(1)).findByPrisonCode("FPI")
+    assertThat(result).isEqualTo(expectedOmuContact)
+  }
+
+  @Test
+  fun `return 404 when OMU email does not exist`() {
+    whenever(omuContactRepository.findByPrisonCode("FPI")).thenThrow(EntityNotFoundException("FPI"))
+
+    val exception = assertThrows<EntityNotFoundException> {
+      omuContactRepository.findByPrisonCode("FPI")
+    }
+
+    assertThat(exception).isInstanceOf(EntityNotFoundException::class.java)
+    verify(omuContactRepository, times(1)).findByPrisonCode("FPI")
+  }
+
+  @Test
+  fun `updates existing OMU email`() {
+    val expectedOmuContact =
+      OmuContact(email = "test.omu@testing.com", dateCreated = LocalDateTime.now(), prisonCode = "FPI")
+    whenever(omuContactRepository.saveAndFlush(any())).thenReturn(expectedOmuContact)
+    val omuContactRequest = UpdateOmuEmailRequest(email = "test.omu@testing.com")
+
+    val result = omuService.updateOmuEmail("FPI", omuContactRequest)
+
+    verify(omuContactRepository, times(1)).findByPrisonCode("FPI")
+    verify(omuContactRepository, times(1)).saveAndFlush(any())
+    assertThat(result).isEqualTo(expectedOmuContact)
+  }
+
+  @Test
+  fun `create new OMU email if one does not exist`() {
+    val expectedOmuContact =
+      OmuContact(email = "test.omu@testing.com", dateCreated = LocalDateTime.now(), prisonCode = "FPI")
+    whenever(omuContactRepository.findByPrisonCode("FPI")).thenReturn(null)
+    whenever(omuContactRepository.saveAndFlush(any())).thenReturn(expectedOmuContact)
+    val omuContactRequest = UpdateOmuEmailRequest(email = "test.omu@testing.com")
+
+    val result = omuService.updateOmuEmail("FPI", omuContactRequest)
+
+    verify(omuContactRepository, times(1)).findByPrisonCode("FPI")
+    verify(omuContactRepository, times(1)).saveAndFlush(any())
+    assertThat(result).isEqualTo(expectedOmuContact)
+  }
+
+  @Test
+  fun `deletes OMU email if one exists`() {
+    val expectedOmuContact =
+      OmuContact(email = "test.omu@testing.com", dateCreated = LocalDateTime.now(), prisonCode = "FPI")
+    whenever(omuContactRepository.findByPrisonCode("FPI")).thenReturn(expectedOmuContact)
+
+    omuService.deleteOmuEmail("FPI")
+
+    verify(omuContactRepository, times(1)).findByPrisonCode("FPI")
+    verify(omuContactRepository, times(1)).delete((expectedOmuContact))
+  }
+
+  @Test
+  fun `return 404 when trying to delete OMU email that does not exists`() {
+    whenever(omuContactRepository.findByPrisonCode("FPI")).thenReturn(null)
+
+    val exception = assertThrows<EntityNotFoundException> {
+      omuService.deleteOmuEmail("FPI")
+    }
+
+    assertThat(exception).isInstanceOf(EntityNotFoundException::class.java)
+    verify(omuContactRepository, times(1)).findByPrisonCode("FPI")
+    verify(omuContactRepository, times(0)).delete((any()))
+  }
+}

--- a/src/test/resources/test_data/clear-all-data.sql
+++ b/src/test/resources/test_data/clear-all-data.sql
@@ -8,3 +8,4 @@ DELETE from community_offender_manager_licence_mailing_list;
 DELETE from licence;
 DELETE from community_offender_manager;
 DELETE from audit_event;
+DELETE from omu_contact;

--- a/src/test/resources/test_data/seed-omu-contact-data.sql
+++ b/src/test/resources/test_data/seed-omu-contact-data.sql
@@ -1,0 +1,2 @@
+INSERT INTO omu_contact (id, prison_code, email, date_created, date_last_updated)
+VALUES (1, 'FPI', 'test.OMU@testing.com', '2022-06-01', null);


### PR DESCRIPTION
Add a new OMU Contact service, initially providing CRUD functionality for OMU email addresses. The service can later be expanded to hold more OMU details if required.