### PR TITLE
CVSL-1030 Add call to community api endpoint to get team codes for a user

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/CommunityApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/CommunityApiClient.kt
@@ -32,7 +32,7 @@ class CommunityApiClient(@Qualifier("oauthCommunityApiClient") val communityApiC
     } catch (exception: WebClientResponseException) {
       with(exception) {
         val uriPath = request?.uri?.path
-        log.error("No user found for staff when calling the community-api $uriPath with the following message ${exception.message}")
+        log.error("No user found for staff identifier when calling the community-api $uriPath with the following message ${exception.message}")
       }
       return emptyList()
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/CommunityApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/CommunityApiClient.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation
 
-import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
@@ -8,10 +7,6 @@ import org.springframework.web.reactive.function.client.WebClient
 
 @Component
 class CommunityApiClient(@Qualifier("oauthCommunityApiClient") val communityApiClient: WebClient) {
-
-  companion object {
-    private val log = LoggerFactory.getLogger(this::class.java)
-  }
 
   fun getTeamsCodesForUser(staffIdentifier: Long): List<String> {
     val communityApiResponse = communityApiClient

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/CommunityApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/CommunityApiClient.kt
@@ -1,27 +1,39 @@
 package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation
 
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientResponseException
 
 @Component
 class CommunityApiClient(@Qualifier("oauthCommunityApiClient") val communityApiClient: WebClient) {
 
+  companion object {
+    private val log = LoggerFactory.getLogger(this::class.java)
+  }
+
   fun getTeamsCodesForUser(staffIdentifier: Long): List<String> {
-    val user = communityApiClient
-      .get()
-      .uri("/secure/staff/staffIdentifier/$staffIdentifier")
-      .accept(MediaType.APPLICATION_JSON)
-      .retrieve()
-      .bodyToMono(User::class.java)
-      .block()
-
-    val userTeams = user?.teams
-
-    if (userTeams != null) {
-      return userTeams.map { team: Team -> team.code }
-    } else {
+    try {
+      val user = communityApiClient
+        .get()
+        .uri("/secure/staff/staffIdentifier/$staffIdentifier")
+        .accept(MediaType.APPLICATION_JSON)
+        .retrieve()
+        .bodyToMono(User::class.java)
+        .block()
+      if (user === null) {
+        return emptyList()
+      } else {
+        val userTeams = user.teams
+        return userTeams.map { team: Team -> team.code }
+      }
+    } catch (exception: WebClientResponseException) {
+      with(exception) {
+        val uriPath = request?.uri?.path
+        log.error("No user found for staff when calling the community-api $uriPath with the following message ${exception.message}")
+      }
       return emptyList()
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/CommunityApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/CommunityApiClient.kt
@@ -17,6 +17,6 @@ class CommunityApiClient(@Qualifier("oauthCommunityApiClient") val communityApiC
       .bodyToMono(User::class.java)
       .block()
     return communityApiResponse?.teams?.map { it.code }
-      ?: throw IllegalStateException("Could not find user with staff identifier $staffIdentifier")
+      ?: throw IllegalStateException("Unexpected null response from API")
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/CommunityApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/CommunityApiClient.kt
@@ -1,8 +1,8 @@
 package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation
 
 import org.springframework.beans.factory.annotation.Qualifier
-import org.springframework.stereotype.Component
 import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
 
 @Component
@@ -25,5 +25,4 @@ class CommunityApiClient(@Qualifier("oauthCommunityApiClient") val communityApiC
       return emptyList()
     }
   }
-
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/CommunityApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/CommunityApiClient.kt
@@ -1,0 +1,29 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation
+
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.stereotype.Component
+import org.springframework.http.MediaType
+import org.springframework.web.reactive.function.client.WebClient
+
+@Component
+class CommunityApiClient(@Qualifier("oauthCommunityApiClient") val communityApiClient: WebClient) {
+
+  fun getTeamsCodesForUser(staffIdentifier: Long): List<String> {
+    val user = communityApiClient
+      .get()
+      .uri("/secure/staff/staffIdentifier/$staffIdentifier")
+      .accept(MediaType.APPLICATION_JSON)
+      .retrieve()
+      .bodyToMono(User::class.java)
+      .block()
+
+    val userTeams = user?.teams
+
+    if (userTeams != null) {
+      return userTeams.map { team: Team -> team.code }
+    } else {
+      return emptyList()
+    }
+  }
+
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/Team.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/Team.kt
@@ -1,5 +1,5 @@
 package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation
 
-data class Team (
+data class Team(
   val code: String
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/Team.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/Team.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation
+
+data class Team (
+  val code: String
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/User.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/User.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation
+
+data class User (
+  val teams: List<Team>
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/User.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/User.kt
@@ -1,5 +1,5 @@
 package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation
 
-data class User (
+data class User(
   val teams: List<Team>
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/ComIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/ComIntegrationTest.kt
@@ -21,7 +21,6 @@ class ComIntegrationTest : IntegrationTestBase() {
     val result = webTestClient.get()
       .uri("$communityApiWiremockUrl/secure/staff/staffIdentifier/123456")
       .accept(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("ROLE_CVL_ADMIN")))
       .exchange()
       .expectStatus().isOk
       .expectHeader().contentType(MediaType.APPLICATION_JSON)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/ComIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/ComIntegrationTest.kt
@@ -4,20 +4,24 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.MediaType
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.integration.wiremock.CommunityApiMockServer
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation.User
 
-const val COMMUNITY_API_WIREMOCK_URL = "http://localhost:8093"
+
 
 class ComIntegrationTest : IntegrationTestBase() {
+
+  @Value("\${hmpps.community.api.url}")
+  val communityApiWiremockUrl: String = ""
 
   @Test
   fun `Get team codes for user with valid staff identifier`() {
     communityApiMockServer.stubGetTeamCodesForUser()
 
     val result = webTestClient.get()
-      .uri("$COMMUNITY_API_WIREMOCK_URL/secure/staff/staffIdentifier/123456")
+      .uri("$communityApiWiremockUrl/secure/staff/staffIdentifier/123456")
       .accept(MediaType.APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_CVL_ADMIN")))
       .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/ComIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/ComIntegrationTest.kt
@@ -9,8 +9,6 @@ import org.springframework.http.MediaType
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.integration.wiremock.CommunityApiMockServer
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation.User
 
-
-
 class ComIntegrationTest : IntegrationTestBase() {
 
   @Value("\${hmpps.community.api.url}")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/ComIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/ComIntegrationTest.kt
@@ -1,0 +1,50 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.integration.wiremock.CommunityApiMockServer
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation.User
+
+const val COMMUNITY_API_WIREMOCK_URL = "http://localhost:8093"
+
+class ComIntegrationTest : IntegrationTestBase() {
+
+  @Test
+  fun `Get team codes for user with valid staff identifier`() {
+    communityApiMockServer.stubGetTeamCodesForUser()
+
+    val result = webTestClient.get()
+      .uri("$COMMUNITY_API_WIREMOCK_URL/secure/staff/staffIdentifier/123456")
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_CVL_ADMIN")))
+      .exchange()
+      .expectStatus().isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(User::class.java)
+      .returnResult().responseBody
+
+    assertThat(result?.teams?.size).isEqualTo(1)
+    assertThat(result?.teams)
+      .extracting("code")
+      .containsExactly("A01B02")
+  }
+
+  private companion object {
+    val communityApiMockServer = CommunityApiMockServer()
+
+    @JvmStatic
+    @BeforeAll
+    fun startMocks() {
+      communityApiMockServer.start()
+    }
+
+    @JvmStatic
+    @AfterAll
+    fun stopMocks() {
+      communityApiMockServer.stop()
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/wiremock/CommunityApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/wiremock/CommunityApiMockServer.kt
@@ -108,4 +108,17 @@ class CommunityApiMockServer : WireMockServer(8093) {
       )
     )
   }
+
+  fun stubGetTeamCodesForInvalidUser(staffIdentifier: Long = 123456) {
+    stubFor(
+      get(urlEqualTo("/secure/staff/staffIdentifier/$staffIdentifier")).willReturn(
+        aResponse().withHeader("Content-Type", "application/json").withBody(
+          """{
+                  "status": "404",
+                  "developerMessage": "This is a message"
+               }"""
+        ).withStatus(404)
+      )
+    )
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/wiremock/CommunityApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/wiremock/CommunityApiMockServer.kt
@@ -8,7 +8,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 class CommunityApiMockServer : WireMockServer(8093) {
   fun stubGetTeamCodesForUser(staffIdentifier: Long = 123456) {
     stubFor(
-      get(urlEqualTo("/api/secure/staff/staffIdentifier/$staffIdentifier")).willReturn(
+      get(urlEqualTo("/secure/staff/staffIdentifier/$staffIdentifier")).willReturn(
         aResponse().withHeader("Content-Type", "application/json").withBody(
           """{
                   "username": "Test User",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/wiremock/CommunityApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/wiremock/CommunityApiMockServer.kt
@@ -8,7 +8,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 class CommunityApiMockServer : WireMockServer(8093) {
   fun stubGetTeamCodesForUser(staffIdentifier: Long = 123456) {
     stubFor(
-      get(urlEqualTo("/secure/staff/staffIdentifier/$staffIdentifier")).willReturn(
+      get(urlEqualTo("/api/secure/staff/staffIdentifier/$staffIdentifier")).willReturn(
         aResponse().withHeader("Content-Type", "application/json").withBody(
           """{
                   "username": "Test User",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/wiremock/CommunityApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/wiremock/CommunityApiMockServer.kt
@@ -1,0 +1,111 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.integration.wiremock
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+
+class CommunityApiMockServer : WireMockServer(8093) {
+  fun stubGetTeamCodesForUser(staffIdentifier: Long = 123456) {
+    stubFor(
+      get(urlEqualTo("/secure/staff/staffIdentifier/$staffIdentifier")).willReturn(
+        aResponse().withHeader("Content-Type", "application/json").withBody(
+          """{
+                  "username": "Test User",
+                  "email": "testUser@test.justice.gov.uk",
+                  "telephoneNumber": "0123456789",
+                  "staffCode": "AB00001",
+                  "staffIdentifier": 123456,
+                  "staff": {
+                    "forenames": "Test",
+                    "surname": "User"
+                  },
+                  "teams": [
+                    {
+                      "code": "A01B02",
+                      "description": "description",
+                      "telephone": "0123456789",
+                      "emailAddress": "first.last@digital.justice.gov.uk",
+                      "localDeliveryUnit": {
+                        "Code": "ABC123",
+                        "Description": "Some description"
+                      },
+                      "teamType": {
+                        "Code": "ABC123",
+                        "Description": "Some description"
+                      },
+                      "district": {
+                        "Code": "ABC123",
+                        "Description": "Some description"
+                      },
+                      "borough": {
+                        "Code": "ABC123",
+                        "Description": "Some description"
+                      },
+                      "startDate": "2023-05-18",
+                      "endDate": "2023-05-18"
+                    }
+                  ],
+                  "probationArea": {
+                    "probationAreaId": 0,
+                    "code": "N01",
+                    "description": "description",
+                    "nps": true,
+                    "organisation": {
+                      "Code": "ABC123",
+                      "Description": "Some description"
+                    },
+                    "institution": {
+                      "institutionId": 0,
+                      "isEstablishment": true,
+                      "code": "string",
+                      "description": "string",
+                      "institutionName": "string",
+                      "establishmentType": {
+                        "Code": "ABC123",
+                        "Description": "Some description"
+                      },
+                      "isPrivate": true,
+                      "nomsPrisonInstitutionCode": "string"
+                    },
+                    "teams": [
+                      {
+                        "providerTeamId": 0,
+                        "teamId": 0,
+                        "code": "string",
+                        "description": "string",
+                        "name": "string",
+                        "isPrivate": true,
+                        "externalProvider": {
+                          "Code": "ABC123",
+                          "Description": "Some description"
+                        },
+                        "scProvider": {
+                          "Code": "ABC123",
+                          "Description": "Some description"
+                        },
+                        "localDeliveryUnit": {
+                          "Code": "ABC123",
+                          "Description": "Some description"
+                        },
+                        "district": {
+                          "Code": "ABC123",
+                          "Description": "Some description"
+                        },
+                        "borough": {
+                          "Code": "ABC123",
+                          "Description": "Some description"
+                        }
+                      }
+                    ]
+                  },
+                  "staffGrade": {
+                    "Code": "ABC123",
+                    "Description": "Some description"
+                  }
+               }"""
+        ).withStatus(200)
+      )
+    )
+  }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -53,7 +53,7 @@ hmpps:
       url: http://localhost:8092/api
   community:
     api:
-      url: http://localhost:8093/api
+      url: http://localhost:8093
   probationSearch:
     api:
       url: http://localhost:8094/api


### PR DESCRIPTION
This PR is to add an endpoint call to the community api to retrieve the team codes for a user based on their staff identifier. 