### PR TITLE
CVSL-750 fixing N+1 issue

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/repository/LicenceSpecifications.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/repository/LicenceSpecifications.kt
@@ -30,6 +30,10 @@ fun LicenceQueryObject.toSpecification(): Specification<Licence> = and(
   hasPdusIn(pdus),
   hasProbationAreaCodeIn(probationAreaCodes)
 )
+  .and { root, query, _ ->
+    root.fetch<Licence, CommunityOffenderManager>("responsibleCom", JoinType.INNER)
+    query.restriction
+  }
 
 fun LicenceQueryObject.getSort(): Sort {
   if (sortBy == null) {


### PR DESCRIPTION
Before the change, "Get licences matches - no filters" test used to generate the following queries:

```
Hibernate: select ... from licence licence0_
Hibernate: select ... from community_offender_manager communityo0_ where communityo0_.id=? Hibernate: select ... from community_offender_manager communityo0_ where communityo0_.id=? Hibernate: select ... from community_offender_manager communityo0_ where communityo0_.id=? ...
```

After this change it generates:
```
select ... from licence licence0_ inner join community_offender_manager communityo1_ on licence0_.responsible_com_id=communityo1_.id
```
Combined with another bug this would generate up to an extra 25-30k sql queries per minute