### PR TITLE
CVSL-758 - Forcing COM usernames to be uppercase and removing case sensitivity on lookup

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/repository/CommunityOffenderManagerRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/repository/CommunityOffenderManagerRepository.kt
@@ -7,6 +7,6 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.CommunityOff
 @Repository
 interface CommunityOffenderManagerRepository : JpaRepository<CommunityOffenderManager, Long> {
   fun findByStaffIdentifier(staffIdentifier: Long): CommunityOffenderManager?
-  fun findByStaffIdentifierOrUsername(staffIdentifier: Long, username: String): List<CommunityOffenderManager>?
+  fun findByStaffIdentifierOrUsernameIgnoreCase(staffIdentifier: Long, username: String): List<CommunityOffenderManager>?
   fun findByUsernameIgnoreCase(username: String): CommunityOffenderManager?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ComService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ComService.kt
@@ -56,7 +56,7 @@ class ComService(
       (comDetails.firstName != com.firstName) ||
       (comDetails.lastName != com.lastName) ||
       (comDetails.staffEmail != com.email) ||
-      (comDetails.staffUsername.uppercase() != com.username.uppercase()) ||
+      (!comDetails.staffUsername.equals(com.username, ignoreCase = true)) ||
       (comDetails.staffIdentifier != com.staffIdentifier)
     ) {
       return this.communityOffenderManagerRepository.saveAndFlush(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ComService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ComService.kt
@@ -25,14 +25,14 @@ class ComService(
    */
   @Transactional
   fun updateComDetails(comDetails: UpdateComRequest): CommunityOffenderManager {
-    val comResult = this.communityOffenderManagerRepository.findByStaffIdentifierOrUsername(
+    val comResult = this.communityOffenderManagerRepository.findByStaffIdentifierOrUsernameIgnoreCase(
       comDetails.staffIdentifier, comDetails.staffUsername
     )
 
     if (comResult == null || comResult.isEmpty()) {
       return this.communityOffenderManagerRepository.saveAndFlush(
         CommunityOffenderManager(
-          username = comDetails.staffUsername,
+          username = comDetails.staffUsername.uppercase(),
           staffIdentifier = comDetails.staffIdentifier,
           email = comDetails.staffEmail,
           firstName = comDetails.firstName,
@@ -56,13 +56,13 @@ class ComService(
       (comDetails.firstName != com.firstName) ||
       (comDetails.lastName != com.lastName) ||
       (comDetails.staffEmail != com.email) ||
-      (comDetails.staffUsername != com.username) ||
+      (comDetails.staffUsername.uppercase() != com.username.uppercase()) ||
       (comDetails.staffIdentifier != com.staffIdentifier)
     ) {
       return this.communityOffenderManagerRepository.saveAndFlush(
         com.copy(
           staffIdentifier = comDetails.staffIdentifier,
-          username = comDetails.staffUsername,
+          username = comDetails.staffUsername.uppercase(),
           email = comDetails.staffEmail,
           firstName = comDetails.firstName,
           lastName = comDetails.lastName,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/OffenderIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/OffenderIntegrationTest.kt
@@ -73,7 +73,7 @@ class OffenderIntegrationTest : IntegrationTestBase() {
     val licence = licenceRepository.findById(1L).orElseThrow()
     assertThat(licence.responsibleCom)
       .extracting("staffIdentifier", "username", "email", "firstName", "lastName")
-      .isEqualTo(listOf(2000L, "test-client", "joebloggs@probation.gov.uk", "Joseph", "Bloggs"))
+      .isEqualTo(listOf(2000L, "TEST-CLIENT", "joebloggs@probation.gov.uk", "Joseph", "Bloggs"))
   }
 
   @Test


### PR DESCRIPTION
It appears that duplicate COM accounts were being created due to a combination of a few factors:
- HMPPS auth returns a normalised version of the username, in uppercase, whereas Delius returns the username as it exists (often lowercase)
- When a COM gets given a new account (possible due to moving probation region), they keep the same username but get a new Staff Indentifier
- Our existing COM record lookup is case sensitive

These three issues combine into a situation where it's possible for two accounts with the same username in different cases to be presumed by CVL to be two unique users, as they have different staff IDs and different casing of username. This then later causes an error when a subsequent search finds both COM records connected to one (differently-cased) username.

This fix adds `IgnoreCase` to the CVL lookup on update, meaning the new Staff Identifier will simply override the existing account info. It also begins a standard of making all CVL COM usernames uppercase, for data consistency.

This PR should be accompanied by a migration to update all existing COM usernames to be uppercase.