### PR TITLE
CVSL-1127 Move to lighter model for updating additional conditions

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/AdditionalConditionRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/AdditionalConditionRequest.kt
@@ -1,0 +1,19 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Describes an additional condition to create/update")
+data class AdditionalConditionRequest(
+  @Schema(description = "Coded value for the additional condition", example = "meetingAddress")
+  val code: String? = null,
+
+  @Schema(description = "The category of the additional condition", example = "Freedom of movement")
+  val category: String? = null,
+
+  @Schema(description = "Sequence of this additional condition within the additional conditions", example = "1")
+  val sequence: Int? = null,
+
+  @Schema(description = "The textual value for this additional condition", example = "You must not enter the location [DESCRIPTION]")
+  val text: String? = null,
+
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/AdditionalConditionsRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/AdditionalConditionsRequest.kt
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.NotNull
 data class AdditionalConditionsRequest(
   @Schema(description = "The list of additional conditions")
   @field:NotNull
-  val additionalConditions: List<AdditionalCondition>,
+  val additionalConditions: List<AdditionalConditionRequest>,
 
   @Schema(description = "The type of additional condition, either licence or post sentence supervision", allowableValues = ["AP", "PSS"])
   @field:NotNull

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ToEntityTransformers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ToEntityTransformers.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service
 
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AdditionalConditionRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.request.CreateLicenceRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.AdditionalCondition as EntityAdditionalCondition
@@ -7,7 +8,6 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.AdditionalCo
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.AuditEvent as EntityAuditEvent
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.Licence as EntityLicence
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.StandardCondition as EntityStandardCondition
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AdditionalCondition as ModelAdditionalCondition
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AdditionalConditionData as ModelAdditionalConditionData
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AuditEvent as ModelAuditEvent
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.StandardCondition as ModelStandardCondition
@@ -55,7 +55,10 @@ fun transform(createRequest: CreateLicenceRequest): EntityLicence {
 }
 
 // Transform a list of model standard conditions to a list of entity StandardConditions, setting the licenceId
-fun List<ModelStandardCondition>.transformToEntityStandard(licence: EntityLicence, conditionType: String): List<EntityStandardCondition> = map { term -> transform(term, licence, conditionType) }
+fun List<ModelStandardCondition>.transformToEntityStandard(
+  licence: EntityLicence,
+  conditionType: String,
+): List<EntityStandardCondition> = map { term -> transform(term, licence, conditionType) }
 
 fun transform(model: ModelStandardCondition, licence: EntityLicence, conditionType: String): EntityStandardCondition {
   return EntityStandardCondition(
@@ -67,7 +70,11 @@ fun transform(model: ModelStandardCondition, licence: EntityLicence, conditionTy
   )
 }
 
-fun transform(model: ModelAdditionalCondition, licence: EntityLicence, conditionType: String): EntityAdditionalCondition {
+fun transform(
+  model: AdditionalConditionRequest,
+  licence: EntityLicence,
+  conditionType: String,
+): EntityAdditionalCondition {
   return EntityAdditionalCondition(
     conditionVersion = licence.version!!,
     conditionCode = model.code,
@@ -80,12 +87,19 @@ fun transform(model: ModelAdditionalCondition, licence: EntityLicence, condition
 }
 
 // Transform a list of model additional conditions to entity additional conditions
-fun List<ModelAdditionalCondition>.transformToEntityAdditional(licence: EntityLicence, conditionType: String): List<EntityAdditionalCondition> = map { transform(it, licence, conditionType) }
+fun List<AdditionalConditionRequest>.transformToEntityAdditional(
+  licence: EntityLicence,
+  conditionType: String,
+): List<EntityAdditionalCondition> = map { transform(it, licence, conditionType) }
 
 // Transform a list of model additional condition data to entity additional condition data
-fun List<ModelAdditionalConditionData>.transformToEntityAdditionalData(additionalCondition: EntityAdditionalCondition): List<EntityAdditionalConditionData> = map { transform(it, additionalCondition) }
+fun List<ModelAdditionalConditionData>.transformToEntityAdditionalData(additionalCondition: EntityAdditionalCondition): List<EntityAdditionalConditionData> =
+  map { transform(it, additionalCondition) }
 
-fun transform(model: ModelAdditionalConditionData, additionalCondition: EntityAdditionalCondition): EntityAdditionalConditionData {
+fun transform(
+  model: ModelAdditionalConditionData,
+  additionalCondition: EntityAdditionalCondition,
+): EntityAdditionalConditionData {
   return EntityAdditionalConditionData(
     dataSequence = model.sequence,
     dataField = model.field,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/LicenceConditionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/LicenceConditionIntegrationTest.kt
@@ -6,8 +6,8 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
 import org.springframework.test.context.jdbc.Sql
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AdditionalCondition
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AdditionalConditionData
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AdditionalConditionRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AdditionalConditionsRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.BespokeConditionRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.Licence
@@ -228,10 +228,10 @@ class LicenceConditionIntegrationTest : IntegrationTestBase() {
 
     val anAdditionalConditionsRequest = AdditionalConditionsRequest(
       additionalConditions = listOf(
-        AdditionalCondition(code = "code1", category = "category", sequence = 0, text = "text"),
-        AdditionalCondition(code = "code2", category = "category", sequence = 1, text = "text"),
-        AdditionalCondition(code = "code3", category = "category", sequence = 2, text = "text"),
-        AdditionalCondition(code = "code4", category = "category", sequence = 3, text = "text"),
+        AdditionalConditionRequest(code = "code1", category = "category", sequence = 0, text = "text"),
+        AdditionalConditionRequest(code = "code2", category = "category", sequence = 1, text = "text"),
+        AdditionalConditionRequest(code = "code3", category = "category", sequence = 2, text = "text"),
+        AdditionalConditionRequest(code = "code4", category = "category", sequence = 3, text = "text"),
       ),
       conditionType = "AP",
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/LicenceControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/LicenceControllerTest.kt
@@ -31,6 +31,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.config.ControllerAdvice
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AdditionalCondition
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AdditionalConditionData
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AdditionalConditionRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AdditionalConditionsRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AppointmentAddressRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AppointmentPersonRequest
@@ -826,7 +827,12 @@ class LicenceControllerTest {
 
     val aStatusUpdateRequest = StatusUpdateRequest(status = LicenceStatus.APPROVED, username = "X", fullName = "Jon Smith")
 
-    val anUpdateAdditionalConditionsListRequest = AdditionalConditionsRequest(additionalConditions = listOf(AdditionalCondition(code = "code", category = "category", sequence = 0, text = "text")), conditionType = "AP")
+    val anUpdateAdditionalConditionsListRequest = AdditionalConditionsRequest(
+      additionalConditions = listOf(
+        AdditionalConditionRequest(code = "code", category = "category", sequence = 0, text = "text"),
+      ),
+      conditionType = "AP",
+    )
 
     val anUpdateAdditionalConditionsDataRequest = UpdateAdditionalConditionDataRequest(
       data = listOf(AdditionalConditionData(field = "field1", value = "value1", sequence = 0)),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceConditionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceConditionServiceTest.kt
@@ -23,6 +23,7 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.AdditionalCo
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.BespokeCondition
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.CommunityOffenderManager
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.Licence
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AdditionalConditionRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AdditionalConditionsRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.BespokeConditionRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.StandardCondition
@@ -217,7 +218,7 @@ class LicenceConditionServiceTest {
           1L,
           AdditionalConditionsRequest(
             additionalConditions = listOf(
-              uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AdditionalCondition(
+              AdditionalConditionRequest(
                 code = "code",
                 category = "category",
                 text = "text",
@@ -287,7 +288,7 @@ class LicenceConditionServiceTest {
 
       val request = AdditionalConditionsRequest(
         additionalConditions = listOf(
-          uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AdditionalCondition(
+          AdditionalConditionRequest(
             code = "code",
             category = "category",
             text = "text",


### PR DESCRIPTION
This removes these fields:
```
 val id: Long? = -1,
 val text: String? = null,
 val expandedText: String? = null,
 val data: List<AdditionalConditionData> = emptyList(),
 val uploadSummary: List<AdditionalConditionUploadSummary> = emptyList(),
```

 this should be backwards compatible as jackson will ignore unknown fields (and they weren't being used anyway) 