### PR TITLE
FB Automate Building API Extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ values required.
 
 `$ ./run-local.sh`
 
+This script will also build the necessary containers for the front end. Once the script has ran
+and has started, in a separate terminal (at the root of the create-and-vary-a-licence repo for the UI), 
+all you need to run is
+
+`$ npm run start:dev`
+
 # Running the unit tests
 
 Unit tests mock all external dependencies and can be run with no dependent containers.

--- a/README.md
+++ b/README.md
@@ -30,12 +30,6 @@ values required.
 
 `$ ./run-local.sh`
 
-This script will also build the necessary containers for the front end. Once the script has ran
-and has started, in a separate terminal (at the root of the create-and-vary-a-licence repo for the UI), 
-all you need to run is
-
-`$ npm run start:dev`
-
 # Running the unit tests
 
 Unit tests mock all external dependencies and can be run with no dependent containers.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,11 +9,11 @@ services:
     ports:
       - "5432:5432"
     environment:
-      - POSTGRES_PASSWORD=create-and-vary-a-licence
-      - POSTGRES_USER=create-and-vary-a-licence
+      - POSTGRES_PASSWORD=cvl
+      - POSTGRES_USER=cvl
       - POSTGRES_DB=create-and-vary-a-licence-db
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready -d create-and-vary-a-licence-db -U create-and-vary-a-licence"]
+      test: [ "CMD-SHELL", "pg_isready -d create-and-vary-a-licence-db -U cvl"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/run-local.sh
+++ b/run-local.sh
@@ -39,7 +39,7 @@ docker compose down --remove-orphans
 #Prune existing containers
 #Comment in if you wish to perform a fresh install of all containers where all containers are removed and deleted
 #You will be prompted to continue with the deletion in the terminal
-docker system prune --all
+#docker system prune --all
 
 echo "Pulling back end containers ..."
 docker compose pull


### PR DESCRIPTION
This PR takes the previous work around API automation one step further and creates a one stop script to build front and back end containers and run the back end from the API. There is still one step of manual operation to run the frontend from the root of the UI repo. 