### PR TITLE
CVSL-446

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/config/ResourceServerConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/config/ResourceServerConfiguration.kt
@@ -15,7 +15,7 @@ class ResourceServerConfiguration {
 
   @Bean
   fun filterChain(http: HttpSecurity): SecurityFilterChain {
-    val chain = http
+    return http
       .sessionManagement()
       .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
       .and().headers().frameOptions().sameOrigin()
@@ -32,8 +32,6 @@ class ResourceServerConfiguration {
           "/swagger-ui.html",
           "/h2-console/**"
         ).permitAll().anyRequest().authenticated()
-      }
-    chain.oauth2ResourceServer().jwt().jwtAuthenticationConverter(AuthAwareTokenConverter())
-    return chain.build()
+      }.also { it.oauth2ResourceServer().jwt().jwtAuthenticationConverter(AuthAwareTokenConverter()) }.build()
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/repository/LicenceRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/repository/LicenceRepository.kt
@@ -10,4 +10,5 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus
 interface LicenceRepository : JpaRepository<Licence, Long>, JpaSpecificationExecutor<Licence> {
   fun findAllByNomsIdAndStatusCodeIn(nomsId: String, status: List<LicenceStatus>): List<Licence>
   fun findAllByCrnAndStatusCodeIn(crn: String, status: List<LicenceStatus>): List<Licence>
+  fun findByStatusCodeAndProbationAreaCode(statusCode: LicenceStatus, probationAreaCode: String): List<Licence>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/LicenceController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/LicenceController.kt
@@ -330,6 +330,38 @@ class LicenceController(private val licenceService: LicenceService) {
     licenceService.updateBespokeConditions(licenceId, request)
   }
 
+  @GetMapping(value = ["/variations/submitted/area/{areaCode}"])
+  @PreAuthorize("hasAnyRole('CVL_ADMIN')")
+  @Operation(
+    summary = "Get a list of licence summaries for submitted variations by probation area.",
+    description = "Get a list of licence summaries for all submitted variations belonging to the specified probation area code. Requires ROLE_CVL_ADMIN.",
+    security = [SecurityRequirement(name = "ROLE_CVL_ADMIN")],
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Returned matching licence summary details - empty if no matches.",
+        content = [Content(mediaType = "application/json", array = ArraySchema(schema = Schema(implementation = LicenceSummary::class)))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorised, requires a valid Oauth2 token",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires an appropriate role",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      )
+    ]
+  )
+  fun submittedVariations(
+    @PathVariable("areaCode") areaCode: String,
+  ): List<LicenceSummary> {
+    return licenceService.findSubmittedVariationsByRegion(probationAreaCode = areaCode)
+  }
+
   @PostMapping(value = ["/match"])
   @PreAuthorize("hasAnyRole('CVL_ADMIN')")
   @Operation(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceService.kt
@@ -521,6 +521,12 @@ class LicenceService(
     }
   }
 
+  fun findSubmittedVariationsByRegion(probationAreaCode: String): List<LicenceSummary> {
+    val matchingLicences =
+      licenceRepository.findByStatusCodeAndProbationAreaCode(VARIATION_SUBMITTED, probationAreaCode)
+    return transformToListOfSummaries(matchingLicences)
+  }
+
   @Transactional
   fun activateLicences(licenceIds: List<Long>) {
     val matchingLicences = licenceRepository.findAllById(licenceIds).filter { licence -> licence.statusCode == APPROVED }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/LicenceControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/LicenceControllerTest.kt
@@ -103,6 +103,21 @@ class LicenceControllerTest {
   }
 
   @Test
+  fun `get variation submitted for region`() {
+    whenever(licenceService.findSubmittedVariationsByRegion("N01A")).thenReturn(listOf(aLicenceSummary))
+
+    val result = mvc.perform(get("/licence/variations/submitted/area/N01A").accept(APPLICATION_JSON))
+      .andExpect(status().isOk)
+      .andExpect(content().contentType(APPLICATION_JSON))
+      .andReturn()
+
+    assertThat(result.response.contentAsString)
+      .isEqualTo(mapper.writeValueAsString(listOf(aLicenceSummary)))
+
+    verify(licenceService, times(1)).findSubmittedVariationsByRegion("N01A")
+  }
+
+  @Test
   fun `404 licence not found`() {
     whenever(licenceService.getLicenceById(1)).thenThrow(EntityNotFoundException(""))
 


### PR DESCRIPTION
Add dedicated endpoint for submitted licence variations by probation area code. This prevents partial matching using the existing match endpoint.

Future work should split the existing controller into licence and variation respectively.