### PR TITLE
change jackson argument to input stream

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/config/PolicyConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/config/PolicyConfiguration.kt
@@ -12,6 +12,6 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.LicencePoli
 class PolicyConfiguration(@Value("classpath:policy_conditions/*.json") private val conditions: Array<Resource>) {
   @Bean
   fun policies(): LicencePolicyService {
-    return LicencePolicyService(conditions.map { policy -> jacksonObjectMapper().readValue(policy.file) })
+    return LicencePolicyService(conditions.map { policy -> jacksonObjectMapper().readValue(policy.inputStream) })
   }
 }


### PR DESCRIPTION
change jackson argument to input stream in order to prevent file path issues when accessing resource from the Jar file