### PR TITLE
Cvsl 618 check hdc status

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This service requires a postgresql database.
 
 Tools required:
 
-* JDK v16+
+* JDK v18+
 * Kotlin
 * docker
 * docker-compose

--- a/helm_deploy/create-and-vary-a-licence-api/values.yaml
+++ b/helm_deploy/create-and-vary-a-licence-api/values.yaml
@@ -32,6 +32,8 @@ generic-service:
     create-and-vary-a-licence-api:
       APPINSIGHTS_INSTRUMENTATIONKEY: "APPINSIGHTS_INSTRUMENTATIONKEY"
       NOTIFY_API_KEY: "NOTIFY_API_KEY"
+      SYSTEM_CLIENT_ID: "SYSTEM_CLIENT_ID"
+      SYSTEM_CLIENT_SECRET: "SYSTEM_CLIENT_SECRET"
     rds-instance-output:
       DB_SERVER: "rds_instance_address"
       DB_NAME: "database_name"

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -10,7 +10,9 @@ generic-service:
 
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
-    HMPPS_AUTH_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
+    HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
+    HMPPS_AUTH_TOKEN_URL: "https://sign-in.hmpps.service.justice.gov.uk/auth/oauth/token"
+    HMPPS_PRISON_API_URL: "https://api-dev.prison.service.justice.gov.uk/api"
     SELF_LINK: "https://create-and-vary-a-licence-dev.hmpps.service.justice.gov.uk"
 
 # CloudPlatform AlertManager receiver to route promethues alerts to slack

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -11,7 +11,7 @@ generic-service:
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
     HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
