### PR TITLE
CSVSL-1048 Improving performance by reducing the number of n+1 issues

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/entity/CommunityOffenderManager.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/entity/CommunityOffenderManager.kt
@@ -5,7 +5,6 @@ import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
-import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 import jakarta.validation.constraints.NotNull
 import java.time.LocalDateTime
@@ -29,15 +28,6 @@ data class CommunityOffenderManager(
   val firstName: String?,
 
   val lastName: String?,
-
-  @OneToMany(mappedBy = "responsibleCom")
-  val licencesResponsibleFor: List<Licence> = emptyList(),
-
-  @OneToMany(mappedBy = "createdBy")
-  val licencesCreated: List<Licence> = emptyList(),
-
-  @OneToMany(mappedBy = "submittedBy")
-  val licencesSubmitted: List<Licence> = emptyList(),
 
   val lastUpdatedTimestamp: LocalDateTime? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/entity/Licence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/entity/Licence.kt
@@ -86,7 +86,7 @@ data class Licence(
 
   @OneToMany(
     mappedBy = "licence",
-    fetch = FetchType.EAGER,
+    fetch = FetchType.LAZY,
     cascade = [CascadeType.ALL],
     orphanRemoval = true,
     targetEntity = StandardCondition::class
@@ -95,25 +95,25 @@ data class Licence(
   @OrderBy("conditionSequence")
   var standardConditions: List<StandardCondition> = emptyList(),
 
-  @OneToMany(mappedBy = "licence", fetch = FetchType.EAGER, cascade = [CascadeType.ALL], orphanRemoval = true)
+  @OneToMany(mappedBy = "licence", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
   @Fetch(value = FetchMode.SUBSELECT)
   @OrderBy("conditionSequence")
   val additionalConditions: List<AdditionalCondition> = emptyList(),
 
-  @OneToMany(mappedBy = "licence", fetch = FetchType.EAGER, cascade = [CascadeType.ALL], orphanRemoval = true)
+  @OneToMany(mappedBy = "licence", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
   @Fetch(value = FetchMode.SUBSELECT)
   @OrderBy("conditionSequence")
   val bespokeConditions: List<BespokeCondition> = emptyList(),
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "responsible_com_id", nullable = false)
   var responsibleCom: CommunityOffenderManager? = null,
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "submitted_by_com_id", nullable = true)
   var submittedBy: CommunityOffenderManager? = null,
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "created_by_com_id", nullable = false)
   var createdBy: CommunityOffenderManager? = null,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceService.kt
@@ -119,6 +119,7 @@ class LicenceService(
     return createLicenceResponse
   }
 
+  @Transactional
   fun getLicenceById(licenceId: Long): Licence {
     val entityLicence = licenceRepository
       .findById(licenceId)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/LicenceConditionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/LicenceConditionIntegrationTest.kt
@@ -30,7 +30,7 @@ class LicenceConditionIntegrationTest : IntegrationTestBase() {
   @Test
   @Sql(
     "classpath:test_data/seed-licence-id-1.sql"
-  )/**/
+  )
   fun `Update the standard conditions`() {
     webTestClient.put()
       .uri("/licence/id/1/standard-conditions")
@@ -64,7 +64,7 @@ class LicenceConditionIntegrationTest : IntegrationTestBase() {
   @Test
   @Sql(
     "classpath:test_data/seed-licence-id-1.sql"
-  )/**/
+  )
   fun `Add an additional condition`() {
     webTestClient.post()
       .uri("/licence/id/1/additional-condition/AP")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/LicenceMatchingIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/LicenceMatchingIntegrationTest.kt
@@ -15,6 +15,24 @@ class LicenceMatchingIntegrationTest : IntegrationTestBase() {
 
   @Test
   @Sql(
+    "classpath:test_data/seed-a-few-licences.sql"
+  )
+  fun `Find approved licences`() {
+    val result = webTestClient.post()
+      .uri("/licence/match")
+      .bodyValue(MatchLicencesRequest(status = listOf(LicenceStatus.APPROVED)))
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_CVL_ADMIN")))
+      .exchange()
+      .expectBodyList(LicenceSummary::class.java)
+      .returnResult().responseBody!!
+
+    assertThat(result.size).isEqualTo(5)
+    assertThat(result.map { it.licenceId }).containsExactly(1L, 2L, 3L, 4L, 5L)
+  }
+
+  @Test
+  @Sql(
     "classpath:test_data/seed-matching-candidates.sql"
   )
   fun `Get licences matches - no filters`() {

--- a/src/test/resources/test_data/seed-a-few-licences.sql
+++ b/src/test/resources/test_data/seed-a-few-licences.sql
@@ -1,0 +1,13 @@
+insert into licence (
+  id,
+  version,
+  responsible_com_id,
+  created_by_com_id,
+  type_code,
+  status_code
+) values
+(1,'1.0',1,4,'AP','APPROVED'),
+(2,'1.0',2,5,'AP','APPROVED'),
+(4,'1.0',2,6,'AP','APPROVED'),
+(5,'1.0',2,7,'AP','APPROVED'),
+(3,'1.0',3,8,'AP','APPROVED');

--- a/src/test/resources/test_data/seed-community-offender-manager.sql
+++ b/src/test/resources/test_data/seed-community-offender-manager.sql
@@ -2,5 +2,10 @@ insert into community_offender_manager(id, staff_identifier, username, email, fi
 values
     (1, 2000, 'test-client', 'testClient@probation.gov.uk', 'Test', 'Client'),
     (2, 125, 'AAA', 'testAAA@probation.gov.uk', 'Adam', 'AAA'),
-    (3, 126, 'BBB', 'testBBB@probation.gov.uk', 'Brian', 'BBB');
+    (3, 126, 'BBB', 'testBBB@probation.gov.uk', 'Brian', 'BBB'),
+    (4, 127, 'CCC', 'testCCC@probation.gov.uk', 'Brian', 'CCC'),
+    (5, 128, 'DDD', 'testDDD@probation.gov.uk', 'Brian', 'DDD'),
+    (6, 129, 'EEE', 'testEEE@probation.gov.uk', 'Brian', 'EEE'),
+    (7, 130, 'FFF', 'testFFF@probation.gov.uk', 'Brian', 'FFF'),
+    (8, 131, 'GGG', 'testGGG@probation.gov.uk', 'Brian', 'GGG');
 


### PR DESCRIPTION
Depending on the way the criteria object was created it could trigger up to 4*n+1 queries as it would eagerly load the various collections of conditions and com details. This was all unnecessary as the matches endpoint produces LicenceSummarys which do not surface any info about additional conditions and only provide info about the responsible com

There still seems to be an n+1 query as it seems to retrieve the created com even though its not being used - still not really sure why!

None of the other methods retrieving multiple Licences require access to associated entities (conditions/other coms). If we need to add these methods we should add custom methods that have appropriate fetch strategies. Using the generic "match" endpoint would be inappropriate for that