### PR TITLE
CVSL-1127 Adding condition formatter to the backend

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/policy/AdditionalConditionAp.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/policy/AdditionalConditionAp.kt
@@ -10,4 +10,4 @@ data class AdditionalConditionAp(
   override val categoryShort: String? = null,
   val subtext: String? = null,
   override val type: String? = null,
-) : IAdditionalCondition<Input>
+) : IAdditionalCondition

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/policy/AdditionalConditionPss.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/policy/AdditionalConditionPss.kt
@@ -8,6 +8,6 @@ data class AdditionalConditionPss(
   override val requiresInput: Boolean,
   override val categoryShort: String? = null,
   val pssDates: Boolean? = null,
-  override val inputs: List<PssInput>? = null,
+  override val inputs: List<Input>? = null,
   override val type: String? = null,
-) : IAdditionalCondition<PssInput>
+) : IAdditionalCondition

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/policy/Conditional.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/policy/Conditional.kt
@@ -2,4 +2,6 @@ package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy
 
 data class Conditional(
   val inputs: List<ConditionalInput>,
-)
+) : HasInputs {
+  override fun getConditionInputs() = inputs.map { it.toInput() }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/policy/ConditionalInput.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/policy/ConditionalInput.kt
@@ -1,11 +1,25 @@
 package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy
 
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.Case
+
 data class ConditionalInput(
-  val type: String,
+  val type: InputType,
   val label: String,
   val name: String,
-  val case: String? = null,
+  val case: Case? = null,
   val handleIndefiniteArticle: Boolean? = null,
   val includeBefore: String? = null,
   val subtext: String? = null,
-)
+) {
+  fun toInput() = Input(
+    type = type,
+    label = label,
+    name = name,
+    listType = null,
+    options = null,
+    case = case,
+    handleIndefiniteArticle = handleIndefiniteArticle,
+    includeBefore = includeBefore,
+    subtext = subtext,
+  )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/policy/Input.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/policy/Input.kt
@@ -1,17 +1,82 @@
 package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy
 
+import com.fasterxml.jackson.annotation.JsonValue
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.AdditionalConditionData
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.InputType.ADDRESS
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.InputType.TEXT
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.Case
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.adjustCase
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.formatAddress
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.formatUsing
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.startsWithVowel
+
+enum class InputType(@JsonValue val description: String) {
+  RADIO("radio"),
+  ADDRESS("address"),
+  TIME_PICKER("timePicker"),
+  DATE_PICKER("datePicker"),
+  FILE_UPLOAD("fileUpload"),
+  TEXT("text"),
+  CHECK("check"),
+}
+
 data class Input(
-  val type: String,
+  override val type: InputType,
   val label: String,
   val name: String,
-  val listType: String? = null,
+  override val listType: String? = null,
   val options: List<Option>? = null,
-  val case: String? = null,
-  val handleIndefiniteArticle: Boolean? = null,
+  override val case: Case? = null,
+  override val handleIndefiniteArticle: Boolean? = null,
   val addAnother: AddAnother? = null,
-  val includeBefore: String? = null,
+  override val includeBefore: String? = null,
   val subtext: String? = null,
-)
+) : FormattingRule
+
+interface FormattingRule {
+  val type: InputType
+  val case: Case?
+  val listType: String?
+  val includeBefore: String?
+  val handleIndefiniteArticle: Boolean?
+
+  companion object {
+    val DEFAULT = object : FormattingRule {
+      override val type = TEXT
+      override val case = null
+      override val listType = "AND"
+      override val includeBefore = null
+      override val handleIndefiniteArticle = null
+    }
+  }
+}
+
+fun FormattingRule.format(data: List<AdditionalConditionData>) = when (data.size) {
+  0 -> ""
+  1 -> formatSingleValue(data.first().dataValue!!)
+  else -> formatMultipleValues(data)
+}
+
+private fun FormattingRule.formatSingleValue(item: String) = item
+  .adjustCase(this.case)
+  .let { this.applyFormattingRules(it) }
+
+private fun FormattingRule.formatMultipleValues(data: List<AdditionalConditionData>) = data
+  .mapNotNull { it.dataValue }
+  .map { it.adjustCase(this.case) }
+  .formatUsing(this.listType ?: "AND")
+  .let { this.applyFormattingRules(it) }
+
+fun FormattingRule.applyFormattingRules(value: String) = value
+  .let { if (this.includeBefore != null) "${this.includeBefore}$it" else it }
+  .let { if (this.type == ADDRESS) formatAddress(it) else it }
+  .let {
+    if (this.handleIndefiniteArticle != null) {
+      if (it.startsWithVowel()) "an $it" else "a $it"
+    } else {
+      it
+    }
+  }
 
 data class AddAnother(
   val label: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/policy/LicencePolicy.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/policy/LicencePolicy.kt
@@ -9,12 +9,29 @@ interface ILicenceCondition {
   val tpl: String?
 }
 
-interface IAdditionalCondition<INPUT> : ILicenceCondition {
+interface IAdditionalCondition : ILicenceCondition, HasInputs {
   val category: String
-  val inputs: List<INPUT>?
+  val inputs: List<Input>?
   val type: String?
   val requiresInput: Boolean
   val categoryShort: String?
+  override fun getConditionInputs() = inputs
+}
+
+interface HasInputs {
+  @JsonIgnore
+  fun getConditionInputs(): List<Input>?
+
+  // Recursively gather all formatting rules, first top level and then recursively to get any conditional rules
+  @JsonIgnore
+  fun getFormattingRules(): List<Input> {
+    val inputs = this.getConditionInputs() ?: emptyList()
+    val options = inputs.flatMap { it.options ?: emptyList() }
+    val conditionalInputs =
+      options.filter { it.conditional != null }.mapNotNull { it.conditional }.flatMap { it.getFormattingRules() }
+
+    return inputs + conditionalInputs
+  }
 }
 
 data class ChangeHint(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ConditionFormatter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ConditionFormatter.kt
@@ -1,0 +1,37 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service
+
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.AdditionalConditionData
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.FormattingRule
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.IAdditionalCondition
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.format
+
+class ConditionFormatter {
+
+  fun format(condition: IAdditionalCondition, data: List<AdditionalConditionData>): String {
+    if (!condition.requiresInput) {
+      return condition.text
+    }
+    val placeholders = condition.tpl.getPlaceholderNames()
+    val rules = condition.getFormattingRules()
+
+    return placeholders.fold(condition.tpl ?: "") { conditionText, placeholder ->
+      val fieldName = data.findFieldNameToUse(placeholder)
+      val conditionData = data.getProvidedDataFor(fieldName)
+      val value = (rules.find { it.name == fieldName } ?: FormattingRule.DEFAULT).format(conditionData)
+      conditionText.replacePlaceholder(placeholder, value)
+    }
+  }
+}
+
+/**
+ * Double pipe notation in a placeholder is used to indicate that either value can be used.
+ * The field names are in priority order (i.e. the second field name will be used only if the first field has no data)
+ */
+private fun List<AdditionalConditionData>.findFieldNameToUse(placeholder: String) =
+  placeholder
+    .splitToSequence("||")
+    .map { it.trim() }
+    .find { this.getProvidedDataFor(it).isNotEmpty() }
+    ?: placeholder
+
+fun List<AdditionalConditionData>.getProvidedDataFor(name: String) = this.filter { it.dataField == name }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/FormattingHelpers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/FormattingHelpers.kt
@@ -1,0 +1,62 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service
+
+import com.fasterxml.jackson.annotation.JsonValue
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.Case.CAPITALISED
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.Case.LOWER
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.Case.UPPER
+
+fun String?.getPlaceholderNames(): List<String> =
+  this?.let {
+    "\\{(.*?)}".toRegex().findAll(this)
+      .map { it.groupValues[1].trim() }
+      .toList()
+  } ?: emptyList()
+
+fun String.replacePlaceholder(placeholder: String, replacement: String) =
+  this.replaceFirst("{$placeholder}", replacement)
+
+private fun properCase(word: String) =
+  if (word.isNotEmpty()) word[0].uppercase() + word.lowercase().substring(1) else word
+
+/**
+ * Converts a name (first name, last name, middle name, etc.) to proper case equivalent, handling double-barreled names
+ * correctly (i.e. each part in a double-barreled is converted to proper case).
+ */
+private fun properCaseName(name: String) =
+  if (name.isBlank()) "" else name.split('-').joinToString("-") { properCase(it) }
+
+fun String.convertToTitleCase() =
+  if (this.isBlank()) "" else this.split(" ").joinToString(" ") { properCaseName(it) }
+
+fun formatAddress(address: String) = address.split(", ").filter { (it.trim().isNotEmpty()) }.joinToString(", ")
+
+fun String.startsWithVowel() = setOf('a', 'e', 'i', 'o', 'u').contains(this.elementAtOrNull(0)?.lowercaseChar())
+
+enum class Case(@JsonValue val description: String) {
+  LOWER("lower"),
+  UPPER("upper"),
+  CAPITALISED("capitalised"),
+}
+
+/**
+ * Adjusts the case of a value according to the rule specified.
+ */
+fun String.adjustCase(case: Case?): String {
+  if (case == null) {
+    return this
+  }
+  return when (case) {
+    LOWER -> this.lowercase()
+    UPPER -> this.uppercase()
+    CAPITALISED -> this.convertToTitleCase()
+  }
+}
+
+fun List<String>.formatUsing(listType: String): String = when (this.size) {
+  0 -> ""
+  1 -> this.first()
+  else ->
+    this
+      .dropLast(1)
+      .joinToString(separator = ", ", postfix = " ${listType.lowercase()} ${this.last()}")
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/PolicyFunctions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/PolicyFunctions.kt
@@ -13,10 +13,10 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.ConditionCh
 /**
  * This will return a list of all changes that need to be addressed as part of migrating a licence from one version of the policy to another.
  */
-fun <T : Any> licencePolicyChanges(
+fun licencePolicyChanges(
   licence: Licence,
-  previousConditions: List<IAdditionalCondition<T>>,
-  currentConditions: List<IAdditionalCondition<T>>,
+  previousConditions: List<IAdditionalCondition>,
+  currentConditions: List<IAdditionalCondition>,
   allReplacements: List<Replacements>,
 ): List<LicenceConditionChanges> {
   val conditionsToCheck = previousConditions.filter { policyCondition ->
@@ -33,9 +33,9 @@ fun <T : Any> licencePolicyChanges(
   }
 }
 
-fun <T : Any> conditionChanges(
-  previousConditions: List<IAdditionalCondition<T>>,
-  currentConditions: List<IAdditionalCondition<T>>,
+fun conditionChanges(
+  previousConditions: List<IAdditionalCondition>,
+  currentConditions: List<IAdditionalCondition>,
   allReplacements: List<Replacements>,
 ): List<LicenceConditionChanges> = previousConditions.mapNotNull { previous ->
   val current = currentConditions.find { it.code == previous.code }
@@ -46,9 +46,9 @@ fun <T : Any> conditionChanges(
   }
 }
 
-private fun <T : Any> conditionUpdated(
-  previous: IAdditionalCondition<T>,
-  current: IAdditionalCondition<T>,
+private fun conditionUpdated(
+  previous: IAdditionalCondition,
+  current: IAdditionalCondition,
 ): LicenceConditionChanges? {
   val textHasChanged = previous.text != current.text
   val removed = (previous.inputs ?: emptyList()) - (current.inputs ?: emptyList()).toSet()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/policies/PolicyV1.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/policies/PolicyV1.kt
@@ -7,12 +7,20 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.Additi
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.Conditional
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.ConditionalInput
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.Input
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.InputType.ADDRESS
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.InputType.CHECK
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.InputType.DATE_PICKER
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.InputType.FILE_UPLOAD
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.InputType.RADIO
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.InputType.TEXT
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.InputType.TIME_PICKER
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.LicencePolicy
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.Option
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.PssInput
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.StandardConditionAp
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.StandardConditionPss
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.StandardConditions
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.Case.CAPITALISED
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.Case.LOWER
 
 val POLICY_V1_0 = LicencePolicy(
   additionalConditions = AdditionalConditions(
@@ -38,7 +46,7 @@ val POLICY_V1_0 = LicencePolicy(
               Option("Kent, Surrey and Sussex"),
               Option("Wales"),
             ),
-            type = "radio",
+            type = RADIO,
           ),
         ),
         requiresInput = true,
@@ -51,7 +59,7 @@ val POLICY_V1_0 = LicencePolicy(
         code = "fce34fb2-02f4-4eb0-9b8d-d091e11451fa",
         inputs = listOf(
           Input(
-            case = "lower",
+            case = LOWER,
             label = "Select the relevant text",
             name = "gender",
             options = listOf(
@@ -59,7 +67,7 @@ val POLICY_V1_0 = LicencePolicy(
               Option("any female"),
               Option("any male"),
             ),
-            type = "radio",
+            type = RADIO,
           ),
           Input(
             label = "Select the relevant age",
@@ -68,7 +76,7 @@ val POLICY_V1_0 = LicencePolicy(
               Option("16"),
               Option("18"),
             ),
-            type = "radio",
+            type = RADIO,
           ),
         ),
         requiresInput = true,
@@ -82,7 +90,7 @@ val POLICY_V1_0 = LicencePolicy(
         code = "b72fdbf2-0dc9-4e7f-81e4-c2ccb5d1bc90",
         inputs = listOf(
           Input(
-            case = "lower",
+            case = LOWER,
             label = "Select all the relevant options",
             listType = "AND",
             name = "appointmentType",
@@ -91,7 +99,7 @@ val POLICY_V1_0 = LicencePolicy(
               Option("Psychologist"),
               Option("Medical practitioner"),
             ),
-            type = "check",
+            type = CHECK,
           ),
         ),
         requiresInput = true,
@@ -115,18 +123,18 @@ val POLICY_V1_0 = LicencePolicy(
             includeBefore = " at ",
             label = "Enter time (optional)",
             name = "appointmentTime",
-            type = "timePicker",
+            type = TIME_PICKER,
           ),
           Input(
             includeBefore = " on ",
             label = "Enter date (optional)",
             name = "appointmentDate",
-            type = "datePicker",
+            type = DATE_PICKER,
           ),
           Input(
             label = "Enter the address for the appointment",
             name = "appointmentAddress",
-            type = "address",
+            type = ADDRESS,
           ),
         ),
         requiresInput = true,
@@ -148,18 +156,18 @@ val POLICY_V1_0 = LicencePolicy(
         inputs = listOf(
           Input(
             addAnother = AddAnother("Add another person"),
-            case = "capitalise",
+            case = CAPITALISED,
             label = "Enter name of victim or family member",
             listType = "OR",
             name = "name",
-            type = "text",
+            type = TEXT,
           ),
           Input(
-            case = "capitalise",
+            case = CAPITALISED,
             includeBefore = " and / or ",
             label = "Enter social services department (optional)",
             name = "socialServicesDepartment",
-            type = "text",
+            type = TEXT,
           ),
         ),
         requiresInput = true,
@@ -173,7 +181,7 @@ val POLICY_V1_0 = LicencePolicy(
         code = "4a5fed48-0fb9-4711-8ddf-b46ddfd90246",
         inputs = listOf(
           Input(
-            case = "lower",
+            case = LOWER,
             label = "Select the relevant gender",
             name = "gender",
             options = listOf(
@@ -181,7 +189,7 @@ val POLICY_V1_0 = LicencePolicy(
               Option("any female"),
               Option("any male"),
             ),
-            type = "radio",
+            type = RADIO,
           ),
           Input(
             label = "Select the relevant age",
@@ -190,14 +198,14 @@ val POLICY_V1_0 = LicencePolicy(
               Option("16 years"),
               Option("18 years"),
             ),
-            type = "radio",
+            type = RADIO,
           ),
           Input(
-            case = "capitalise",
+            case = CAPITALISED,
             includeBefore = " and / or ",
             label = "Enter social services department (optional)",
             name = "socialServicesDepartment",
-            type = "text",
+            type = TEXT,
           ),
         ),
         requiresInput = true,
@@ -212,11 +220,11 @@ val POLICY_V1_0 = LicencePolicy(
         inputs = listOf(
           Input(
             addAnother = AddAnother("Add another person"),
-            case = "capitalise",
+            case = CAPITALISED,
             label = "Enter name of offender or individual",
             listType = "OR",
             name = "nameOfIndividual",
-            type = "text",
+            type = TEXT,
           ),
         ),
         requiresInput = true,
@@ -248,7 +256,7 @@ val POLICY_V1_0 = LicencePolicy(
             label = "Enter the name of group or organisation",
             listType = "OR",
             name = "nameOfOrganisation",
-            type = "text",
+            type = TEXT,
           ),
         ),
         requiresInput = true,
@@ -277,13 +285,13 @@ val POLICY_V1_0 = LicencePolicy(
               Option("prolific offending behaviour"),
               Option("offending behaviour"),
             ),
-            type = "check",
+            type = CHECK,
           ),
           Input(
             includeBefore = " at the ",
             label = "Enter name of course or centre (optional)",
             name = "course",
-            type = "text",
+            type = TEXT,
           ),
         ),
         requiresInput = true,
@@ -303,7 +311,7 @@ val POLICY_V1_0 = LicencePolicy(
               Option("16 years"),
               Option("18 years"),
             ),
-            type = "radio",
+            type = RADIO,
           ),
         ),
         requiresInput = true,
@@ -371,7 +379,7 @@ val POLICY_V1_0 = LicencePolicy(
             label = "Enter the name of the item",
             listType = "OR",
             name = "item",
-            type = "text",
+            type = TEXT,
           ),
         ),
         requiresInput = true,
@@ -390,7 +398,7 @@ val POLICY_V1_0 = LicencePolicy(
         code = "db2d7e24-b130-4c7e-a1bf-6bb5f3036c02",
         inputs = listOf(
           Input(
-            case = "lower",
+            case = LOWER,
             label = "Select the relevant text",
             name = "gender",
             options = listOf(
@@ -398,7 +406,7 @@ val POLICY_V1_0 = LicencePolicy(
               Option("women"),
               Option("women or men"),
             ),
-            type = "radio",
+            type = RADIO,
           ),
         ),
         requiresInput = true,
@@ -431,15 +439,15 @@ val POLICY_V1_0 = LicencePolicy(
           Input(
             label = "Enter the curfew start time",
             name = "curfewStart",
-            type = "timePicker",
+            type = TIME_PICKER,
           ),
           Input(
             label = "Enter the curfew end time",
             name = "curfewEnd",
-            type = "timePicker",
+            type = TIME_PICKER,
           ),
           Input(
-            case = "lower",
+            case = LOWER,
             handleIndefiniteArticle = true,
             label = "Select a review period",
             name = "reviewPeriod",
@@ -450,18 +458,18 @@ val POLICY_V1_0 = LicencePolicy(
                 conditional = Conditional(
                   inputs = listOf(
                     ConditionalInput(
-                      case = "lower",
+                      case = LOWER,
                       handleIndefiniteArticle = true,
                       label = "Enter a review period",
                       name = "alternativeReviewPeriod",
-                      type = "text",
+                      type = TEXT,
                     ),
                   ),
                 ),
                 value = "Other",
               ),
             ),
-            type = "radio",
+            type = RADIO,
           ),
         ),
         requiresInput = true,
@@ -477,17 +485,17 @@ val POLICY_V1_0 = LicencePolicy(
           Input(
             label = "Enter the curfew address",
             name = "curfewAddress",
-            type = "address",
+            type = ADDRESS,
           ),
           Input(
             label = "Enter the curfew start time",
             name = "curfewStart",
-            type = "timePicker",
+            type = TIME_PICKER,
           ),
           Input(
             label = "Enter the curfew end time",
             name = "curfewEnd",
-            type = "timePicker",
+            type = TIME_PICKER,
           ),
         ),
         requiresInput = true,
@@ -503,12 +511,12 @@ val POLICY_V1_0 = LicencePolicy(
           Input(
             label = "Enter the name of the area shown on the map",
             name = "outOfBoundArea",
-            type = "text",
+            type = TEXT,
           ),
           Input(
             label = "Select a PDF map of the area this person must not enter",
             name = "outOfBoundFilename",
-            type = "fileUpload",
+            type = FILE_UPLOAD,
           ),
         ),
         requiresInput = true,
@@ -524,12 +532,12 @@ val POLICY_V1_0 = LicencePolicy(
           Input(
             label = "Enter name or type of premises",
             name = "nameOfPremises",
-            type = "text",
+            type = TEXT,
           ),
           Input(
             label = "Enter the address of the premises",
             name = "premisesAddress",
-            type = "address",
+            type = ADDRESS,
           ),
         ),
         requiresInput = true,
@@ -542,10 +550,10 @@ val POLICY_V1_0 = LicencePolicy(
         code = "c4a17002-88a3-43b4-b3f7-82ff476cb217",
         inputs = listOf(
           Input(
-            case = "lower",
+            case = LOWER,
             label = "Enter area or type of premises",
             name = "typeOfPremises",
-            type = "text",
+            type = TEXT,
           ),
         ),
         requiresInput = true,
@@ -571,18 +579,18 @@ val POLICY_V1_0 = LicencePolicy(
         code = "4673ebe4-9fc0-4e48-87c9-eb17d5280867",
         inputs = listOf(
           Input(
-            case = "capitalised",
+            case = CAPITALISED,
             label = "Enter name of approved premises",
             name = "approvedPremises",
-            type = "text",
+            type = TEXT,
           ),
           Input(
             label = "Enter a reporting time",
             name = "reportingTime",
-            type = "timePicker",
+            type = TIME_PICKER,
           ),
           Input(
-            case = "lower",
+            case = LOWER,
             handleIndefiniteArticle = true,
             label = "Select a review period",
             name = "reviewPeriod",
@@ -593,18 +601,18 @@ val POLICY_V1_0 = LicencePolicy(
                 conditional = Conditional(
                   inputs = listOf(
                     ConditionalInput(
-                      case = "lower",
+                      case = LOWER,
                       handleIndefiniteArticle = true,
                       label = "Enter a review period",
                       name = "alternativeReviewPeriod",
-                      type = "text",
+                      type = TEXT,
                     ),
                   ),
                 ),
                 value = "Other",
               ),
             ),
-            type = "radio",
+            type = RADIO,
           ),
         ),
         requiresInput = true,
@@ -618,18 +626,18 @@ val POLICY_V1_0 = LicencePolicy(
         code = "2027ae19-04a2-4fa6-8d1b-a62dffba2e62",
         inputs = listOf(
           Input(
-            case = "capitalised",
+            case = CAPITALISED,
             label = "Enter name of police station",
             name = "policeStation",
-            type = "text",
+            type = TEXT,
           ),
           Input(
             label = "Enter a reporting time",
             name = "reportingTime",
-            type = "timePicker",
+            type = TIME_PICKER,
           ),
           Input(
-            case = "lower",
+            case = LOWER,
             handleIndefiniteArticle = true,
             label = "Select a review period",
             name = "reviewPeriod",
@@ -640,18 +648,18 @@ val POLICY_V1_0 = LicencePolicy(
                 conditional = Conditional(
                   inputs = listOf(
                     ConditionalInput(
-                      case = "lower",
+                      case = LOWER,
                       handleIndefiniteArticle = true,
                       label = "Enter a review period",
                       name = "alternativeReviewPeriod",
-                      type = "text",
+                      type = TEXT,
                     ),
                   ),
                 ),
                 value = "Other",
               ),
             ),
-            type = "radio",
+            type = RADIO,
           ),
         ),
         requiresInput = true,
@@ -709,12 +717,12 @@ val POLICY_V1_0 = LicencePolicy(
           Input(
             label = "Enter name of organisation",
             name = "name",
-            type = "text",
+            type = TEXT,
           ),
           Input(
             label = "Enter address",
             name = "address",
-            type = "address",
+            type = ADDRESS,
           ),
         ),
         requiresInput = true,
@@ -738,7 +746,7 @@ val POLICY_V1_0 = LicencePolicy(
               Option("alcohol monitoring"),
               Option("alcohol abstinence"),
             ),
-            type = "check",
+            type = CHECK,
           ),
         ),
         requiresInput = true,
@@ -753,7 +761,7 @@ val POLICY_V1_0 = LicencePolicy(
           Input(
             label = "Enter the end date",
             name = "endDate",
-            type = "datePicker",
+            type = DATE_PICKER,
           ),
         ),
         requiresInput = true,
@@ -768,7 +776,7 @@ val POLICY_V1_0 = LicencePolicy(
           Input(
             label = "Enter the approved address",
             name = "approvedAddress",
-            type = "address",
+            type = ADDRESS,
           ),
         ),
         requiresInput = true,
@@ -783,12 +791,12 @@ val POLICY_V1_0 = LicencePolicy(
           Input(
             label = "Enter the timeframe",
             name = "timeframe",
-            type = "text",
+            type = TEXT,
           ),
           Input(
             label = "Enter the end date",
             name = "endDate",
-            type = "datePicker",
+            type = DATE_PICKER,
           ),
         ),
         requiresInput = true,
@@ -802,22 +810,22 @@ val POLICY_V1_0 = LicencePolicy(
         category = "Drug appointment",
         code = "62c83b80-2223-4562-a195-0670f4072088",
         inputs = listOf(
-          PssInput(
+          Input(
             includeBefore = " at ",
             label = "Enter time (optional)",
             name = "appointmentTime",
-            type = "timePicker",
+            type = TIME_PICKER,
           ),
-          PssInput(
+          Input(
             includeBefore = " on ",
             label = "Enter date (optional)",
             name = "appointmentDate",
-            type = "datePicker",
+            type = DATE_PICKER,
           ),
-          PssInput(
+          Input(
             label = "Enter the address for the appointment",
             name = "appointmentAddress",
-            type = "address",
+            type = ADDRESS,
           ),
         ),
         pssDates = true,
@@ -830,15 +838,15 @@ val POLICY_V1_0 = LicencePolicy(
         category = "Drug testing",
         code = "fda24aa9-a2b0-4d49-9c87-23b0a7be4013",
         inputs = listOf(
-          PssInput(
+          Input(
             label = "Enter name",
             name = "name",
-            type = "text",
+            type = TEXT,
           ),
-          PssInput(
+          Input(
             label = "Enter address",
             name = "address",
-            type = "address",
+            type = ADDRESS,
           ),
         ),
         requiresInput = true,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/policies/PolicyV2.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/policies/PolicyV2.kt
@@ -7,12 +7,20 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.Additi
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.Conditional
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.ConditionalInput
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.Input
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.InputType.ADDRESS
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.InputType.CHECK
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.InputType.DATE_PICKER
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.InputType.FILE_UPLOAD
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.InputType.RADIO
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.InputType.TEXT
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.InputType.TIME_PICKER
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.LicencePolicy
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.Option
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.PssInput
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.StandardConditionAp
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.StandardConditionPss
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.StandardConditions
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.Case.CAPITALISED
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.Case.LOWER
 
 val POLICY_V2_0 = LicencePolicy(
   additionalConditions = AdditionalConditions(
@@ -38,7 +46,7 @@ val POLICY_V2_0 = LicencePolicy(
               Option("Kent, Surrey and Sussex"),
               Option("Wales"),
             ),
-            type = "radio",
+            type = RADIO,
           ),
         ),
         requiresInput = true,
@@ -51,7 +59,7 @@ val POLICY_V2_0 = LicencePolicy(
         code = "fce34fb2-02f4-4eb0-9b8d-d091e11451fa",
         inputs = listOf(
           Input(
-            case = "lower",
+            case = LOWER,
             label = "Select the relevant text",
             name = "gender",
             options = listOf(
@@ -59,7 +67,7 @@ val POLICY_V2_0 = LicencePolicy(
               Option("any female"),
               Option("any male"),
             ),
-            type = "radio",
+            type = RADIO,
           ),
           Input(
             label = "Select the relevant age",
@@ -68,7 +76,7 @@ val POLICY_V2_0 = LicencePolicy(
               Option("16"),
               Option("18"),
             ),
-            type = "radio",
+            type = RADIO,
           ),
         ),
         requiresInput = true,
@@ -82,7 +90,7 @@ val POLICY_V2_0 = LicencePolicy(
         code = "b72fdbf2-0dc9-4e7f-81e4-c2ccb5d1bc90",
         inputs = listOf(
           Input(
-            case = "lower",
+            case = LOWER,
             label = "Select all the relevant options",
             listType = "AND",
             name = "appointmentType",
@@ -91,7 +99,7 @@ val POLICY_V2_0 = LicencePolicy(
               Option("Psychologist"),
               Option("Medical practitioner"),
             ),
-            type = "check",
+            type = CHECK,
           ),
         ),
         requiresInput = true,
@@ -115,18 +123,18 @@ val POLICY_V2_0 = LicencePolicy(
             includeBefore = " at ",
             label = "Enter time (optional)",
             name = "appointmentTime",
-            type = "timePicker",
+            type = TIME_PICKER,
           ),
           Input(
             includeBefore = " on ",
             label = "Enter date (optional)",
             name = "appointmentDate",
-            type = "datePicker",
+            type = DATE_PICKER,
           ),
           Input(
             label = "Enter the address for the appointment",
             name = "appointmentAddress",
-            type = "address",
+            type = ADDRESS,
           ),
         ),
         requiresInput = true,
@@ -148,18 +156,18 @@ val POLICY_V2_0 = LicencePolicy(
         inputs = listOf(
           Input(
             addAnother = AddAnother("Add another person"),
-            case = "capitalise",
+            case = CAPITALISED,
             label = "Enter name of victim or family member",
             listType = "OR",
             name = "name",
-            type = "text",
+            type = TEXT,
           ),
           Input(
-            case = "capitalise",
+            case = CAPITALISED,
             includeBefore = " and / or ",
             label = "Enter social services department (optional)",
             name = "socialServicesDepartment",
-            type = "text",
+            type = TEXT,
           ),
         ),
         requiresInput = true,
@@ -173,7 +181,7 @@ val POLICY_V2_0 = LicencePolicy(
         code = "4a5fed48-0fb9-4711-8ddf-b46ddfd90246",
         inputs = listOf(
           Input(
-            case = "lower",
+            case = LOWER,
             label = "Select the relevant gender",
             name = "gender",
             options = listOf(
@@ -181,7 +189,7 @@ val POLICY_V2_0 = LicencePolicy(
               Option("any female"),
               Option("any male"),
             ),
-            type = "radio",
+            type = RADIO,
           ),
           Input(
             label = "Select the relevant age",
@@ -190,14 +198,14 @@ val POLICY_V2_0 = LicencePolicy(
               Option("16 years"),
               Option("18 years"),
             ),
-            type = "radio",
+            type = RADIO,
           ),
           Input(
-            case = "capitalise",
+            case = CAPITALISED,
             includeBefore = " and / or ",
             label = "Enter social services department (optional)",
             name = "socialServicesDepartment",
-            type = "text",
+            type = TEXT,
           ),
         ),
         requiresInput = true,
@@ -212,11 +220,11 @@ val POLICY_V2_0 = LicencePolicy(
         inputs = listOf(
           Input(
             addAnother = AddAnother("Add another person"),
-            case = "capitalise",
+            case = CAPITALISED,
             label = "Enter name of offender or individual",
             listType = "OR",
             name = "nameOfIndividual",
-            type = "text",
+            type = TEXT,
           ),
         ),
         requiresInput = true,
@@ -248,7 +256,7 @@ val POLICY_V2_0 = LicencePolicy(
             label = "Enter the name of group or organisation",
             listType = "OR",
             name = "nameOfOrganisation",
-            type = "text",
+            type = TEXT,
           ),
         ),
         requiresInput = true,
@@ -277,13 +285,13 @@ val POLICY_V2_0 = LicencePolicy(
               Option("prolific offending behaviour"),
               Option("offending behaviour"),
             ),
-            type = "check",
+            type = CHECK,
           ),
           Input(
             includeBefore = " at the ",
             label = "Enter name of course or centre (optional)",
             name = "course",
-            type = "text",
+            type = TEXT,
           ),
         ),
         requiresInput = true,
@@ -303,7 +311,7 @@ val POLICY_V2_0 = LicencePolicy(
               Option("16 years"),
               Option("18 years"),
             ),
-            type = "radio",
+            type = RADIO,
           ),
         ),
         requiresInput = true,
@@ -371,7 +379,7 @@ val POLICY_V2_0 = LicencePolicy(
             label = "Enter the name of the item",
             listType = "OR",
             name = "item",
-            type = "text",
+            type = TEXT,
           ),
         ),
         requiresInput = true,
@@ -390,7 +398,7 @@ val POLICY_V2_0 = LicencePolicy(
         code = "db2d7e24-b130-4c7e-a1bf-6bb5f3036c02",
         inputs = listOf(
           Input(
-            case = "lower",
+            case = LOWER,
             label = "Select the relevant text",
             name = "gender",
             options = listOf(
@@ -398,7 +406,7 @@ val POLICY_V2_0 = LicencePolicy(
               Option("women"),
               Option("women or men"),
             ),
-            type = "radio",
+            type = RADIO,
           ),
         ),
         requiresInput = true,
@@ -431,15 +439,15 @@ val POLICY_V2_0 = LicencePolicy(
           Input(
             label = "Enter the curfew start time",
             name = "curfewStart",
-            type = "timePicker",
+            type = TIME_PICKER,
           ),
           Input(
             label = "Enter the curfew end time",
             name = "curfewEnd",
-            type = "timePicker",
+            type = TIME_PICKER,
           ),
           Input(
-            case = "lower",
+            case = LOWER,
             handleIndefiniteArticle = true,
             label = "Select a review period",
             name = "reviewPeriod",
@@ -450,18 +458,18 @@ val POLICY_V2_0 = LicencePolicy(
                 conditional = Conditional(
                   inputs = listOf(
                     ConditionalInput(
-                      case = "lower",
+                      case = LOWER,
                       handleIndefiniteArticle = true,
                       label = "Enter a review period",
                       name = "alternativeReviewPeriod",
-                      type = "text",
+                      type = TEXT,
                     ),
                   ),
                 ),
                 value = "Other",
               ),
             ),
-            type = "radio",
+            type = RADIO,
           ),
         ),
         requiresInput = true,
@@ -477,17 +485,17 @@ val POLICY_V2_0 = LicencePolicy(
           Input(
             label = "Enter the curfew address",
             name = "curfewAddress",
-            type = "address",
+            type = ADDRESS,
           ),
           Input(
             label = "Enter the curfew start time",
             name = "curfewStart",
-            type = "timePicker",
+            type = TIME_PICKER,
           ),
           Input(
             label = "Enter the curfew end time",
             name = "curfewEnd",
-            type = "timePicker",
+            type = TIME_PICKER,
           ),
         ),
         requiresInput = true,
@@ -503,12 +511,12 @@ val POLICY_V2_0 = LicencePolicy(
           Input(
             label = "Enter the name of the area shown on the map",
             name = "outOfBoundArea",
-            type = "text",
+            type = TEXT,
           ),
           Input(
             label = "Select a PDF map of the area this person must not enter",
             name = "outOfBoundFilename",
-            type = "fileUpload",
+            type = FILE_UPLOAD,
           ),
         ),
         requiresInput = true,
@@ -523,12 +531,12 @@ val POLICY_V2_0 = LicencePolicy(
           Input(
             label = "Enter name or type of premises",
             name = "nameOfPremises",
-            type = "text",
+            type = TEXT,
           ),
           Input(
             label = "Enter the address of the premises",
             name = "premisesAddress",
-            type = "address",
+            type = ADDRESS,
           ),
         ),
         requiresInput = true,
@@ -541,10 +549,10 @@ val POLICY_V2_0 = LicencePolicy(
         code = "c4a17002-88a3-43b4-b3f7-82ff476cb217",
         inputs = listOf(
           Input(
-            case = "lower",
+            case = LOWER,
             label = "Enter area or type of premises",
             name = "typeOfPremises",
-            type = "text",
+            type = TEXT,
           ),
         ),
         requiresInput = true,
@@ -570,18 +578,18 @@ val POLICY_V2_0 = LicencePolicy(
         code = "4673ebe4-9fc0-4e48-87c9-eb17d5280867",
         inputs = listOf(
           Input(
-            case = "capitalised",
+            case = CAPITALISED,
             label = "Enter name of approved premises",
             name = "approvedPremises",
-            type = "text",
+            type = TEXT,
           ),
           Input(
             label = "Enter a reporting time",
             name = "reportingTime",
-            type = "timePicker",
+            type = TIME_PICKER,
           ),
           Input(
-            case = "lower",
+            case = LOWER,
             handleIndefiniteArticle = true,
             label = "Select a review period",
             name = "reviewPeriod",
@@ -592,18 +600,18 @@ val POLICY_V2_0 = LicencePolicy(
                 conditional = Conditional(
                   inputs = listOf(
                     ConditionalInput(
-                      case = "lower",
+                      case = LOWER,
                       handleIndefiniteArticle = true,
                       label = "Enter a review period",
                       name = "alternativeReviewPeriod",
-                      type = "text",
+                      type = TEXT,
                     ),
                   ),
                 ),
                 value = "Other",
               ),
             ),
-            type = "radio",
+            type = RADIO,
           ),
         ),
         requiresInput = true,
@@ -617,18 +625,18 @@ val POLICY_V2_0 = LicencePolicy(
         code = "2027ae19-04a2-4fa6-8d1b-a62dffba2e62",
         inputs = listOf(
           Input(
-            case = "capitalised",
+            case = CAPITALISED,
             label = "Enter name of police station",
             name = "policeStation",
-            type = "text",
+            type = TEXT,
           ),
           Input(
             label = "Enter a reporting time",
             name = "reportingTime",
-            type = "timePicker",
+            type = TIME_PICKER,
           ),
           Input(
-            case = "lower",
+            case = LOWER,
             handleIndefiniteArticle = true,
             label = "Select a review period",
             name = "reviewPeriod",
@@ -639,18 +647,18 @@ val POLICY_V2_0 = LicencePolicy(
                 conditional = Conditional(
                   inputs = listOf(
                     ConditionalInput(
-                      case = "lower",
+                      case = LOWER,
                       handleIndefiniteArticle = true,
                       label = "Enter a review period",
                       name = "alternativeReviewPeriod",
-                      type = "text",
+                      type = TEXT,
                     ),
                   ),
                 ),
                 value = "Other",
               ),
             ),
-            type = "radio",
+            type = RADIO,
           ),
         ),
         requiresInput = true,
@@ -708,12 +716,12 @@ val POLICY_V2_0 = LicencePolicy(
           Input(
             label = "Enter name of organisation",
             name = "name",
-            type = "text",
+            type = TEXT,
           ),
           Input(
             label = "Enter address",
             name = "address",
-            type = "address",
+            type = ADDRESS,
           ),
         ),
         requiresInput = true,
@@ -737,7 +745,7 @@ val POLICY_V2_0 = LicencePolicy(
               Option("alcohol monitoring"),
               Option("alcohol abstinence"),
             ),
-            type = "check",
+            type = CHECK,
           ),
         ),
         requiresInput = true,
@@ -752,7 +760,7 @@ val POLICY_V2_0 = LicencePolicy(
           Input(
             label = "Enter the end date",
             name = "endDate",
-            type = "datePicker",
+            type = DATE_PICKER,
           ),
         ),
         requiresInput = true,
@@ -767,7 +775,7 @@ val POLICY_V2_0 = LicencePolicy(
           Input(
             label = "Enter the approved address",
             name = "approvedAddress",
-            type = "address",
+            type = ADDRESS,
           ),
         ),
         requiresInput = true,
@@ -782,12 +790,12 @@ val POLICY_V2_0 = LicencePolicy(
           Input(
             label = "Enter the timeframe",
             name = "timeframe",
-            type = "text",
+            type = TEXT,
           ),
           Input(
             label = "Enter the end date",
             name = "endDate",
-            type = "datePicker",
+            type = DATE_PICKER,
           ),
         ),
         requiresInput = true,
@@ -807,22 +815,22 @@ val POLICY_V2_0 = LicencePolicy(
         category = "Drug appointment",
         code = "62c83b80-2223-4562-a195-0670f4072088",
         inputs = listOf(
-          PssInput(
+          Input(
             includeBefore = " at ",
             label = "Enter time (optional)",
             name = "appointmentTime",
-            type = "timePicker",
+            type = TIME_PICKER,
           ),
-          PssInput(
+          Input(
             includeBefore = " on ",
             label = "Enter date (optional)",
             name = "appointmentDate",
-            type = "datePicker",
+            type = DATE_PICKER,
           ),
-          PssInput(
+          Input(
             label = "Enter the address for the appointment",
             name = "appointmentAddress",
-            type = "address",
+            type = ADDRESS,
           ),
         ),
         pssDates = true,
@@ -835,15 +843,15 @@ val POLICY_V2_0 = LicencePolicy(
         category = "Drug testing",
         code = "fda24aa9-a2b0-4d49-9c87-23b0a7be4013",
         inputs = listOf(
-          PssInput(
+          Input(
             label = "Enter name",
             name = "name",
-            type = "text",
+            type = TEXT,
           ),
-          PssInput(
+          Input(
             label = "Enter address",
             name = "address",
-            type = "address",
+            type = ADDRESS,
           ),
         ),
         requiresInput = true,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/policies/PolicyV2Dot1.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/policies/PolicyV2Dot1.kt
@@ -8,12 +8,20 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.Change
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.Conditional
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.ConditionalInput
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.Input
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.InputType.ADDRESS
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.InputType.CHECK
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.InputType.DATE_PICKER
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.InputType.FILE_UPLOAD
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.InputType.RADIO
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.InputType.TEXT
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.InputType.TIME_PICKER
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.LicencePolicy
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.Option
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.PssInput
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.StandardConditionAp
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.StandardConditionPss
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.StandardConditions
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.Case.CAPITALISED
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.Case.LOWER
 
 val POLICY_V2_1 = LicencePolicy(
   additionalConditions = AdditionalConditions(
@@ -63,7 +71,7 @@ val POLICY_V2_1 = LicencePolicy(
                 value = "Wales",
               ),
             ),
-            type = "radio",
+            type = RADIO,
           ),
         ),
         requiresInput = true,
@@ -76,7 +84,7 @@ val POLICY_V2_1 = LicencePolicy(
         code = "fce34fb2-02f4-4eb0-9b8d-d091e11451fa",
         inputs = listOf(
           Input(
-            case = "lower",
+            case = LOWER,
             label = "Select the relevant text",
             name = "gender",
             options = listOf(
@@ -90,7 +98,7 @@ val POLICY_V2_1 = LicencePolicy(
                 value = "any male",
               ),
             ),
-            type = "radio",
+            type = RADIO,
           ),
           Input(
             label = "Select the relevant age",
@@ -103,7 +111,7 @@ val POLICY_V2_1 = LicencePolicy(
                 value = "18",
               ),
             ),
-            type = "radio",
+            type = RADIO,
           ),
         ),
         requiresInput = true,
@@ -146,18 +154,18 @@ val POLICY_V2_1 = LicencePolicy(
         inputs = listOf(
           Input(
             addAnother = AddAnother("Add another person"),
-            case = "capitalise",
+            case = CAPITALISED,
             label = "Enter name of victim or family member",
             listType = "OR",
             name = "name",
-            type = "text",
+            type = TEXT,
           ),
           Input(
-            case = "capitalise",
+            case = CAPITALISED,
             includeBefore = " and / or ",
             label = "Enter social services department (optional)",
             name = "socialServicesDepartment",
-            type = "text",
+            type = TEXT,
           ),
         ),
         requiresInput = true,
@@ -171,7 +179,7 @@ val POLICY_V2_1 = LicencePolicy(
         code = "4a5fed48-0fb9-4711-8ddf-b46ddfd90246",
         inputs = listOf(
           Input(
-            case = "lower",
+            case = LOWER,
             label = "Select the relevant gender",
             name = "gender",
             options = listOf(
@@ -185,7 +193,7 @@ val POLICY_V2_1 = LicencePolicy(
                 value = "any male",
               ),
             ),
-            type = "radio",
+            type = RADIO,
           ),
           Input(
             label = "Select the relevant age",
@@ -198,14 +206,14 @@ val POLICY_V2_1 = LicencePolicy(
                 value = "18 years",
               ),
             ),
-            type = "radio",
+            type = RADIO,
           ),
           Input(
-            case = "capitalise",
+            case = CAPITALISED,
             includeBefore = " and / or ",
             label = "Enter social services department (optional)",
             name = "socialServicesDepartment",
-            type = "text",
+            type = TEXT,
           ),
         ),
         requiresInput = true,
@@ -220,11 +228,11 @@ val POLICY_V2_1 = LicencePolicy(
         inputs = listOf(
           Input(
             addAnother = AddAnother("Add another person"),
-            case = "capitalise",
+            case = CAPITALISED,
             label = "Enter name of offender or individual",
             listType = "OR",
             name = "nameOfIndividual",
-            type = "text",
+            type = TEXT,
           ),
         ),
         requiresInput = true,
@@ -256,7 +264,7 @@ val POLICY_V2_1 = LicencePolicy(
             label = "Enter the name of group or organisation",
             listType = "OR",
             name = "nameOfOrganisation",
-            type = "text",
+            type = TEXT,
           ),
         ),
         requiresInput = true,
@@ -305,7 +313,7 @@ val POLICY_V2_1 = LicencePolicy(
                 value = "offending behaviour",
               ),
             ),
-            type = "check",
+            type = CHECK,
           ),
         ),
         requiresInput = true,
@@ -329,7 +337,7 @@ val POLICY_V2_1 = LicencePolicy(
                 value = "18 years",
               ),
             ),
-            type = "radio",
+            type = RADIO,
           ),
         ),
         requiresInput = true,
@@ -404,7 +412,7 @@ val POLICY_V2_1 = LicencePolicy(
             label = "Enter the name of the item",
             listType = "OR",
             name = "item",
-            type = "text",
+            type = TEXT,
           ),
         ),
         requiresInput = true,
@@ -449,15 +457,15 @@ val POLICY_V2_1 = LicencePolicy(
           Input(
             label = "Enter the curfew start time",
             name = "curfewStart",
-            type = "timePicker",
+            type = TIME_PICKER,
           ),
           Input(
             label = "Enter the curfew end time",
             name = "curfewEnd",
-            type = "timePicker",
+            type = TIME_PICKER,
           ),
           Input(
-            case = "lower",
+            case = LOWER,
             handleIndefiniteArticle = true,
             label = "Select a review period",
             name = "reviewPeriod",
@@ -472,18 +480,18 @@ val POLICY_V2_1 = LicencePolicy(
                 conditional = Conditional(
                   inputs = listOf(
                     ConditionalInput(
-                      case = "lower",
+                      case = LOWER,
                       handleIndefiniteArticle = true,
                       label = "Enter a review period",
                       name = "alternativeReviewPeriod",
-                      type = "text",
+                      type = TEXT,
                     ),
                   ),
                 ),
                 value = "Other",
               ),
             ),
-            type = "radio",
+            type = RADIO,
           ),
         ),
         requiresInput = true,
@@ -499,12 +507,12 @@ val POLICY_V2_1 = LicencePolicy(
           Input(
             label = "Enter the name of the area shown on the map",
             name = "outOfBoundArea",
-            type = "text",
+            type = TEXT,
           ),
           Input(
             label = "Select a PDF map of the area this person must not enter",
             name = "outOfBoundFilename",
-            type = "fileUpload",
+            type = FILE_UPLOAD,
           ),
         ),
         requiresInput = true,
@@ -519,12 +527,12 @@ val POLICY_V2_1 = LicencePolicy(
           Input(
             label = "Enter name or type of premises",
             name = "nameOfPremises",
-            type = "text",
+            type = TEXT,
           ),
           Input(
             label = "Enter the address of the premises",
             name = "premisesAddress",
-            type = "address",
+            type = ADDRESS,
           ),
         ),
         requiresInput = true,
@@ -537,10 +545,10 @@ val POLICY_V2_1 = LicencePolicy(
         code = "c4a17002-88a3-43b4-b3f7-82ff476cb217",
         inputs = listOf(
           Input(
-            case = "lower",
+            case = LOWER,
             label = "Enter area or type of premises",
             name = "typeOfPremises",
-            type = "text",
+            type = TEXT,
           ),
         ),
         requiresInput = true,
@@ -566,10 +574,10 @@ val POLICY_V2_1 = LicencePolicy(
         code = "4673ebe4-9fc0-4e48-87c9-eb17d5280867",
         inputs = listOf(
           Input(
-            case = "capitalised",
+            case = CAPITALISED,
             label = "Enter name of approved premises",
             name = "approvedPremises",
-            type = "text",
+            type = TEXT,
           ),
           Input(
             label = "Select when the person needs to report",
@@ -585,17 +593,16 @@ val POLICY_V2_1 = LicencePolicy(
                 conditional = Conditional(
                   inputs = listOf(
                     ConditionalInput(
-                      case = "capitalise",
                       label = "Enter the other frequency",
                       name = "alternativeReportingFrequency",
-                      type = "text",
+                      type = TEXT,
                     ),
                   ),
                 ),
                 value = "Other",
               ),
             ),
-            type = "radio",
+            type = RADIO,
           ),
           Input(
             label = "Select how many times each day they need to report",
@@ -607,7 +614,7 @@ val POLICY_V2_1 = LicencePolicy(
                     ConditionalInput(
                       label = "Enter the reporting time",
                       name = "reportingTime",
-                      type = "timePicker",
+                      type = TIME_PICKER,
                     ),
                   ),
                 ),
@@ -619,13 +626,13 @@ val POLICY_V2_1 = LicencePolicy(
                     ConditionalInput(
                       label = "Enter the first reporting time",
                       name = "reportingTime1",
-                      type = "timePicker",
+                      type = TIME_PICKER,
                     ),
                     ConditionalInput(
                       includeBefore = " and ",
                       label = "Enter the second reporting time",
                       name = "reportingTime2",
-                      type = "timePicker",
+                      type = TIME_PICKER,
                     ),
                   ),
                 ),
@@ -633,10 +640,10 @@ val POLICY_V2_1 = LicencePolicy(
               ),
             ),
             subtext = "If you want to add more than 2 reporting times per day, this must be done as a bespoke condition approved by PPCS.",
-            type = "radio",
+            type = RADIO,
           ),
           Input(
-            case = "lower",
+            case = LOWER,
             handleIndefiniteArticle = true,
             label = "Select a review period",
             name = "reviewPeriod",
@@ -651,18 +658,18 @@ val POLICY_V2_1 = LicencePolicy(
                 conditional = Conditional(
                   inputs = listOf(
                     ConditionalInput(
-                      case = "lower",
+                      case = LOWER,
                       handleIndefiniteArticle = true,
                       label = "Enter a review period",
                       name = "alternativeReviewPeriod",
-                      type = "text",
+                      type = TEXT,
                     ),
                   ),
                 ),
                 value = "Other",
               ),
             ),
-            type = "radio",
+            type = RADIO,
           ),
         ),
         requiresInput = true,
@@ -676,10 +683,10 @@ val POLICY_V2_1 = LicencePolicy(
         code = "2027ae19-04a2-4fa6-8d1b-a62dffba2e62",
         inputs = listOf(
           Input(
-            case = "capitalised",
+            case = CAPITALISED,
             label = "Enter name of police station",
             name = "policeStation",
-            type = "text",
+            type = TEXT,
           ),
           Input(
             label = "Select when the person needs to report",
@@ -695,17 +702,16 @@ val POLICY_V2_1 = LicencePolicy(
                 conditional = Conditional(
                   inputs = listOf(
                     ConditionalInput(
-                      case = "capitalise",
                       label = "Enter the other frequency",
                       name = "alternativeReportingFrequency",
-                      type = "text",
+                      type = TEXT,
                     ),
                   ),
                 ),
                 value = "Other",
               ),
             ),
-            type = "radio",
+            type = RADIO,
           ),
           Input(
             label = "Select how many times each day they need to report",
@@ -717,7 +723,7 @@ val POLICY_V2_1 = LicencePolicy(
                     ConditionalInput(
                       label = "Enter the reporting time",
                       name = "reportingTime",
-                      type = "timePicker",
+                      type = TIME_PICKER,
                     ),
                   ),
                 ),
@@ -729,13 +735,13 @@ val POLICY_V2_1 = LicencePolicy(
                     ConditionalInput(
                       label = "Enter the first reporting time",
                       name = "reportingTime1",
-                      type = "timePicker",
+                      type = TIME_PICKER,
                     ),
                     ConditionalInput(
                       includeBefore = " and ",
                       label = "Enter the second reporting time",
                       name = "reportingTime2",
-                      type = "timePicker",
+                      type = TIME_PICKER,
                     ),
                   ),
                 ),
@@ -743,10 +749,10 @@ val POLICY_V2_1 = LicencePolicy(
               ),
             ),
             subtext = "If you want to add more than 2 reporting times per day, this must be done as a bespoke condition approved by PPCS.",
-            type = "radio",
+            type = RADIO,
           ),
           Input(
-            case = "lower",
+            case = LOWER,
             handleIndefiniteArticle = true,
             label = "Select a review period",
             name = "reviewPeriod",
@@ -761,18 +767,18 @@ val POLICY_V2_1 = LicencePolicy(
                 conditional = Conditional(
                   inputs = listOf(
                     ConditionalInput(
-                      case = "lower",
+                      case = LOWER,
                       handleIndefiniteArticle = true,
                       label = "Enter a review period",
                       name = "alternativeReviewPeriod",
-                      type = "text",
+                      type = TEXT,
                     ),
                   ),
                 ),
                 value = "Other",
               ),
             ),
-            type = "radio",
+            type = RADIO,
           ),
         ),
         requiresInput = true,
@@ -857,7 +863,7 @@ val POLICY_V2_1 = LicencePolicy(
                 value = "alcohol abstinence",
               ),
             ),
-            type = "check",
+            type = CHECK,
           ),
         ),
         requiresInput = true,
@@ -872,7 +878,7 @@ val POLICY_V2_1 = LicencePolicy(
           Input(
             label = "Enter the end date",
             name = "endDate",
-            type = "datePicker",
+            type = DATE_PICKER,
           ),
         ),
         requiresInput = true,
@@ -887,7 +893,7 @@ val POLICY_V2_1 = LicencePolicy(
           Input(
             label = "Enter the approved address",
             name = "approvedAddress",
-            type = "address",
+            type = ADDRESS,
           ),
         ),
         requiresInput = true,
@@ -902,7 +908,7 @@ val POLICY_V2_1 = LicencePolicy(
           Input(
             label = "Enter the end date",
             name = "endDate",
-            type = "datePicker",
+            type = DATE_PICKER,
           ),
         ),
         requiresInput = true,
@@ -917,7 +923,7 @@ val POLICY_V2_1 = LicencePolicy(
           Input(
             label = "Enter the end date",
             name = "endDate",
-            type = "datePicker",
+            type = DATE_PICKER,
           ),
         ),
         requiresInput = true,
@@ -937,22 +943,22 @@ val POLICY_V2_1 = LicencePolicy(
         category = "Drug appointment",
         code = "62c83b80-2223-4562-a195-0670f4072088",
         inputs = listOf(
-          PssInput(
+          Input(
             includeBefore = " at ",
             label = "Enter time (optional)",
             name = "appointmentTime",
-            type = "timePicker",
+            type = TIME_PICKER,
           ),
-          PssInput(
+          Input(
             includeBefore = " on ",
             label = "Enter date (optional)",
             name = "appointmentDate",
-            type = "datePicker",
+            type = DATE_PICKER,
           ),
-          PssInput(
+          Input(
             label = "Enter the address for the appointment",
             name = "appointmentAddress",
-            type = "address",
+            type = ADDRESS,
           ),
         ),
         pssDates = true,
@@ -965,15 +971,15 @@ val POLICY_V2_1 = LicencePolicy(
         category = "Drug testing",
         code = "fda24aa9-a2b0-4d49-9c87-23b0a7be4013",
         inputs = listOf(
-          PssInput(
+          Input(
             label = "Enter name",
             name = "name",
-            type = "text",
+            type = TEXT,
           ),
-          PssInput(
+          Input(
             label = "Enter address",
             name = "address",
-            type = "address",
+            type = ADDRESS,
           ),
         ),
         requiresInput = true,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ConditionFormatterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ConditionFormatterTest.kt
@@ -1,0 +1,1043 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.AdditionalCondition
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.AdditionalConditionData
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.Licence
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.AdditionalConditionAp
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.Conditional
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.ConditionalInput
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.Input
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.InputType.ADDRESS
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.InputType.CHECK
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.InputType.DATE_PICKER
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.InputType.RADIO
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.InputType.TEXT
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.InputType.TIME_PICKER
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.Option
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.Case.CAPITALISED
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.Case.LOWER
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceType
+
+class ConditionFormatterTest {
+  private val conditionFormatter = ConditionFormatter()
+
+  @Test
+  fun `Will return text verbatim when no placeholders exist`() {
+    val conditionConfig = AdditionalConditionAp(
+      code = "ed607a91-fe3a-4816-8eb9-b447c945935c",
+      category = "Possession, ownership, control or inspection of specified items or documents",
+      text = "Not to own or use a camera without the prior approval of your supervising officer.",
+      requiresInput = false,
+      categoryShort = "Items and documents",
+      inputs = emptyList(),
+      tpl = null,
+      subtext = null,
+      type = null,
+    )
+
+    val result = conditionFormatter.format(conditionConfig, emptyList())
+    assertThat(result).isEqualTo("Not to own or use a camera without the prior approval of your supervising officer.")
+  }
+
+  @Test
+  fun `Will replace single placeholder with a single value`() {
+    val data = listOf(
+      AdditionalConditionData(
+        id = 1,
+        dataField = "probationRegion",
+        dataValue = "London",
+        dataSequence = 0,
+        additionalCondition = condition,
+      ),
+    )
+
+    val conditionConfig = AdditionalConditionAp(
+      code = "5db26ab3-9b6f-4bee-b2aa-53aa3f3be7dd",
+      category = "Residence at a specific place",
+      text =
+      "You must reside within the [INSERT REGION] while of no fixed abode, unless otherwise approved by your supervising officer.",
+      tpl =
+      "You must reside within the {probationRegion} probation region while of no fixed abode, unless otherwise approved by your supervising officer.",
+      requiresInput = true,
+      inputs = emptyList(),
+      categoryShort = null,
+      subtext = null,
+      type = null,
+    )
+
+    val result = conditionFormatter.format(conditionConfig, data)
+    assertThat(result).isEqualTo(
+      "You must reside within the London probation region while of no fixed abode, unless otherwise approved by your supervising officer.",
+    )
+  }
+
+  @Test
+  fun `Will remove optional placeholders that are not matched by data`() {
+    val data = listOf(
+      AdditionalConditionData(
+        id = 1,
+        dataField = "wrongName",
+        dataValue = "London",
+        dataSequence = 0,
+        additionalCondition = condition,
+      ),
+    )
+
+    val conditionConfig = AdditionalConditionAp(
+      code = "5db26ab3-9b6f-4bee-b2aa-53aa3f3be7dd",
+      category = "Residence at a specific place",
+      text =
+      "You must reside within the [INSERT REGION] while of no fixed abode, unless otherwise approved by your supervising officer.",
+      tpl =
+      "You must reside within the {probationRegion} probation region while of no fixed abode, unless otherwise approved by your supervising officer.",
+      requiresInput = true,
+      inputs = emptyList(),
+      categoryShort = null,
+      subtext = null,
+      type = null,
+    )
+
+    val result = conditionFormatter.format(conditionConfig, data)
+    assertThat(result).isEqualTo(
+      "You must reside within the  probation region while of no fixed abode, unless otherwise approved by your supervising officer.",
+    )
+  }
+
+  @Test
+  fun `Will replace placeholders of type number`() {
+    val data = listOf(
+      AdditionalConditionData(
+        id = 1,
+        dataField = "age",
+        dataValue = "18",
+        dataSequence = 0,
+        additionalCondition = condition,
+      ),
+    )
+
+    val conditionConfig = AdditionalConditionAp(
+      code = "5db26ab3-9b6f-4bee-b2aa-53aa3f3be7dd",
+      category = "Participation in, or co-operation with, a programme or set of activities",
+      text =
+      "Not to undertake work or other organised activity which will involve a person under the age of [INSERT AGE], either on a paid or unpaid basis without the prior approval of your supervising officer.",
+      tpl =
+      "Not to undertake work or other organised activity which will involve a person under the age of {age}, either on a paid or unpaid basis without the prior approval of your supervising officer.",
+      requiresInput = true,
+      inputs = emptyList(),
+      categoryShort = null,
+      subtext = null,
+      type = null,
+    )
+
+    val result = conditionFormatter.format(conditionConfig, data)
+    assertThat(result).isEqualTo(
+      "Not to undertake work or other organised activity which will involve a person under the age of 18, either on a paid or unpaid basis without the prior approval of your supervising officer.",
+    )
+  }
+
+  @Test
+  fun `Will replace multiple placeholders and adjust case to lower`() {
+    val data = listOf(
+      AdditionalConditionData(
+        id = 1,
+        dataField = "gender",
+        dataValue = "Any",
+        dataSequence = 0,
+        additionalCondition = condition,
+      ),
+      AdditionalConditionData(
+        id = 1,
+        dataField = "age",
+        dataValue = "18",
+        dataSequence = 1,
+        additionalCondition = condition,
+      ),
+    )
+
+    val conditionConfig = AdditionalConditionAp(
+      code = "5db26ab3-9b6f-4bee-b2aa-53aa3f3be7dd",
+      category = "Participation in, or co-operation with, a programme or set of activities",
+      text = "Not to reside (not even to stay for one night) in the same household as [ANY / ANY FEMALE / ANY MALE] child under the age of [INSERT AGE] without the prior approval of your supervising officer.",
+      tpl = "Not to reside (not even to stay for one night) in the same household as {gender} child under the age of {age} without the prior approval of your supervising officer.",
+      requiresInput = true,
+      inputs = listOf(
+        Input(
+          type = RADIO,
+          label = "Select the relevant text",
+          name = "gender",
+          case = LOWER,
+          listType = null,
+          options = emptyList(),
+          handleIndefiniteArticle = null,
+          addAnother = null,
+          includeBefore = null,
+          subtext = null,
+        ),
+      ),
+      categoryShort = null,
+      subtext = null,
+      type = null,
+    )
+
+    val result = conditionFormatter.format(conditionConfig, data)
+    assertThat(result).isEqualTo(
+      "Not to reside (not even to stay for one night) in the same household as any child under the age of 18 without the prior approval of your supervising officer.",
+    )
+  }
+
+  @Test
+  fun `Will remove any placeholders without data items`() {
+    val conditionConfig = AdditionalConditionAp(
+      code = "5db26ab3-9b6f-4bee-b2aa-53aa3f3be7dd",
+      category = "Participation in, or co-operation with, a programme or set of activities",
+      text = "Not to reside (not even to stay for one night) in the same household as [ANY / ANY FEMALE / ANY MALE] child under the age of [INSERT AGE] without the prior approval of your supervising officer.",
+      tpl = "Not to reside (not even to stay for one night) in the same household as {gender} child under the age of {age} without the prior approval of your supervising officer.",
+      requiresInput = true,
+      inputs = emptyList(),
+      categoryShort = null,
+      subtext = null,
+      type = null,
+    )
+
+    val result = conditionFormatter.format(conditionConfig, emptyList())
+    assertThat(result).isEqualTo(
+      "Not to reside (not even to stay for one night) in the same household as  child under the age of  without the prior approval of your supervising officer.",
+    )
+  }
+
+  @Test
+  fun `Will replace placeholders for a list with and 'and' between them and include optional text for optional values`() {
+    val data = listOf(
+      AdditionalConditionData(
+        id = 1,
+        dataField = "behaviourProblems",
+        dataValue = "alcohol",
+        dataSequence = 0,
+        additionalCondition = condition,
+      ),
+      AdditionalConditionData(
+        id = 1,
+        dataField = "behaviourProblems",
+        dataValue = "drug",
+        dataSequence = 1,
+        additionalCondition = condition,
+      ),
+      AdditionalConditionData(
+        id = 1,
+        dataField = "course",
+        dataValue = "Walthamstow Rehabilitation Clinic",
+        dataSequence = 2,
+        additionalCondition = condition,
+      ),
+    )
+
+    val conditionConfig = AdditionalConditionAp(
+      code = "5db26ab3-9b6f-4bee-b2aa-53aa3f3be7dd",
+      category = "Participation in, or co-operation with, a programme or set of activities",
+      text = "To comply with any requirements specified by your supervising officer for the purpose of ensuring that you address your alcohol / drug / sexual / violent / gambling / solvent abuse / anger / debt / prolific / offending behaviour problems at the [NAME OF COURSE / CENTRE].",
+      tpl = "To comply with any requirements specified by your supervising officer for the purpose of ensuring that you address your {behaviourProblems} problems{course}.",
+      requiresInput = true,
+      inputs = listOf(
+        Input(
+          type = CHECK,
+          label = "Select all that apply",
+          name = "behaviourProblems",
+          case = null,
+          listType = "AND",
+          options = emptyList(),
+          handleIndefiniteArticle = null,
+          addAnother = null,
+          includeBefore = null,
+          subtext = null,
+        ),
+        Input(
+          type = TEXT,
+          label = "Enter name of course or centre (optional)",
+          name = "course",
+          includeBefore = " at the ",
+          subtext = null,
+          options = emptyList(),
+          handleIndefiniteArticle = null,
+          addAnother = null,
+          case = null,
+          listType = null,
+        ),
+      ),
+      categoryShort = null,
+      subtext = null,
+      type = null,
+    )
+
+    val result = conditionFormatter.format(conditionConfig, data)
+    assertThat(result).isEqualTo(
+      "To comply with any requirements specified by your supervising officer for the purpose of ensuring that you address your alcohol and drug problems at the Walthamstow Rehabilitation Clinic.",
+    )
+  }
+
+  @Test
+  fun `Will omit optional text from the sentence when an optional value is not supplied`() {
+    val data = listOf(
+      AdditionalConditionData(
+        id = 1,
+        dataField = "behaviourProblems",
+        dataValue = "alcohol",
+        dataSequence = 0,
+        additionalCondition = condition,
+      ),
+      AdditionalConditionData(
+        id = 1,
+        dataField = "behaviourProblems",
+        dataValue = "drug",
+        dataSequence = 1,
+        additionalCondition = condition,
+      ),
+    )
+
+    val conditionConfig = AdditionalConditionAp(
+      code = "5db26ab3-9b6f-4bee-b2aa-53aa3f3be7dd",
+      category = "Participation in, or co-operation with, a programme or set of activities",
+      text = "To comply with any requirements specified by your supervising officer for the purpose of ensuring that you address your alcohol / drug / sexual / violent / gambling / solvent abuse / anger / debt / prolific / offending behaviour problems at the [NAME OF COURSE / CENTRE].",
+      tpl = "To comply with any requirements specified by your supervising officer for the purpose of ensuring that you address your {behaviourProblems} problems{course}.",
+      requiresInput = true,
+      inputs = listOf(
+        Input(
+          type = CHECK,
+          label = "Select all that apply",
+          name = "behaviourProblems",
+          case = null,
+          listType = "AND",
+          options = emptyList(),
+          handleIndefiniteArticle = null,
+          addAnother = null,
+          includeBefore = null,
+          subtext = null,
+        ),
+        Input(
+          type = TEXT,
+          label = "Enter name of course or centre (optional)",
+          name = "course",
+          includeBefore = " at the ",
+          subtext = null,
+          options = emptyList(),
+          handleIndefiniteArticle = null,
+          addAnother = null,
+          case = null,
+          listType = null,
+        ),
+      ),
+      categoryShort = null,
+      subtext = null,
+      type = null,
+    )
+
+    val result = conditionFormatter.format(conditionConfig, data)
+    assertThat(result).isEqualTo(
+      "To comply with any requirements specified by your supervising officer for the purpose of ensuring that you address your alcohol and drug problems.",
+    )
+  }
+
+  @Test
+  fun `Will make sense with multiple optional values - none supplied`() {
+    val data = listOf(
+      AdditionalConditionData(
+        id = 1,
+        dataField = "appointmentAddress",
+        dataValue = "Harlow Clinic, High Street, London, W1 3GV",
+        dataSequence = 0,
+        additionalCondition = condition,
+      ),
+      AdditionalConditionData(
+        id = 2,
+        dataField = "appointmentDate",
+        dataValue = "12th February 2022",
+        dataSequence = 1,
+        additionalCondition = condition,
+      ),
+    )
+
+    val conditionConfig = AdditionalConditionAp(
+      code = "5db26ab3-9b6f-4bee-b2aa-53aa3f3be7dd",
+      category = "Participation in, or co-operation with, a programme or set of activities",
+      text = "Attend [INSERT APPOINTMENT TIME DATE AND ADDRESS], as directed, to address your dependency on, or propensity to misuse, a controlled drug.",
+      tpl = "Attend {appointmentAddress}{appointmentDate}{appointmentTime}, as directed, to address your dependency on, or propensity to misuse, a controlled drug.",
+      requiresInput = true,
+      inputs = listOf(
+        Input(
+          type = TIME_PICKER,
+          label = "Enter time (optional)",
+          name = "appointmentTime",
+          includeBefore = " at ",
+          case = null,
+          listType = null,
+          options = emptyList(),
+          handleIndefiniteArticle = null,
+          addAnother = null,
+          subtext = null,
+        ),
+        Input(
+          type = DATE_PICKER,
+          label = "Enter date (optional)",
+          name = "appointmentDate",
+          includeBefore = " on ",
+          subtext = null,
+          options = emptyList(),
+          handleIndefiniteArticle = null,
+          addAnother = null,
+          case = null,
+          listType = null,
+        ),
+        Input(
+          type = ADDRESS,
+          label = "Enter the address for the appointment",
+          name = "appointmentAddress",
+          includeBefore = null,
+          subtext = null,
+          options = emptyList(),
+          handleIndefiniteArticle = null,
+          addAnother = null,
+          case = null,
+          listType = null,
+        ),
+      ),
+      categoryShort = null,
+      subtext = null,
+      type = null,
+    )
+
+    val result = conditionFormatter.format(conditionConfig, data)
+    assertThat(result).isEqualTo(
+      "Attend Harlow Clinic, High Street, London, W1 3GV on 12th February 2022, as directed, to address your dependency on, or propensity to misuse, a controlled drug.",
+    )
+  }
+
+  @Test
+  fun `Will make sense with multiple optional values - two supplied`() {
+    val data = listOf(
+      AdditionalConditionData(
+        id = 1,
+        dataField = "appointmentAddress",
+        dataValue = "Harlow Clinic, High Street, London, W1 3GV",
+        dataSequence = 0,
+        additionalCondition = condition,
+      ),
+      AdditionalConditionData(
+        id = 2,
+        dataField = "appointmentDate",
+        dataValue = "12th February 2022",
+        dataSequence = 1,
+        additionalCondition = condition,
+      ),
+      AdditionalConditionData(
+        id = 3,
+        dataField = "appointmentTime",
+        dataValue = "11=15 am",
+        dataSequence = 2,
+        additionalCondition = condition,
+      ),
+    )
+
+    val conditionConfig = AdditionalConditionAp(
+      code = "5db26ab3-9b6f-4bee-b2aa-53aa3f3be7dd",
+      category = "Participation in, or co-operation with, a programme or set of activities",
+      text = "Attend [INSERT APPOINTMENT TIME DATE AND ADDRESS], as directed, to address your dependency on, or propensity to misuse, a controlled drug.",
+      tpl = "Attend {appointmentAddress}{appointmentDate}{appointmentTime}, as directed, to address your dependency on, or propensity to misuse, a controlled drug.",
+      requiresInput = true,
+      inputs = listOf(
+        Input(
+          type = TIME_PICKER,
+          label = "Enter time (optional)",
+          name = "appointmentTime",
+          includeBefore = " at ",
+          case = null,
+          listType = null,
+          options = emptyList(),
+          handleIndefiniteArticle = null,
+          addAnother = null,
+          subtext = null,
+        ),
+        Input(
+          type = DATE_PICKER,
+          label = "Enter date (optional)",
+          name = "appointmentDate",
+          includeBefore = " on ",
+          subtext = null,
+          options = emptyList(),
+          handleIndefiniteArticle = null,
+          addAnother = null,
+          case = null,
+          listType = null,
+        ),
+        Input(
+          type = ADDRESS,
+          label = "Enter the address for the appointment",
+          name = "appointmentAddress",
+          includeBefore = null,
+          subtext = null,
+          options = emptyList(),
+          handleIndefiniteArticle = null,
+          addAnother = null,
+          case = null,
+          listType = null,
+        ),
+      ),
+      categoryShort = null,
+      subtext = null,
+      type = null,
+    )
+
+    val result = conditionFormatter.format(conditionConfig, data)
+    assertThat(result).isEqualTo(
+      "Attend Harlow Clinic, High Street, London, W1 3GV on 12th February 2022 at 11=15 am, as directed, to address your dependency on, or propensity to misuse, a controlled drug.",
+    )
+  }
+
+  @Test
+  fun `Will replace placeholders for a list of values with commas and 'and' between (list type AND)`() {
+    val data = listOf(
+      AdditionalConditionData(
+        id = 1,
+        dataField = "behaviourProblems",
+        dataValue = "alcohol",
+        dataSequence = 0,
+        additionalCondition = condition,
+      ),
+      AdditionalConditionData(
+        id = 2,
+        dataField = "behaviourProblems",
+        dataValue = "drug",
+        dataSequence = 1,
+        additionalCondition = condition,
+      ),
+      AdditionalConditionData(
+        id = 3,
+        dataField = "behaviourProblems",
+        dataValue = "sexual",
+        dataSequence = 2,
+        additionalCondition = condition,
+      ),
+      AdditionalConditionData(
+        id = 4,
+        dataField = "behaviourProblems",
+        dataValue = "violent",
+        dataSequence = 3,
+        additionalCondition = condition,
+      ),
+      AdditionalConditionData(
+        id = 5,
+        dataField = "behaviourProblems",
+        dataValue = "gambling",
+        dataSequence = 4,
+        additionalCondition = condition,
+      ),
+      AdditionalConditionData(
+        id = 6,
+        dataField = "behaviourProblems",
+        dataValue = "anger",
+        dataSequence = 5,
+        additionalCondition = condition,
+      ),
+      AdditionalConditionData(
+        id = 7,
+        dataField = "course",
+        dataValue = "AA meeting",
+        dataSequence = 6,
+        additionalCondition = condition,
+      ),
+    )
+
+    val conditionConfig = AdditionalConditionAp(
+      code = "5db26ab3-9b6f-4bee-b2aa-53aa3f3be7dd",
+      category = "Participation in, or co-operation with, a programme or set of activities",
+      text = "To comply with any requirements specified by your supervising officer for the purpose of ensuring that you address your alcohol / drug / sexual / violent / gambling / solvent abuse / anger / debt / prolific / offending behaviour problems at the [NAME OF COURSE / CENTRE].",
+      tpl = "To comply with any requirements specified by your supervising officer for the purpose of ensuring that you address your {behaviourProblems} problems{course}.",
+      requiresInput = true,
+      inputs = listOf(
+        Input(
+          type = CHECK,
+          label = "Select all that apply",
+          name = "behaviourProblems",
+          listType = "AND",
+          includeBefore = null,
+          case = null,
+          options = emptyList(),
+          handleIndefiniteArticle = null,
+          addAnother = null,
+          subtext = null,
+        ),
+        Input(
+          type = TEXT,
+          label = "Enter name of course or centre (optional)",
+          name = "course",
+          includeBefore = " at the ",
+          subtext = null,
+          options = emptyList(),
+          handleIndefiniteArticle = null,
+          addAnother = null,
+          case = null,
+          listType = null,
+        ),
+
+      ),
+      categoryShort = null,
+      subtext = null,
+      type = null,
+    )
+
+    val result = conditionFormatter.format(conditionConfig, data)
+    assertThat(result).isEqualTo(
+      "To comply with any requirements specified by your supervising officer for the purpose of ensuring that you address your alcohol, drug, sexual, violent, gambling and anger problems at the AA meeting.",
+    )
+  }
+
+  @Test
+  fun `Will replace placeholders for a list of 2 values with an 'OR' between them (list type OR)`() {
+    val data = listOf(
+      AdditionalConditionData(
+        id = 1,
+        dataField = "name",
+        dataValue = "Jane Doe",
+        dataSequence = 0,
+        additionalCondition = condition,
+      ),
+      AdditionalConditionData(
+        id = 2,
+        dataField = "name",
+        dataValue = "John Doe",
+        dataSequence = 1,
+        additionalCondition = condition,
+      ),
+      AdditionalConditionData(
+        id = 3,
+        dataField = "socialServicesDepartment",
+        dataValue = "East Hull Social Services",
+        dataSequence = 2,
+        additionalCondition = condition,
+      ),
+    )
+
+    val conditionConfig = AdditionalConditionAp(
+      code = "5db26ab3-9b6f-4bee-b2aa-53aa3f3be7dd",
+      category = "Participation in, or co-operation with, a programme or set of activities",
+      text = "Not to seek to approach or communicate with [INSERT NAME OF VICTIM AND / OR FAMILY MEMBERS] without the prior approval of your supervising officer and / or [INSERT NAME OF APPROPRIATE SOCIAL SERVICES DEPARTMENT].",
+      tpl = "Not to seek to approach or communicate with {name} without the prior approval of your supervising officer{socialServicesDepartment}.",
+      requiresInput = true,
+      inputs = listOf(
+        Input(
+          type = TEXT,
+          label = "Enter name of victim or family member",
+          name = "name",
+          listType = "OR",
+          case = CAPITALISED,
+          includeBefore = null,
+          options = emptyList(),
+          handleIndefiniteArticle = null,
+          addAnother = null,
+          subtext = null,
+        ),
+        Input(
+          type = TEXT,
+          label = "Enter social services department (optional)",
+          name = "socialServicesDepartment",
+          case = CAPITALISED,
+          includeBefore = " and / or ",
+          options = emptyList(),
+          listType = null,
+          handleIndefiniteArticle = null,
+          addAnother = null,
+          subtext = null,
+        ),
+      ),
+      categoryShort = null,
+      subtext = null,
+      type = null,
+    )
+    val result = conditionFormatter.format(conditionConfig, data)
+    assertThat(result).isEqualTo(
+      "Not to seek to approach or communicate with Jane Doe or John Doe without the prior approval of your supervising officer and / or East Hull Social Services.",
+    )
+  }
+
+  @Test
+  fun `Will replace placeholders for a list of values with commas and an 'OR' between them (list type OR)`() {
+    val data = listOf(
+      AdditionalConditionData(
+        id = 1,
+        dataField = "name",
+        dataValue = "Jane Doe",
+        dataSequence = 0,
+        additionalCondition = condition,
+      ),
+      AdditionalConditionData(
+        id = 2,
+        dataField = "name",
+        dataValue = "John Doe",
+        dataSequence = 1,
+        additionalCondition = condition,
+      ),
+      AdditionalConditionData(
+        id = 3,
+        dataField = "name",
+        dataValue = "Jack Dont",
+        dataSequence = 2,
+        additionalCondition = condition,
+      ),
+      AdditionalConditionData(
+        id = 4,
+        dataField = "socialServicesDepartment",
+        dataValue = "East Hull Social Services",
+        dataSequence = 3,
+        additionalCondition = condition,
+      ),
+    )
+
+    val conditionConfig = AdditionalConditionAp(
+      code = "5db26ab3-9b6f-4bee-b2aa-53aa3f3be7dd",
+      category = "Participation in, or co-operation with, a programme or set of activities",
+      text = "Not to seek to approach or communicate with [INSERT NAME OF VICTIM AND / OR FAMILY MEMBERS] without the prior approval of your supervising officer and / or [INSERT NAME OF APPROPRIATE SOCIAL SERVICES DEPARTMENT].",
+      tpl = "Not to seek to approach or communicate with {name} without the prior approval of your supervising officer{socialServicesDepartment}.",
+      requiresInput = true,
+      inputs = listOf(
+        Input(
+          type = TEXT,
+          label = "Enter name of victim or family member",
+          name = "name",
+          listType = "OR",
+          case = CAPITALISED,
+          includeBefore = null,
+          options = emptyList(),
+          handleIndefiniteArticle = null,
+          addAnother = null,
+          subtext = null,
+        ),
+        Input(
+          type = TEXT,
+          label = "Enter social services department (optional)",
+          name = "socialServicesDepartment",
+          case = CAPITALISED,
+          includeBefore = " and / or ",
+          options = emptyList(),
+          listType = null,
+          handleIndefiniteArticle = null,
+          addAnother = null,
+          subtext = null,
+        ),
+      ),
+      categoryShort = null,
+      subtext = null,
+      type = null,
+    )
+    val result = conditionFormatter.format(conditionConfig, data)
+    assertThat(result).isEqualTo(
+      "Not to seek to approach or communicate with Jane Doe, John Doe or Jack Dont without the prior approval of your supervising officer and / or East Hull Social Services.",
+    )
+  }
+
+  @Test
+  fun `Will correctly format an address`() {
+    val data = listOf(
+      AdditionalConditionData(
+        id = 1,
+        dataField = "appointmentAddress",
+        dataValue = "123 Fake Street, , Fakestown, , LN123TO",
+        dataSequence = 0,
+        additionalCondition = condition,
+      ),
+    )
+
+    val conditionConfig = AdditionalConditionAp(
+      code = "5db26ab3-9b6f-4bee-b2aa-53aa3f3be7dd",
+      category = "Participation in, or co-operation with, a programme or set of activities",
+      text = "Attend [INSERT APPOINTMENT TIME DATE AND ADDRESS], as directed, to address your dependency on, or propensity to misuse, a controlled drug.",
+      tpl = "Attend {appointmentAddress}{appointmentDate}{appointmentTime}, as directed, to address your dependency on, or propensity to misuse, a controlled drug.",
+      requiresInput = true,
+      inputs = listOf(
+        Input(
+          type = TIME_PICKER,
+          label = "Enter time (optional)",
+          name = "appointmentTime",
+          includeBefore = " at ",
+          case = null,
+          listType = null,
+          options = emptyList(),
+          handleIndefiniteArticle = null,
+          addAnother = null,
+          subtext = null,
+        ),
+        Input(
+          type = DATE_PICKER,
+          label = "Enter date (optional)",
+          name = "appointmentDate",
+          includeBefore = " on ",
+          case = null,
+          options = emptyList(),
+          listType = null,
+          handleIndefiniteArticle = null,
+          addAnother = null,
+          subtext = null,
+        ),
+        Input(
+          type = ADDRESS,
+          label = "Enter the address for the appointment",
+          name = "appointmentAddress",
+          case = null,
+          includeBefore = null,
+          options = emptyList(),
+          listType = null,
+          handleIndefiniteArticle = null,
+          addAnother = null,
+          subtext = null,
+        ),
+      ),
+      categoryShort = null,
+      subtext = null,
+      type = null,
+    )
+    val result = conditionFormatter.format(conditionConfig, data)
+    assertThat(result).isEqualTo(
+      "Attend 123 Fake Street, Fakestown, LN123TO, as directed, to address your dependency on, or propensity to misuse, a controlled drug.",
+    )
+  }
+
+  @Test
+  fun `Will replace placeholders for conditional reveal inputs`() {
+    val data = listOf(
+      AdditionalConditionData(
+        id = 1,
+        dataField = "approvedPremises",
+        dataValue = "the police station",
+        dataSequence = 0,
+        additionalCondition = condition,
+      ),
+      AdditionalConditionData(
+        id = 2,
+        dataField = "reportingTime",
+        dataValue = "2pm",
+        dataSequence = 1,
+        additionalCondition = condition,
+      ),
+      AdditionalConditionData(
+        id = 3,
+        dataField = "reviewPeriod",
+        dataValue = "Other",
+        dataSequence = 2,
+        additionalCondition = condition,
+      ),
+      AdditionalConditionData(
+        id = 4,
+        dataField = "alternativeReviewPeriod",
+        dataValue = "Fortnightly",
+        dataSequence = 3,
+        additionalCondition = condition,
+      ),
+    )
+
+    val conditionConfig = AdditionalConditionAp(
+      code = "5db26ab3-9b6f-4bee-b2aa-53aa3f3be7dd",
+      category = "Participation in, or co-operation with, a programme or set of activities",
+      text = "Report to staff at [NAME OF APPROVED PREMISES] at [TIME / DAILY], unless otherwise authorised by your supervising officer. This condition will be reviewed by your supervising officer on a [WEEKLY / MONTHLY / ETC] basis and may be amended or removed if it is felt that the level of risk you present has reduced appropriately.",
+      tpl = "Report to staff at {approvedPremises} at {reportingTime}, unless otherwise authorised by your supervising officer. This condition will be reviewed by your supervising officer on {alternativeReviewPeriod || reviewPeriod} basis and may be amended or removed if it is felt that the level of risk you present has reduced appropriately.",
+      requiresInput = true,
+      inputs = listOf(
+        Input(
+          type = TEXT,
+          label = "Enter name of approved premises",
+          name = "approvedPremises",
+          case = CAPITALISED,
+          includeBefore = null,
+          listType = null,
+          options = emptyList(),
+          handleIndefiniteArticle = null,
+          addAnother = null,
+          subtext = null,
+        ),
+        Input(
+          type = TIME_PICKER,
+          label = "Enter a reporting time",
+          name = "reportingTime",
+          includeBefore = null,
+          case = null,
+          options = emptyList(),
+          listType = null,
+          handleIndefiniteArticle = null,
+          addAnother = null,
+          subtext = null,
+        ),
+        Input(
+          type = RADIO,
+          label = "Select a review period",
+          name = "reviewPeriod",
+          includeBefore = null,
+          case = null,
+          options = listOf(
+            Option(
+              value = "Other",
+              conditional = Conditional(
+                inputs = listOf(
+                  ConditionalInput(
+                    type = TEXT,
+                    label = "Enter a review period",
+                    name = "alternativeReviewPeriod",
+                    case = LOWER,
+                    handleIndefiniteArticle = true,
+                    includeBefore = null,
+                    subtext = null,
+                  ),
+                ),
+              ),
+            ),
+          ),
+          listType = null,
+          handleIndefiniteArticle = true,
+          addAnother = null,
+          subtext = null,
+        ),
+      ),
+      categoryShort = null,
+      subtext = null,
+      type = null,
+    )
+
+    val result = conditionFormatter.format(conditionConfig, data)
+    assertThat(result).isEqualTo(
+      "Report to staff at The Police Station at 2pm, unless otherwise authorised by your supervising officer. This condition will be reviewed by your supervising officer on a fortnightly basis and may be amended or removed if it is felt that the level of risk you present has reduced appropriately.",
+    )
+  }
+
+  @Test
+  fun `Will replace adjust wording where values start with vowel`() {
+    val data = listOf(
+      AdditionalConditionData(
+        id = 1,
+        dataField = "approvedPremises",
+        dataValue = "the police station",
+        dataSequence = 0,
+        additionalCondition = condition,
+      ),
+      AdditionalConditionData(
+        id = 2,
+        dataField = "reportingTime",
+        dataValue = "2pm",
+        dataSequence = 1,
+        additionalCondition = condition,
+      ),
+      AdditionalConditionData(
+        id = 3,
+        dataField = "reviewPeriod",
+        dataValue = "Other",
+        dataSequence = 2,
+        additionalCondition = condition,
+      ),
+      AdditionalConditionData(
+        id = 4,
+        dataField = "alternativeReviewPeriod",
+        dataValue = "ongoing",
+        dataSequence = 3,
+        additionalCondition = condition,
+      ),
+    )
+
+    val conditionConfig = AdditionalConditionAp(
+      code = "5db26ab3-9b6f-4bee-b2aa-53aa3f3be7dd",
+      category = "Participation in, or co-operation with, a programme or set of activities",
+      text = "Report to staff at [NAME OF APPROVED PREMISES] at [TIME / DAILY], unless otherwise authorised by your supervising officer. This condition will be reviewed by your supervising officer on a [WEEKLY / MONTHLY / ETC] basis and may be amended or removed if it is felt that the level of risk you present has reduced appropriately.",
+      tpl = "Report to staff at {approvedPremises} at {reportingTime}, unless otherwise authorised by your supervising officer. This condition will be reviewed by your supervising officer on {alternativeReviewPeriod || reviewPeriod} basis and may be amended or removed if it is felt that the level of risk you present has reduced appropriately.",
+      requiresInput = true,
+      inputs = listOf(
+        Input(
+          type = TEXT,
+          label = "Enter name of approved premises",
+          name = "approvedPremises",
+          case = CAPITALISED,
+          includeBefore = null,
+          listType = null,
+          options = emptyList(),
+          handleIndefiniteArticle = null,
+          addAnother = null,
+          subtext = null,
+        ),
+        Input(
+          type = TIME_PICKER,
+          label = "Enter a reporting time",
+          name = "reportingTime",
+          includeBefore = null,
+          case = null,
+          options = emptyList(),
+          listType = null,
+          handleIndefiniteArticle = null,
+          addAnother = null,
+          subtext = null,
+        ),
+        Input(
+          type = RADIO,
+          label = "Select a review period",
+          name = "reviewPeriod",
+          includeBefore = null,
+          case = null,
+          options = listOf(
+            Option(
+              value = "Other",
+              conditional = Conditional(
+                inputs = listOf(
+                  ConditionalInput(
+                    type = TEXT,
+                    label = "Enter a review period",
+                    name = "alternativeReviewPeriod",
+                    case = LOWER,
+                    handleIndefiniteArticle = true,
+                    includeBefore = null,
+                    subtext = null,
+                  ),
+                ),
+              ),
+            ),
+          ),
+          listType = null,
+          handleIndefiniteArticle = true,
+          addAnother = null,
+          subtext = null,
+        ),
+      ),
+      categoryShort = null,
+      subtext = null,
+      type = null,
+    )
+
+    val result = conditionFormatter.format(conditionConfig, data)
+    assertThat(result).isEqualTo(
+      "Report to staff at The Police Station at 2pm, unless otherwise authorised by your supervising officer. This condition will be reviewed by your supervising officer on an ongoing basis and may be amended or removed if it is felt that the level of risk you present has reduced appropriately.",
+    )
+  }
+
+  val licence = Licence(
+    id = 2L,
+    crn = "exampleCrn",
+    forename = "Robin",
+    surname = "Smith",
+    typeCode = LicenceType.AP,
+    statusCode = LicenceStatus.ACTIVE,
+    version = "1.0",
+    probationAreaCode = "N01",
+    probationAreaDescription = "N01 Region",
+    probationPduCode = "PDU1",
+    probationPduDescription = "PDU1 Pdu",
+    probationLauCode = "LAU1",
+    probationLauDescription = "LAU1 Lau",
+    probationTeamCode = "TEAM1",
+    probationTeamDescription = "TEAM1 probation team",
+  )
+
+  val condition = AdditionalCondition(
+    id = 1,
+    conditionCode = "5db26ab3-9b6f-4bee-b2aa-53aa3f3be7dd",
+    conditionCategory = "Residence at a specific place",
+    conditionSequence = 0,
+    conditionText = "You must reside within the [INSERT REGION] while of no fixed abode, unless otherwise approved by your supervising officer.",
+    additionalConditionData = emptyList(),
+    additionalConditionUploadSummary = emptyList(),
+    conditionVersion = "1.0",
+    licence = licence,
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/FormattingHelpersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/FormattingHelpersTest.kt
@@ -1,0 +1,166 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class FormattingHelpersTest {
+
+  @Test
+  fun `Check placeholder names`() {
+    assertThat(
+      """aaa{1} bbbb {2222   } 
+      saa| { dfdfd}
+      |fdfd  sddsdfdfdfdf
+      """.trimMargin().getPlaceholderNames(),
+    ).containsExactly("1", "2222", "dfdfd")
+
+    assertThat(null.getPlaceholderNames()).isEmpty()
+  }
+
+  @Test
+  fun `replace named placeholder`() {
+    assertThat("aaa {aaa} bbb".replacePlaceholder("aaa", "ddd")).isEqualTo("aaa ddd bbb")
+
+    assertThat(
+      """{bbb} aaa {aaa} bbb
+      |{bbb} {ccc}
+      """.trimMargin().replacePlaceholder("ccc", "uuu"),
+    ).isEqualTo(
+      """{bbb} aaa {aaa} bbb
+{bbb} uuu""",
+    )
+  }
+
+  @Nested
+  inner class `Convert to title case` {
+    @Test
+    fun `empty string`() {
+      assertThat("".convertToTitleCase()).isEqualTo("")
+    }
+
+    @Test
+    fun `Lower Case`() {
+      assertThat("robert".convertToTitleCase()).isEqualTo("Robert")
+    }
+
+    @Test
+    fun `Upper Case`() {
+      assertThat("ROBERT".convertToTitleCase()).isEqualTo("Robert")
+    }
+
+    @Test
+    fun `Mixed Case`() {
+      assertThat("RoBErT".convertToTitleCase()).isEqualTo("Robert")
+    }
+
+    @Test
+    fun `Multiple words`() {
+      assertThat("RobeRT SMiTH".convertToTitleCase()).isEqualTo("Robert Smith")
+    }
+
+    @Test
+    fun `Leading spaces`() {
+      assertThat("  RobeRT".convertToTitleCase()).isEqualTo("  Robert")
+    }
+
+    @Test
+    fun `Trailing spaces`() {
+      assertThat("RobeRT  ".convertToTitleCase()).isEqualTo("Robert  ")
+    }
+
+    @Test
+    fun `Hyphenated`() {
+      assertThat("Robert-John SmiTH-jONes-WILSON".convertToTitleCase()).isEqualTo("Robert-John Smith-Jones-Wilson")
+    }
+  }
+
+  @Nested
+  inner class `Format address` {
+    @Test
+    fun empty() {
+      assertThat(formatAddress("")).isEqualTo("")
+    }
+
+    @Test
+    fun `one piece`() {
+      assertThat(formatAddress("1 Main Road")).isEqualTo("1 Main Road")
+    }
+
+    @Test
+    fun `two pieces`() {
+      assertThat(formatAddress("1 Main Road, Bridgport")).isEqualTo("1 Main Road, Bridgport")
+    }
+
+    @Test
+    fun `two pieces with empty piece in between`() {
+      assertThat(formatAddress("1 Main Road, , Bridgport")).isEqualTo("1 Main Road, Bridgport")
+    }
+
+    @Test
+    fun `empty pieces`() {
+      assertThat(formatAddress(" , , ")).isEqualTo("")
+    }
+  }
+
+  @Nested
+  inner class `Starts with a vowel` {
+    @Test
+    fun `empty string`() {
+      assertThat("".startsWithVowel()).isFalse
+    }
+
+    @Test
+    fun `animal starts with vowel`() {
+      assertThat("animal".startsWithVowel()).isTrue
+    }
+
+    @Test
+    fun `zoo does not start with vowel`() {
+      assertThat("zoo".startsWithVowel()).isFalse
+    }
+
+    @Test
+    fun `case insensitive`() {
+      assertThat("A".startsWithVowel()).isTrue
+    }
+
+    @Test
+    fun `Z is not a vowel`() {
+      assertThat("Z".startsWithVowel()).isFalse
+    }
+  }
+
+  @Nested
+  inner class `format as list` {
+    @Test
+    fun `empty list`() {
+      assertThat(emptyList<String>().formatUsing("AND")).isEqualTo("")
+    }
+
+    @Test
+    fun `single item`() {
+      assertThat(listOf("word").formatUsing("AND")).isEqualTo("word")
+    }
+
+    @Test
+    fun `two items joined with and`() {
+      assertThat(listOf("word", "weight").formatUsing("AND")).isEqualTo("word and weight")
+    }
+
+    @Test
+    fun `two items joined with or`() {
+      assertThat(listOf("word", "weight").formatUsing("OR")).isEqualTo("word or weight")
+    }
+
+    @Test
+    fun `multiple items joined with and`() {
+      assertThat(listOf("word", "weight", "sound").formatUsing("AND")).isEqualTo("word, weight and sound")
+    }
+
+    @Test
+    fun `multiple items joined with or`() {
+      assertThat(listOf("word", "weight", "sound").formatUsing("OR")).isEqualTo("word, weight or sound")
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/PolicyFunctionsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/PolicyFunctionsTest.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AdditionalCon
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.Licence
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.AdditionalConditionAp
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.Input
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.InputType.TEXT
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.policy.Replacements
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.ConditionChangeType.DELETED
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.ConditionChangeType.NEW_OPTIONS
@@ -269,7 +270,7 @@ class PolicyFunctionsTest {
   )
 
   fun input() = Input(
-    type = "default-type",
+    type = TEXT,
     label = "default-type",
     name = "default-type",
     listType = null,

--- a/src/test/resources/test_data/policy_conditions/policyV1.json
+++ b/src/test/resources/test_data/policy_conditions/policyV1.json
@@ -334,7 +334,7 @@
             "name": "name",
             "listType": "OR",
             "options": null,
-            "case": "capitalise",
+            "case": "capitalised",
             "handleIndefiniteArticle": null,
             "addAnother": {
               "label": "Add another person"
@@ -348,7 +348,7 @@
             "name": "socialServicesDepartment",
             "listType": null,
             "options": null,
-            "case": "capitalise",
+            "case": "capitalised",
             "handleIndefiniteArticle": null,
             "addAnother": null,
             "includeBefore": " and / or ",
@@ -418,7 +418,7 @@
             "name": "socialServicesDepartment",
             "listType": null,
             "options": null,
-            "case": "capitalise",
+            "case": "capitalised",
             "handleIndefiniteArticle": null,
             "addAnother": null,
             "includeBefore": " and / or ",
@@ -442,7 +442,7 @@
             "name": "nameOfIndividual",
             "listType": "OR",
             "options": null,
-            "case": "capitalise",
+            "case": "capitalised",
             "handleIndefiniteArticle": null,
             "addAnother": {
               "label": "Add another person"
@@ -1443,19 +1443,37 @@
             "type": "timePicker",
             "label": "Enter time (optional)",
             "name": "appointmentTime",
-            "includeBefore": " at "
+            "listType": null,
+            "options": null,
+            "case": null,
+            "handleIndefiniteArticle": null,
+            "addAnother": null,
+            "includeBefore": " at ",
+            "subtext": null
           },
           {
             "type": "datePicker",
             "label": "Enter date (optional)",
             "name": "appointmentDate",
-            "includeBefore": " on "
+            "listType": null,
+            "options": null,
+            "case": null,
+            "handleIndefiniteArticle": null,
+            "addAnother": null,
+            "includeBefore": " on ",
+            "subtext": null
           },
           {
             "type": "address",
             "label": "Enter the address for the appointment",
             "name": "appointmentAddress",
-            "includeBefore": null
+            "listType": null,
+            "options": null,
+            "case": null,
+            "handleIndefiniteArticle": null,
+            "addAnother": null,
+            "includeBefore": null,
+            "subtext": null
           }
         ],
         "type": "AppointmentTimeAndPlaceDuringPss"
@@ -1473,13 +1491,25 @@
             "type": "text",
             "label": "Enter name",
             "name": "name",
-            "includeBefore": null
+            "listType": null,
+            "options": null,
+            "case": null,
+            "handleIndefiniteArticle": null,
+            "addAnother": null,
+            "includeBefore": null,
+            "subtext": null
           },
           {
             "type": "address",
             "label": "Enter address",
             "name": "address",
-            "includeBefore": null
+            "listType": null,
+            "options": null,
+            "case": null,
+            "handleIndefiniteArticle": null,
+            "addAnother": null,
+            "includeBefore": null,
+            "subtext": null
           }
         ],
         "type": "DrugTestLocation"

--- a/src/test/resources/test_data/policy_conditions/policyV2.json
+++ b/src/test/resources/test_data/policy_conditions/policyV2.json
@@ -344,7 +344,7 @@
             "name": "name",
             "listType": "OR",
             "options": null,
-            "case": "capitalise",
+            "case": "capitalised",
             "handleIndefiniteArticle": null,
             "addAnother": {
               "label": "Add another person"
@@ -358,7 +358,7 @@
             "name": "socialServicesDepartment",
             "listType": null,
             "options": null,
-            "case": "capitalise",
+            "case": "capitalised",
             "handleIndefiniteArticle": null,
             "addAnother": null,
             "includeBefore": " and / or ",
@@ -428,7 +428,7 @@
             "name": "socialServicesDepartment",
             "listType": null,
             "options": null,
-            "case": "capitalise",
+            "case": "capitalised",
             "handleIndefiniteArticle": null,
             "addAnother": null,
             "includeBefore": " and / or ",
@@ -452,7 +452,7 @@
             "name": "nameOfIndividual",
             "listType": "OR",
             "options": null,
-            "case": "capitalise",
+            "case": "capitalised",
             "handleIndefiniteArticle": null,
             "addAnother": {
               "label": "Add another person"
@@ -1464,19 +1464,37 @@
             "type": "timePicker",
             "label": "Enter time (optional)",
             "name": "appointmentTime",
-            "includeBefore": " at "
+            "listType": null,
+            "options": null,
+            "case": null,
+            "handleIndefiniteArticle": null,
+            "addAnother": null,
+            "includeBefore": " at ",
+            "subtext": null
           },
           {
             "type": "datePicker",
             "label": "Enter date (optional)",
             "name": "appointmentDate",
-            "includeBefore": " on "
+            "listType": null,
+            "options": null,
+            "case": null,
+            "handleIndefiniteArticle": null,
+            "addAnother": null,
+            "includeBefore": " on ",
+            "subtext": null
           },
           {
             "type": "address",
             "label": "Enter the address for the appointment",
             "name": "appointmentAddress",
-            "includeBefore": null
+            "listType": null,
+            "options": null,
+            "case": null,
+            "handleIndefiniteArticle": null,
+            "addAnother": null,
+            "includeBefore": null,
+            "subtext": null
           }
         ],
         "type": "AppointmentTimeAndPlaceDuringPss"
@@ -1494,13 +1512,25 @@
             "type": "text",
             "label": "Enter name",
             "name": "name",
-            "includeBefore": null
+            "listType": null,
+            "options": null,
+            "case": null,
+            "handleIndefiniteArticle": null,
+            "addAnother": null,
+            "includeBefore": null,
+            "subtext": null
           },
           {
             "type": "address",
             "label": "Enter address",
             "name": "address",
-            "includeBefore": null
+            "listType": null,
+            "options": null,
+            "case": null,
+            "handleIndefiniteArticle": null,
+            "addAnother": null,
+            "includeBefore": null,
+            "subtext": null
           }
         ],
         "type": "DrugTestLocation"

--- a/src/test/resources/test_data/policy_conditions/policyV2_1.json
+++ b/src/test/resources/test_data/policy_conditions/policyV2_1.json
@@ -281,7 +281,7 @@
             "name": "name",
             "listType": "OR",
             "options": null,
-            "case": "capitalise",
+            "case": "capitalised",
             "handleIndefiniteArticle": null,
             "addAnother": {
               "label": "Add another person"
@@ -295,7 +295,7 @@
             "name": "socialServicesDepartment",
             "listType": null,
             "options": null,
-            "case": "capitalise",
+            "case": "capitalised",
             "handleIndefiniteArticle": null,
             "addAnother": null,
             "includeBefore": " and / or ",
@@ -365,7 +365,7 @@
             "name": "socialServicesDepartment",
             "listType": null,
             "options": null,
-            "case": "capitalise",
+            "case": "capitalised",
             "handleIndefiniteArticle": null,
             "addAnother": null,
             "includeBefore": " and / or ",
@@ -389,7 +389,7 @@
             "name": "nameOfIndividual",
             "listType": "OR",
             "options": null,
-            "case": "capitalise",
+            "case": "capitalised",
             "handleIndefiniteArticle": null,
             "addAnother": {
               "label": "Add another person"
@@ -949,7 +949,7 @@
                       "type": "text",
                       "label": "Enter the other frequency",
                       "name": "alternativeReportingFrequency",
-                      "case": "capitalise",
+                      "case": null,
                       "handleIndefiniteArticle": null,
                       "includeBefore": null,
                       "subtext": null
@@ -1101,7 +1101,7 @@
                       "type": "text",
                       "label": "Enter the other frequency",
                       "name": "alternativeReportingFrequency",
-                      "case": "capitalise",
+                      "case": null,
                       "handleIndefiniteArticle": null,
                       "includeBefore": null,
                       "subtext": null
@@ -1471,19 +1471,37 @@
             "type": "timePicker",
             "label": "Enter time (optional)",
             "name": "appointmentTime",
-            "includeBefore": " at "
+            "listType": null,
+            "options": null,
+            "case": null,
+            "handleIndefiniteArticle": null,
+            "addAnother": null,
+            "includeBefore": " at ",
+            "subtext": null
           },
           {
             "type": "datePicker",
             "label": "Enter date (optional)",
             "name": "appointmentDate",
-            "includeBefore": " on "
+            "listType": null,
+            "options": null,
+            "case": null,
+            "handleIndefiniteArticle": null,
+            "addAnother": null,
+            "includeBefore": " on ",
+            "subtext": null
           },
           {
             "type": "address",
             "label": "Enter the address for the appointment",
             "name": "appointmentAddress",
-            "includeBefore": null
+            "listType": null,
+            "options": null,
+            "case": null,
+            "handleIndefiniteArticle": null,
+            "addAnother": null,
+            "includeBefore": null,
+            "subtext": null
           }
         ],
         "type": "AppointmentTimeAndPlaceDuringPss"
@@ -1501,13 +1519,25 @@
             "type": "text",
             "label": "Enter name",
             "name": "name",
-            "includeBefore": null
+            "listType": null,
+            "options": null,
+            "case": null,
+            "handleIndefiniteArticle": null,
+            "addAnother": null,
+            "includeBefore": null,
+            "subtext": null
           },
           {
             "type": "address",
             "label": "Enter address",
             "name": "address",
-            "includeBefore": null
+            "listType": null,
+            "options": null,
+            "case": null,
+            "handleIndefiniteArticle": null,
+            "addAnother": null,
+            "includeBefore": null,
+            "subtext": null
           }
         ],
         "type": "DrugTestLocation"


### PR DESCRIPTION
This also fixes a couple of bugs:

* Incorrect casing of some inputs due to typo - captilise vs capitalised

* Incorrectly capitalise the joining word: or vs Or

This still needs to be hooked up, may dual run for a bit to identify any issues but then hope to remove the code from the frontend and move to stop exposing formatting rules
