### PR TITLE
CVSL-138 Set varied licence version to parent licence version temporarily, to prevent issues with inflight licences

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceService.kt
@@ -682,7 +682,7 @@ class LicenceService(
     licenceVariation.createdBy = createdBy
     licenceVariation.mailingList.add(licenceVariation.responsibleCom!!)
     licenceVariation.mailingList.add(createdBy!!)
-    licenceVariation.version = licencePolicyService.currentPolicy().version
+    licenceVariation.version = licenceEntity.version
 
     val newLicence = licenceRepository.save(licenceVariation)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceServiceTest.kt
@@ -1315,7 +1315,7 @@ class LicenceServiceTest {
 
     verify(licenceRepository, times(1)).save(licenceCaptor.capture())
     with(licenceCaptor.value) {
-      assertThat(version).isEqualTo("2.1")
+      assertThat(version).isEqualTo(aLicenceEntity.version)
     }
   }
 


### PR DESCRIPTION
Change related to https://github.com/ministryofjustice/create-and-vary-a-licence/pull/395