### PR TITLE
CVSL-999 add additional fields for search response

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/FoundProbationRecord.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/FoundProbationRecord.kt
@@ -13,12 +13,12 @@ data class FoundProbationRecord(
   val name: String = "",
 
   @Schema(
-    description = "The case reference number (CRN) of this person, from either prison or probation service",
+    description = "The case reference number (CRN) of the offender,",
     example = "X12344",
   )
   val crn: String? = "",
 
-  @Schema(description = "The prison nomis number for this offender", example = "A1234AA")
+  @Schema(description = "The prison nomis number for the offender", example = "A1234AA")
   val nomisId: String? = "",
 
   @Schema(description = "The forename and surname of the COM")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/FoundProbationRecord.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/FoundProbationRecord.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model
 import com.fasterxml.jackson.annotation.JsonFormat
 import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceType
 import java.time.LocalDate
 
 @Schema(description = "Describes a search result which has been found and enriched")
@@ -10,6 +11,15 @@ data class FoundProbationRecord(
 
   @Schema(description = "The forename and surname of the offender")
   val name: String = "",
+
+  @Schema(
+    description = "The case reference number (CRN) of this person, from either prison or probation service",
+    example = "X12344",
+  )
+  val crn: String? = "",
+
+  @Schema(description = "The prison nomis number for this offender", example = "A1234AA")
+  val nomisId: String? = "",
 
   @Schema(description = "The forename and surname of the COM")
   val comName: String = "",
@@ -20,6 +30,12 @@ data class FoundProbationRecord(
   @Schema(description = "The release date of the offender", example = "27/07/2023")
   @JsonFormat(pattern = "dd/MM/yyyy")
   val releaseDate: LocalDate? = null,
+
+  @Schema(description = "The ID of the most recent and relevant licence", example = "123344")
+  val licenceId: Long? = null,
+
+  @Schema(description = "The type of licence")
+  val licenceType: LicenceType? = null,
 
   @Schema(description = "The status of the licence")
   val licenceStatus: LicenceStatus? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ToModelTransformers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ToModelTransformers.kt
@@ -233,9 +233,13 @@ fun transform(entity: EntityLicenceEvent): ModelLicenceEvent {
 fun ProbationSearchResponseResult.transformToModelFoundProbationRecord(licence: Licence?): ModelFoundProbationRecord {
   return ModelFoundProbationRecord(
     name = "${name.forename} ${name.surname}",
+    crn = licence?.crn,
+    nomisId = licence?.nomsId,
     comName = "${manager.name?.forename} ${manager.name?.surname}",
     teamName = manager.team.description,
     releaseDate = licence?.conditionalReleaseDate ?: licence?.actualReleaseDate,
+    licenceId = licence?.id,
+    licenceType = licence?.typeCode,
     licenceStatus = licence?.statusCode,
     isOnProbation = licence?.statusCode?.isOnProbation(),
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/ComIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/ComIntegrationTest.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.request.Proba
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation.model.request.LicenceCaseloadSearchRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation.model.request.ProbationSearchSortByRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceType
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.ProbationSearchSortBy
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.SearchDirection
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.SearchField
@@ -47,13 +48,22 @@ class ComIntegrationTest : IntegrationTestBase() {
 
     assertThat(resultsList?.size).isEqualTo(1)
     assertThat(offender)
-      .extracting { tuple(it?.name, it?.comName, it?.teamName, it?.releaseDate, it?.licenceStatus, it?.isOnProbation) }
+      .extracting {
+        tuple(
+          it?.name, it?.crn, it?.nomisId, it?.comName, it?.teamName, it?.releaseDate, it?.licenceId, it?.licenceType,
+          it?.licenceStatus, it?.isOnProbation,
+        )
+      }
       .isEqualTo(
         tuple(
           "Test Surname",
+          "CRN1",
+          "A1234AA",
           "Staff Surname",
           "Test Team",
           LocalDate.parse("2022-02-12"),
+          1L,
+          LicenceType.AP,
           LicenceStatus.IN_PROGRESS,
           false,
         ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/ComControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/ComControllerTest.kt
@@ -34,6 +34,7 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.request.Proba
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.ComService
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.NotifyService
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceType
 import java.time.LocalDate
 
 @ExtendWith(SpringExtension::class)
@@ -122,9 +123,13 @@ class ComControllerTest {
       listOf(
         FoundProbationRecord(
           name = "Test Surname",
+          crn = "CRN1",
+          nomisId = "NOMS1",
           comName = "Staff Surname",
           teamName = "Test Team",
           releaseDate = LocalDate.of(2021, 10, 22),
+          licenceId = 1L,
+          licenceType = LicenceType.AP,
           licenceStatus = LicenceStatus.IN_PROGRESS,
           isOnProbation = false,
         ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ComServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ComServiceTest.kt
@@ -293,13 +293,17 @@ class ComServiceTest {
     assertThat(resultsList.size).isEqualTo(1)
 
     assertThat(offender)
-      .extracting { Tuple.tuple(it.name, it.comName, it.teamName, it.releaseDate, it.licenceStatus, it.isOnProbation) }
+      .extracting { Tuple.tuple(it.name, it.crn, it.nomisId, it.comName, it.teamName, it.releaseDate, it.licenceId, it.licenceType, it.licenceStatus, it.isOnProbation) }
       .isEqualTo(
         Tuple.tuple(
           "Test Surname",
+          "A123456",
+          "A1234AA",
           "Staff Surname",
           "Test Team",
           LocalDate.parse("2021-10-22"),
+          1L,
+          LicenceType.AP,
           LicenceStatus.IN_PROGRESS,
           false,
         ),
@@ -430,13 +434,17 @@ class ComServiceTest {
     assertThat(resultsList.size).isEqualTo(1)
 
     assertThat(offender)
-      .extracting { Tuple.tuple(it.name, it.comName, it.teamName, it.releaseDate, it.licenceStatus, it.isOnProbation) }
+      .extracting { Tuple.tuple(it.name, it.crn, it.nomisId, it.comName, it.teamName, it.releaseDate, it.licenceId, it.licenceType, it.licenceStatus, it.isOnProbation) }
       .isEqualTo(
         Tuple.tuple(
           "Test Surname",
+          "A123456",
+          "A1234AA",
           "Staff Surname",
           "Test Team",
           LocalDate.parse("2021-10-22"),
+          1L,
+          LicenceType.AP,
           LicenceStatus.APPROVED,
           false,
         ),
@@ -551,13 +559,17 @@ class ComServiceTest {
     assertThat(resultsList.size).isEqualTo(1)
 
     assertThat(offender)
-      .extracting { Tuple.tuple(it.name, it.comName, it.teamName, it.releaseDate, it.licenceStatus, it.isOnProbation) }
+      .extracting { Tuple.tuple(it.name, it.crn, it.nomisId, it.comName, it.teamName, it.releaseDate, it.licenceId, it.licenceType, it.licenceStatus, it.isOnProbation) }
       .isEqualTo(
         Tuple.tuple(
           "Test Surname",
+          "A123456",
+          "A1234AA",
           "Staff Surname",
           "Test Team",
           LocalDate.parse("2021-10-22"),
+          1L,
+          LicenceType.AP,
           LicenceStatus.VARIATION_SUBMITTED,
           true,
         ),
@@ -626,13 +638,17 @@ class ComServiceTest {
     assertThat(resultsList.size).isEqualTo(1)
 
     assertThat(offender)
-      .extracting { Tuple.tuple(it.name, it.comName, it.teamName, it.releaseDate, it.licenceStatus, it.isOnProbation) }
+      .extracting { Tuple.tuple(it.name, it.crn, it.nomisId, it.comName, it.teamName, it.releaseDate, it.licenceId, it.licenceType, it.licenceStatus, it.isOnProbation) }
       .isEqualTo(
         Tuple.tuple(
           "Test Surname",
+          "A123456",
+          "A1234AA",
           "Staff Surname",
           "Test Team",
           LocalDate.parse("2023-07-27"),
+          1L,
+          LicenceType.AP,
           LicenceStatus.VARIATION_IN_PROGRESS,
           true,
         ),


### PR DESCRIPTION
This PR is to add some additional fields for the search response from the API to enable the results table to be displayed accurately in the frontend. 