### PR TITLE
Fixing prisoner search request structure and removing error handling for loud failures

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/IS91DeterminationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/IS91DeterminationService.kt
@@ -8,7 +8,7 @@ class IS91DeterminationService(
   private val prisonApiClient: PrisonApiClient
 ) {
 
-  private object IS91Constants {
+  private companion object IS91Constants {
     val resultCodes = setOf("5500", "4022", "3006", "5502")
     const val offenceCode = "IA99000-001N"
   }
@@ -16,9 +16,9 @@ class IS91DeterminationService(
   fun getIS91AndExtraditionBookingIds(bookingIds: List<Long>): List<Long> {
     val offenceHistories = prisonApiClient.getOffenceHistories(bookingIds)
     val is91AndExtraditionOffenceHistories = offenceHistories.filter {
-      IS91Constants.resultCodes.contains(it.primaryResultCode) ||
-        IS91Constants.resultCodes.contains(it.secondaryResultCode) ||
-        it.offenceCode == IS91Constants.offenceCode
+      resultCodes.contains(it.primaryResultCode) ||
+        resultCodes.contains(it.secondaryResultCode) ||
+        it.offenceCode == offenceCode
     }
     return is91AndExtraditionOffenceHistories.map { it.bookingId }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/prison/PrisonerSearchApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/prison/PrisonerSearchApiClient.kt
@@ -2,13 +2,11 @@ package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.prison
 
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
-import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
-import org.springframework.web.reactive.function.client.WebClientResponseException
-import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.typeReference
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.prison.model.request.PrisonerSearchByBookingIdsRequest
 
 @Service
 class PrisonerSearchApiClient(@Qualifier("oauthPrisonerSearchClient") val prisonerSearchApiWebClient: WebClient) {
@@ -22,30 +20,9 @@ class PrisonerSearchApiClient(@Qualifier("oauthPrisonerSearchClient") val prison
       .post()
       .uri("/prisoner-search/booking-ids")
       .accept(MediaType.APPLICATION_JSON)
-      .bodyValue(bookingIds)
+      .bodyValue(PrisonerSearchByBookingIdsRequest(bookingIds))
       .retrieve()
       .bodyToMono(typeReference<List<PrisonerSearchPrisoner>>())
-      .onErrorResume { webClientErrorHandler(it) }
       .block() ?: emptyList<PrisonerSearchPrisoner>()
   }
-
-  private fun <API_RESPONSE_BODY_TYPE> webClientErrorHandler(exception: Throwable): Mono<API_RESPONSE_BODY_TYPE> =
-    with(exception) {
-      if (this is WebClientResponseException) {
-        val uriPath = request?.uri?.path
-        when (statusCode) {
-          HttpStatus.FORBIDDEN -> {
-            log.error("Client token does not have correct role to call prisoner-search-api $uriPath")
-          }
-          HttpStatus.NOT_FOUND -> {
-            log.info("No resource found when calling prisoner-search-api $uriPath")
-          }
-          else -> {
-            log.error("Failed to call prisoner-search-api $uriPath [statusCode: $statusCode, body: ${this.responseBodyAsString}]")
-          }
-        }
-      } else {
-        log.error("Failed to call prisoner-search-api", exception)
-      }
-    }.let { Mono.empty() }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/prison/model/request/PrisonerSearchByBookingIdsRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/prison/model/request/PrisonerSearchByBookingIdsRequest.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.prison.model.request
+
+data class PrisonerSearchByBookingIdsRequest(
+  val bookingIds: List<Long>
+)


### PR DESCRIPTION
Removing error handling from the prisonerSearchApi call to prevent an issue where the licence activation job would seemingly complete, but have just failed quietly.

Also fixing the incorrect request formatting that was causing the job to fail.