### PR TITLE
CVSL-727

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceService.kt
@@ -1025,7 +1025,7 @@ class LicenceService(
     updatedLicenceEntity.bookingId?.let {
       prisonApiClient.hdcStatus(it)
         .defaultIfEmpty(PrisonerHdcStatus(passed = false, approvalStatus = "UNKNOWN"))
-        .filter { h -> h.approvalStatus !== "APPROVED" }.subscribe {
+        .filter { h -> h.approvalStatus != "APPROVED" }.subscribe {
           log.info("Notifying COM ${licenceEntity.responsibleCom?.email} of date change event for $licenceId")
           notifyService.sendDatesChangedEmail(
             licenceId.toString(),


### PR DESCRIPTION
Change equality check for HDC status to none referential. Otherwise the check will always be true, as its checking against the object reference