-    HMPPS_AUTH_TOKEN_URL: "https://sign-in.hmpps.service.justice.gov.uk/auth/oauth/token"
+    HMPPS_AUTH_TOKEN_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth/oauth/token"
     HMPPS_PRISON_API_URL: "https://api-dev.prison.service.justice.gov.uk/api"
     SELF_LINK: "https://create-and-vary-a-licence-dev.hmpps.service.justice.gov.uk"
 

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -10,7 +10,9 @@ generic-service:
 
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
-    HMPPS_AUTH_URL: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth
+    HMPPS_AUTH_URL: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth"
+    HMPPS_AUTH_TOKEN_URL: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth/oauth/token"
+    HMPPS_PRISON_API_URL: "https://api-preprod.prison.service.justice.gov.uk/api"
     SELF_LINK: "https://create-and-vary-a-licence-preprod.hmpps.service.justice.gov.uk"
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -10,7 +10,9 @@ generic-service:
 
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json
-    HMPPS_AUTH_URL: https://sign-in.hmpps.service.justice.gov.uk/auth
+    HMPPS_AUTH_URL: "https://sign-in.hmpps.service.justice.gov.uk/auth"
+    HMPPS_AUTH_TOKEN_URL: "https://sign-in.hmpps.service.justice.gov.uk/auth/oauth/token"
+    HMPPS_PRISON_API_URL: "https://api.prison.service.justice.gov.uk/api"
     SELF_LINK: "https://create-and-vary-a-licence.hmpps.service.justice.gov.uk"
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/config/WebClientConfiguration.kt
@@ -3,21 +3,19 @@ package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.config
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.security.oauth2.client.AuthorizedClientServiceReactiveOAuth2AuthorizedClientManager
-import org.springframework.security.oauth2.client.InMemoryReactiveOAuth2AuthorizedClientService
-import org.springframework.security.oauth2.client.registration.ClientRegistration
-import org.springframework.security.oauth2.client.registration.InMemoryReactiveClientRegistrationRepository
-import org.springframework.security.oauth2.client.web.reactive.function.client.ServerOAuth2AuthorizedClientExchangeFilterFunction
-import org.springframework.security.oauth2.core.AuthorizationGrantType
+import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
+import org.springframework.security.oauth2.client.web.reactive.function.client.ServletOAuth2AuthorizedClientExchangeFilterFunction
+import org.springframework.web.reactive.function.client.ExchangeStrategies
 import org.springframework.web.reactive.function.client.WebClient
 
 @Configuration
 class WebClientConfiguration(
   @Value("\${hmpps.auth.url}") private val oauthApiUrl: String,
   @Value("\${hmpps.prison.api.url}") private val prisonApiUrl: String,
-  @Value("\${oauth.client.token-url}") private val oauthTokenUrl: String,
-  @Value("\${oauth.client.id}") private val oauthClientId: String,
-  @Value("\${oauth.client.secret}") private val oauthSecret: String,
 ) {
 
   @Bean
@@ -26,27 +24,32 @@ class WebClientConfiguration(
   }
 
   @Bean
-  fun oauthPrisonClient(): WebClient {
-    val clientRegistryRepo = InMemoryReactiveClientRegistrationRepository(
-      ClientRegistration
-        .withRegistrationId("hmpps-auth")
-        .tokenUri(oauthTokenUrl)
-        .clientId(oauthClientId)
-        .clientSecret(oauthSecret)
-        .authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
-        .build()
-    )
-
-    val clientService = InMemoryReactiveOAuth2AuthorizedClientService(clientRegistryRepo)
-
+  fun authorizedClientManager(
+    clientRegistrationRepository: ClientRegistrationRepository,
+    oAuth2AuthorizedClientService: OAuth2AuthorizedClientService
+  ): OAuth2AuthorizedClientManager? {
+    val authorizedClientProvider = OAuth2AuthorizedClientProviderBuilder.builder().clientCredentials().build()
     val authorizedClientManager =
-      AuthorizedClientServiceReactiveOAuth2AuthorizedClientManager(clientRegistryRepo, clientService)
+      AuthorizedClientServiceOAuth2AuthorizedClientManager(clientRegistrationRepository, oAuth2AuthorizedClientService)
+    authorizedClientManager.setAuthorizedClientProvider(authorizedClientProvider)
+    return authorizedClientManager
+  }
 
-    val oauthFilter = ServerOAuth2AuthorizedClientExchangeFilterFunction(authorizedClientManager)
-    oauthFilter.setDefaultClientRegistrationId("hmpps-auth")
+  @Bean
+  fun oauthPrisonClient(authorizedClientManager: OAuth2AuthorizedClientManager): WebClient {
+    val oauth2Client = ServletOAuth2AuthorizedClientExchangeFilterFunction(authorizedClientManager)
+    oauth2Client.setDefaultClientRegistrationId("hmpps-auth")
 
-    return WebClient.builder().baseUrl(prisonApiUrl)
-      .filter(oauthFilter)
-      .build()
+    return WebClient.builder()
+      .baseUrl(prisonApiUrl)
+      .apply(oauth2Client.oauth2Configuration())
+      .exchangeStrategies(
+        ExchangeStrategies.builder()
+          .codecs { configurer ->
+            configurer.defaultCodecs()
+              .maxInMemorySize(-1)
+          }
+          .build()
+      ).build()
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/config/WebClientConfiguration.kt
@@ -15,9 +15,9 @@ import org.springframework.web.reactive.function.client.WebClient
 class WebClientConfiguration(
   @Value("\${hmpps.auth.url}") private val oauthApiUrl: String,
   @Value("\${hmpps.prison.api.url}") private val prisonApiUrl: String,
-  @Value("\${spring.security.oauth2.client.provider.hmpps-auth.token-uri}") private val oauthTokenUrl: String,
-  @Value("\${spring.security.oauth2.client.registration.oauth-clients.client-id}") private val oauthClientId: String,
-  @Value("\${spring.security.oauth2.client.registration.oauth-clients.client-secret}") private val oauthSecret: String,
+  @Value("\${oauth.client.token-url}") private val oauthTokenUrl: String,
+  @Value("\${oauth.client.id}") private val oauthClientId: String,
+  @Value("\${oauth.client.secret}") private val oauthSecret: String,
 ) {
 
   @Bean

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/config/WebClientConfiguration.kt
@@ -3,16 +3,50 @@ package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.config
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.security.oauth2.client.AuthorizedClientServiceReactiveOAuth2AuthorizedClientManager
+import org.springframework.security.oauth2.client.InMemoryReactiveOAuth2AuthorizedClientService
+import org.springframework.security.oauth2.client.registration.ClientRegistration
+import org.springframework.security.oauth2.client.registration.InMemoryReactiveClientRegistrationRepository
+import org.springframework.security.oauth2.client.web.reactive.function.client.ServerOAuth2AuthorizedClientExchangeFilterFunction
+import org.springframework.security.oauth2.core.AuthorizationGrantType
 import org.springframework.web.reactive.function.client.WebClient
 
 @Configuration
 class WebClientConfiguration(
   @Value("\${hmpps.auth.url}") private val oauthApiUrl: String,
-  private val webClientBuilder: WebClient.Builder
+  @Value("\${hmpps.prison.api.url}") private val prisonApiUrl: String,
+  @Value("\${spring.security.oauth2.client.provider.hmpps-auth.token-uri}") private val oauthTokenUrl: String,
+  @Value("\${spring.security.oauth2.client.registration.oauth-clients.client-id}") private val oauthClientId: String,
+  @Value("\${spring.security.oauth2.client.registration.oauth-clients.client-secret}") private val oauthSecret: String,
 ) {
 
   @Bean
   fun oauthApiHealthWebClient(): WebClient {
-    return webClientBuilder.baseUrl(oauthApiUrl).build()
+    return WebClient.builder().baseUrl(oauthApiUrl).build()
+  }
+
+  @Bean
+  fun oauthPrisonClient(): WebClient {
+    val clientRegistryRepo = InMemoryReactiveClientRegistrationRepository(
+      ClientRegistration
+        .withRegistrationId("hmpps-auth")
+        .tokenUri(oauthTokenUrl)
+        .clientId(oauthClientId)
+        .clientSecret(oauthSecret)
+        .authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
+        .build()
+    )
+
+    val clientService = InMemoryReactiveOAuth2AuthorizedClientService(clientRegistryRepo)
+
+    val authorizedClientManager =
+      AuthorizedClientServiceReactiveOAuth2AuthorizedClientManager(clientRegistryRepo, clientService)
+
+    val oauthFilter = ServerOAuth2AuthorizedClientExchangeFilterFunction(authorizedClientManager)
+    oauthFilter.setDefaultClientRegistrationId("hmpps-auth")
+
+    return WebClient.builder().baseUrl(prisonApiUrl)
+      .filter(oauthFilter)
+      .build()
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceFunctions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceFunctions.kt
@@ -1,0 +1,32 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service
+
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.Licence
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.request.UpdateSentenceDatesRequest
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus
+
+data class SentenceChanges(
+  val lsdChanged: Boolean,
+  val ledChanged: Boolean,
+  val sedChanged: Boolean,
+  val tussdChanged: Boolean,
+  val tusedChanged: Boolean,
+  val isMaterial: Boolean
+)
+
+fun getSentenceChanges(sentenceDatesRequest: UpdateSentenceDatesRequest, licenceEntity: Licence): SentenceChanges {
+  val lsdChanged = nullableDatesDiffer(sentenceDatesRequest.licenceStartDate, licenceEntity.licenceStartDate)
+  val ledChanged = nullableDatesDiffer(sentenceDatesRequest.licenceExpiryDate, licenceEntity.licenceExpiryDate)
+  val sedChanged = nullableDatesDiffer(sentenceDatesRequest.sentenceEndDate, licenceEntity.sentenceEndDate)
+  val tussdChanged =
+    nullableDatesDiffer(sentenceDatesRequest.topupSupervisionStartDate, licenceEntity.topupSupervisionStartDate)
+  val tusedChanged =
+    nullableDatesDiffer(sentenceDatesRequest.topupSupervisionExpiryDate, licenceEntity.topupSupervisionExpiryDate)
+
+  val isMaterial =
+    (
+      lsdChanged || ledChanged || tussdChanged || tusedChanged ||
+        (sedChanged && licenceEntity.statusCode == LicenceStatus.APPROVED)
+      )
+
+  return SentenceChanges(lsdChanged, ledChanged, sedChanged, tussdChanged, tusedChanged, isMaterial)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceService.kt
@@ -962,11 +962,12 @@ class LicenceService(
             "${licenceEntity.forename} ${licenceEntity.surname}",
             licenceEntity.crn,
             mapOf(
-              Pair("Release date", sentenceChanges.lsdChanged),
-              Pair("Licence end date", sentenceChanges.ledChanged),
-              Pair("Sentence end date", sentenceChanges.sedChanged),
-              Pair("Top up supervision start date", sentenceChanges.tussdChanged),
-              Pair("Top up supervision end date", sentenceChanges.tusedChanged),
+              "Release date" to sentenceChanges.lsdChanged,
+              "Release date" to sentenceChanges.lsdChanged,
+              "Licence end date" to sentenceChanges.ledChanged,
+              "Sentence end date" to sentenceChanges.sedChanged,
+              "Top up supervision start date" to sentenceChanges.tussdChanged,
+              "Top up supervision end date" to sentenceChanges.tusedChanged,
             ),
           )
         }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/prison/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/prison/PrisonApiClient.kt
@@ -33,7 +33,7 @@ class PrisonApiClient(@Qualifier("oauthPrisonClient") val prisonerApiWebClient: 
         val uriPath = request?.uri?.path
         when (statusCode) {
           FORBIDDEN -> {
-            log.info("Client token does not have correct role to call prisoner-api $uriPath")
+            log.error("Client token does not have correct role to call prisoner-api $uriPath")
           }
           NOT_FOUND -> {
             log.info("No resource found when calling prisoner-api $uriPath")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/prison/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/prison/PrisonApiClient.kt
@@ -1,0 +1,42 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.prison
+
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.http.HttpStatus.FORBIDDEN
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import reactor.core.publisher.Mono
+
+@Service
+class PrisonApiClient(@Qualifier("oauthPrisonClient") val prisonerApiWebClient: WebClient) {
+
+  companion object {
+    private val log = LoggerFactory.getLogger(this::class.java)
+  }
+
+  fun hdcStatus(bookingId: Long): Mono<PrisonerHdcStatus> {
+    return prisonerApiWebClient
+      .get()
+      .uri("/offender-sentences/booking/$bookingId/home-detention-curfews/latest")
+      .accept(MediaType.APPLICATION_JSON)
+      .retrieve()
+      .bodyToMono(PrisonerHdcStatus::class.java)
+      .onErrorResume { webClientErrorHandler(it) }
+  }
+
+  private fun <API_RESPONSE_BODY_TYPE> webClientErrorHandler(exception: Throwable): Mono<API_RESPONSE_BODY_TYPE> =
+    with(exception) {
+      if (this is WebClientResponseException) {
+        val uriPath = request?.uri?.path
+        if (statusCode == FORBIDDEN) {
+          log.info("Client token does not have correct role to call prisoner-api $uriPath")
+        } else {
+          log.error("Failed to call prisoner-api $uriPath [statusCode: $statusCode, body: ${this.responseBodyAsString}]")
+        }
+      } else {
+        log.error("Failed to call prisoner-api", exception)
+      }
+    }.let { Mono.empty() }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/prison/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/prison/PrisonApiClient.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.prison
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.http.HttpStatus.FORBIDDEN
+import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
@@ -30,10 +31,16 @@ class PrisonApiClient(@Qualifier("oauthPrisonClient") val prisonerApiWebClient: 
     with(exception) {
       if (this is WebClientResponseException) {
         val uriPath = request?.uri?.path
-        if (statusCode == FORBIDDEN) {
-          log.info("Client token does not have correct role to call prisoner-api $uriPath")
-        } else {
-          log.error("Failed to call prisoner-api $uriPath [statusCode: $statusCode, body: ${this.responseBodyAsString}]")
+        when (statusCode) {
+          FORBIDDEN -> {
+            log.info("Client token does not have correct role to call prisoner-api $uriPath")
+          }
+          NOT_FOUND -> {
+            log.info("No resource found when calling prisoner-api $uriPath")
+          }
+          else -> {
+            log.error("Failed to call prisoner-api $uriPath [statusCode: $statusCode, body: ${this.responseBodyAsString}]")
+          }
         }
       } else {
         log.error("Failed to call prisoner-api", exception)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/prison/PrisonerHdcStatus.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/prison/PrisonerHdcStatus.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.prison
+
+data class PrisonerHdcStatus(
+  val approvalStatus: String?,
+  val approvalStatusDate: String?,
+  val bookingId: Int?,
+  val checksPassedDate: String?,
+  val passed: Boolean,
+  val refusedReason: String?
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/prison/PrisonerHdcStatus.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/prison/PrisonerHdcStatus.kt
@@ -1,10 +1,10 @@
 package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.prison
 
 data class PrisonerHdcStatus(
-  val approvalStatus: String?,
-  val approvalStatusDate: String?,
-  val bookingId: Long?,
-  val checksPassedDate: String?,
+  val approvalStatus: String? = null,
+  val approvalStatusDate: String? = null,
+  val bookingId: Long? = null,
+  val checksPassedDate: String? = null,
   val passed: Boolean,
-  val refusedReason: String?
+  val refusedReason: String? = null
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/prison/PrisonerHdcStatus.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/prison/PrisonerHdcStatus.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.prison
 data class PrisonerHdcStatus(
   val approvalStatus: String?,
   val approvalStatusDate: String?,
-  val bookingId: Int?,
+  val bookingId: Long?,
   val checksPassedDate: String?,
   val passed: Boolean,
   val refusedReason: String?

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -20,3 +20,5 @@ spring:
 hmpps:
   auth:
     url: http://localhost:8090/auth
+  prison:
+    url: https://api-dev.prison.service.justice.gov.uk/api

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -20,5 +20,3 @@ spring:
 hmpps:
   auth:
     url: http://localhost:8090/auth
-  prison:
-    url: https://api-dev.prison.service.justice.gov.uk/api

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -20,3 +20,9 @@ spring:
 hmpps:
   auth:
     url: http://localhost:8090/auth
+
+oauth:
+  client:
+    id: ${SYSTEM_CLIENT_ID}
+    secret: ${SYSTEM_CLIENT_SECRET}
+    token-url: ${HMPPS_AUTH_TOKEN_URL}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -20,9 +20,6 @@ spring:
 hmpps:
   auth:
     url: http://localhost:8090/auth
-
-oauth:
-  client:
-    id: ${SYSTEM_CLIENT_ID}
-    secret: ${SYSTEM_CLIENT_SECRET}
-    token-url: ${HMPPS_AUTH_TOKEN_URL}
+  prison:
+    api:
+      url: "https://api-dev.prison.service.justice.gov.uk/api"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,9 +19,19 @@ spring:
 
   security:
     oauth2:
-      resourceserver:
-        jwt:
-          jwk-set-uri: ${hmpps.auth.url}/.well-known/jwks.json
+      client:
+        registration:
+          hmpps-auth:
+            provider: hmpps-auth
+            client-id: ${oauth.client.id}
+            client-secret: ${oauth.client.secret}
+            authorization-grant-type: client_credentials
+        provider:
+          hmpps-auth:
+            token-uri: ${oauth.client.token-url}
+    resourceserver:
+      jwt:
+        jwk-set-uri: ${hmpps.auth.url}/.well-known/jwks.json
 
   jpa:
     open-in-view: false
@@ -111,9 +121,3 @@ hmpps:
   prison:
     api:
       url: "https://api-dev.prison.service.justice.gov.uk/api"
-
-oauth:
-  client:
-    id: ${SYSTEM_CLIENT_ID}
-    secret: ${SYSTEM_CLIENT_SECRET}
-    token-url: ${HMPPS_AUTH_TOKEN_URL}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,9 +29,9 @@ spring:
         provider:
           hmpps-auth:
             token-uri: ${oauth.client.token-url}
-    resourceserver:
-      jwt:
-        jwk-set-uri: ${hmpps.auth.url}/.well-known/jwks.json
+      resourceserver:
+        jwt:
+          jwk-set-uri: ${hmpps.auth.url}/.well-known/jwks.json
 
   jpa:
     open-in-view: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,6 +19,17 @@ spring:
 
   security:
     oauth2:
+      client:
+        registration:
+          oauth-clients:
+            provider: hmpps-auth
+            client-id: ${SYSTEM_CLIENT_ID}
+            client-secret: ${SYSTEM_CLIENT_SECRET}
+            authorization-grant-type: client_credentials
+            scope: write
+        provider:
+          hmpps-auth:
+            token-uri: ${HMPPS_AUTH_TOKEN_URL}
       resourceserver:
         jwt:
           jwk-set-uri: ${hmpps.auth.url}/.well-known/jwks.json
@@ -107,3 +118,11 @@ notify:
 self:
   link: "http://localhost:3000"
 
+prison-api:
+  endpoint:
+    url: https://api-dev.prison.service.justice.gov.uk/
+
+hmpps:
+  prison:
+    api:
+      url: "https://api-dev.prison.service.justice.gov.uk/api"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,12 +23,12 @@ spring:
         registration:
           hmpps-auth:
             provider: hmpps-auth
-            client-id: ${oauth.client.id}
-            client-secret: ${oauth.client.secret}
+            client-id: ${system.client.id}
+            client-secret: ${system.client.secret}
             authorization-grant-type: client_credentials
         provider:
           hmpps-auth:
-            token-uri: ${oauth.client.token-url}
+            token-uri: ${hmpps.auth.token.url}
       resourceserver:
         jwt:
           jwk-set-uri: ${hmpps.auth.url}/.well-known/jwks.json
@@ -116,8 +116,3 @@ notify:
 # Overridden in real environments
 self:
   link: "http://localhost:3000"
-
-hmpps:
-  prison:
-    api:
-      url: "https://api-dev.prison.service.justice.gov.uk/api"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,17 +19,6 @@ spring:
 
   security:
     oauth2:
-      client:
-        registration:
-          oauth-clients:
-            provider: hmpps-auth
-            client-id: ${SYSTEM_CLIENT_ID}
-            client-secret: ${SYSTEM_CLIENT_SECRET}
-            authorization-grant-type: client_credentials
-            scope: write
-        provider:
-          hmpps-auth:
-            token-uri: ${HMPPS_AUTH_TOKEN_URL}
       resourceserver:
         jwt:
           jwk-set-uri: ${hmpps.auth.url}/.well-known/jwks.json
@@ -118,11 +107,13 @@ notify:
 self:
   link: "http://localhost:3000"
 
-prison-api:
-  endpoint:
-    url: https://api-dev.prison.service.justice.gov.uk/
-
 hmpps:
   prison:
     api:
       url: "https://api-dev.prison.service.justice.gov.uk/api"
+
+oauth:
+  client:
+    id: ${SYSTEM_CLIENT_ID}
+    secret: ${SYSTEM_CLIENT_SECRET}
+    token-url: ${HMPPS_AUTH_TOKEN_URL}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/LicenceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/LicenceIntegrationTest.kt
@@ -3,12 +3,15 @@ package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.integration
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.groups.Tuple
 import org.assertj.core.groups.Tuple.tuple
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.test.context.jdbc.Sql
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.config.ErrorResponse
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.integration.wiremock.PrisonApiMockServer
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AdditionalCondition
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AdditionalConditionData
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AdditionalConditionsRequest
@@ -637,6 +640,8 @@ class LicenceIntegrationTest : IntegrationTestBase() {
     "classpath:test_data/seed-licence-id-1.sql"
   )
   fun `Update sentence dates`() {
+    prisonApiMockServer.stubGetHdcLatest()
+
     webTestClient.put()
       .uri("/licence/id/1/sentence-dates")
       .bodyValue(
@@ -677,6 +682,20 @@ class LicenceIntegrationTest : IntegrationTestBase() {
   }
 
   private companion object {
+    val prisonApiMockServer = PrisonApiMockServer()
+
+    @JvmStatic
+    @BeforeAll
+    fun startMocks() {
+      prisonApiMockServer.start()
+    }
+
+    @JvmStatic
+    @AfterAll
+    fun stopMocks() {
+      prisonApiMockServer.stop()
+    }
+
     val someStandardConditions = listOf(
       StandardCondition(code = "goodBehaviour", sequence = 1, text = "Be of good behaviour"),
       StandardCondition(code = "notBreakLaw", sequence = 2, text = "Do not break any law"),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/wiremock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/wiremock/PrisonApiMockServer.kt
@@ -1,0 +1,24 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.integration.wiremock
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+
+class PrisonApiMockServer : WireMockServer(8091) {
+  fun stubGetHdcLatest(bookingId: Long = 12345, approvalStatus: String = "REJECTED", passed: Boolean = true) {
+    stubFor(
+      get(urlEqualTo("/offender-sentences/booking/$bookingId/home-detention-curfews/latest")).willReturn(
+        aResponse().withHeader("Content-Type", "application/json").withBody(
+          """{
+                  "content": {
+                      "approvalStatus": "$approvalStatus",
+                      "passed": $passed,
+                      "bookingId": $bookingId
+                   }
+               }"""
+        ).withStatus(200)
+      )
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceServiceTest.kt
@@ -4,10 +4,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.anyList
-import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -21,6 +19,7 @@ import org.springframework.data.mapping.PropertyReferenceException
 import org.springframework.security.core.Authentication
 import org.springframework.security.core.context.SecurityContext
 import org.springframework.security.core.context.SecurityContextHolder
+import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.AdditionalConditionData
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.CommunityOffenderManager
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.OmuContact
@@ -53,6 +52,7 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.LicenceQ
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.LicenceRepository
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.StandardConditionRepository
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.prison.PrisonApiClient
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.prison.PrisonerHdcStatus
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceEventType
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceType
@@ -71,7 +71,6 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AdditionalCon
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.Licence as ModelLicence
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.StandardCondition as ModelStandardCondition
 
-@ExtendWith(MockitoExtension::class)
 class LicenceServiceTest {
   private val standardConditionRepository = mock<StandardConditionRepository>()
   private val additionalConditionRepository = mock<AdditionalConditionRepository>()
@@ -1032,6 +1031,14 @@ class LicenceServiceTest {
   @Test
   fun `update sentence dates persists the updated entity`() {
     whenever(licenceRepository.findById(1L)).thenReturn(Optional.of(aLicenceEntity))
+    whenever(prisonApiClient.hdcStatus(any())).thenReturn(
+      Mono.just(
+        PrisonerHdcStatus(
+          approvalStatusDate = null, approvalStatus = "REJECTED", refusedReason = null,
+          checksPassedDate = null, bookingId = aLicenceEntity.bookingId!!, passed = true
+        )
+      )
+    )
 
     service.updateSentenceDates(
       1L,
@@ -1100,9 +1107,97 @@ class LicenceServiceTest {
   }
 
   @Test
+  fun `update sentence dates does not email if HDC licence is not found`() {
+    whenever(licenceRepository.findById(1L)).thenReturn(Optional.of(aLicenceEntity))
+    whenever(prisonApiClient.hdcStatus(any())).thenReturn(Mono.empty())
+
+    service.updateSentenceDates(
+      1L,
+      UpdateSentenceDatesRequest(
+        conditionalReleaseDate = LocalDate.parse("2023-09-11"),
+        actualReleaseDate = LocalDate.parse("2023-09-11"),
+        sentenceStartDate = LocalDate.parse("2021-09-11"),
+        sentenceEndDate = LocalDate.parse("2024-09-11"),
+        licenceStartDate = LocalDate.parse("2023-09-11"),
+        licenceExpiryDate = LocalDate.parse("2024-09-11"),
+        topupSupervisionStartDate = LocalDate.parse("2024-09-11"),
+        topupSupervisionExpiryDate = LocalDate.parse("2025-09-11"),
+      )
+    )
+
+    verify(notifyService, times(0)).sendDatesChangedEmail(any(), any(), any(), any(), any(), any())
+  }
+
+  @Test
+  fun `update sentence dates does not email if HDC licence is Approved`() {
+    whenever(licenceRepository.findById(1L)).thenReturn(Optional.of(aLicenceEntity))
+    whenever(prisonApiClient.hdcStatus(any())).thenReturn(
+      Mono.just(
+        PrisonerHdcStatus(
+          approvalStatusDate = null, approvalStatus = "APPROVED", refusedReason = null,
+          checksPassedDate = null, bookingId = aLicenceEntity.bookingId!!, passed = true
+        )
+      )
+    )
+
+    service.updateSentenceDates(
+      1L,
+      UpdateSentenceDatesRequest(
+        conditionalReleaseDate = LocalDate.parse("2023-09-11"),
+        actualReleaseDate = LocalDate.parse("2023-09-11"),
+        sentenceStartDate = LocalDate.parse("2021-09-11"),
+        sentenceEndDate = LocalDate.parse("2024-09-11"),
+        licenceStartDate = LocalDate.parse("2023-09-11"),
+        licenceExpiryDate = LocalDate.parse("2024-09-11"),
+        topupSupervisionStartDate = LocalDate.parse("2024-09-11"),
+        topupSupervisionExpiryDate = LocalDate.parse("2025-09-11"),
+      )
+    )
+
+    verify(notifyService, times(0)).sendDatesChangedEmail(any(), any(), any(), any(), any(), any())
+  }
+
+  @Test
+  fun `update sentence dates does not email if Licence BookingId is missing`() {
+    whenever(licenceRepository.findById(1L)).thenReturn(Optional.of(aLicenceEntity.copy(bookingId = null)))
+    whenever(prisonApiClient.hdcStatus(any())).thenReturn(
+      Mono.just(
+        PrisonerHdcStatus(
+          approvalStatusDate = null, approvalStatus = "REJECTED", refusedReason = null,
+          checksPassedDate = null, bookingId = aLicenceEntity.bookingId!!, passed = false
+        )
+      )
+    )
+
+    service.updateSentenceDates(
+      1L,
+      UpdateSentenceDatesRequest(
+        conditionalReleaseDate = LocalDate.parse("2023-09-11"),
+        actualReleaseDate = LocalDate.parse("2023-09-11"),
+        sentenceStartDate = LocalDate.parse("2021-09-11"),
+        sentenceEndDate = LocalDate.parse("2024-09-11"),
+        licenceStartDate = LocalDate.parse("2023-09-11"),
+        licenceExpiryDate = LocalDate.parse("2024-09-11"),
+        topupSupervisionStartDate = LocalDate.parse("2024-09-11"),
+        topupSupervisionExpiryDate = LocalDate.parse("2025-09-11"),
+      )
+    )
+
+    verify(notifyService, times(0)).sendDatesChangedEmail(any(), any(), any(), any(), any(), any())
+  }
+
+  @Test
   fun `update sentence dates persists the updated entity with null dates`() {
     val licence = aLicenceEntity.copy(sentenceStartDate = null, licenceExpiryDate = null)
     whenever(licenceRepository.findById(1L)).thenReturn(Optional.of(licence))
+    whenever(prisonApiClient.hdcStatus(any())).thenReturn(
+      Mono.just(
+        PrisonerHdcStatus(
+          approvalStatusDate = null, approvalStatus = "REJECTED", refusedReason = null,
+          checksPassedDate = null, bookingId = aLicenceEntity.bookingId!!, passed = false
+        )
+      )
+    )
 
     service.updateSentenceDates(
       1L,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceServiceTest.kt
@@ -4,8 +4,10 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.anyList
+import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -50,6 +52,7 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.LicenceE
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.LicenceQueryObject
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.LicenceRepository
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.StandardConditionRepository
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.prison.PrisonApiClient
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceEventType
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceType
@@ -68,6 +71,7 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AdditionalCon
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.Licence as ModelLicence
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.StandardCondition as ModelStandardCondition
 
+@ExtendWith(MockitoExtension::class)
 class LicenceServiceTest {
   private val standardConditionRepository = mock<StandardConditionRepository>()
   private val additionalConditionRepository = mock<AdditionalConditionRepository>()
@@ -79,6 +83,7 @@ class LicenceServiceTest {
   private val auditEventRepository = mock<AuditEventRepository>()
   private val notifyService = mock<NotifyService>()
   private val omuService = mock<OmuService>()
+  private val prisonApiClient = mock<PrisonApiClient>()
 
   private val service = LicenceService(
     licenceRepository,
@@ -90,7 +95,8 @@ class LicenceServiceTest {
     additionalConditionUploadDetailRepository,
     auditEventRepository,
     notifyService,
-    omuService
+    omuService,
+    prisonApiClient
   )
 
   @BeforeEach

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceServiceTest.kt
@@ -1107,7 +1107,7 @@ class LicenceServiceTest {
   }
 
   @Test
-  fun `update sentence dates does not email if HDC licence is not found`() {
+  fun `update sentence dates still sends email if HDC licence is not found`() {
     whenever(licenceRepository.findById(1L)).thenReturn(Optional.of(aLicenceEntity))
     whenever(prisonApiClient.hdcStatus(any())).thenReturn(Mono.empty())
 
@@ -1125,7 +1125,7 @@ class LicenceServiceTest {
       )
     )
 
-    verify(notifyService, times(0)).sendDatesChangedEmail(any(), any(), any(), any(), any(), any())
+    verify(notifyService, times(1)).sendDatesChangedEmail(any(), any(), any(), any(), any(), any())
   }
 
   @Test

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -51,3 +51,9 @@ hmpps:
 
 notify:
   enabled: false
+
+oauth:
+  client:
+    id: client-id
+    secret: clientsecret
+    token-url: http://localhost:8090/auth/oauth/token

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -48,6 +48,9 @@ management.endpoint:
 hmpps:
   auth:
     url: http://localhost:8090/auth
+  prison:
+    api:
+      url: http://localhost:8091/api
 
 notify:
   enabled: false
@@ -56,4 +59,4 @@ oauth:
   client:
     id: client-id
     secret: clientsecret
-    token-url: http://localhost:8090/auth/oauth/token
+    token-url: http://localhost:8090/auth


### PR DESCRIPTION
Add oauth client configuration along with PrisonAPI WebClient Bean. Check HDC status is not Approved before emailing sentence changes in regard to a Standard Licence. Update deployment variables with the existing system client and secret used by CVL Node application. 