### PR TITLE
CVSL-999 add missed field for search

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/FoundProbationRecord.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/FoundProbationRecord.kt
@@ -24,6 +24,9 @@ data class FoundProbationRecord(
   @Schema(description = "The forename and surname of the COM")
   val comName: String = "",
 
+  @Schema(description = "The COM's staff code")
+  val comStaffCode: String? = "",
+
   @Schema(description = "The description of the COM's team")
   val teamName: String? = "",
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ToModelTransformers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ToModelTransformers.kt
@@ -236,6 +236,7 @@ fun ProbationSearchResponseResult.transformToModelFoundProbationRecord(licence: 
     crn = licence?.crn,
     nomisId = licence?.nomsId,
     comName = "${manager.name?.forename} ${manager.name?.surname}",
+    comStaffCode = manager.code,
     teamName = manager.team.description,
     releaseDate = licence?.conditionalReleaseDate ?: licence?.actualReleaseDate,
     licenceId = licence?.id,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/ComIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/ComIntegrationTest.kt
@@ -50,8 +50,8 @@ class ComIntegrationTest : IntegrationTestBase() {
     assertThat(offender)
       .extracting {
         tuple(
-          it?.name, it?.crn, it?.nomisId, it?.comName, it?.teamName, it?.releaseDate, it?.licenceId, it?.licenceType,
-          it?.licenceStatus, it?.isOnProbation,
+          it?.name, it?.crn, it?.nomisId, it?.comName, it?.comStaffCode, it?.teamName, it?.releaseDate, it?.licenceId,
+          it?.licenceType, it?.licenceStatus, it?.isOnProbation,
         )
       }
       .isEqualTo(
@@ -60,6 +60,7 @@ class ComIntegrationTest : IntegrationTestBase() {
           "CRN1",
           "A1234AA",
           "Staff Surname",
+          "A01B02C",
           "Test Team",
           LocalDate.parse("2022-02-12"),
           1L,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/ComControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/ComControllerTest.kt
@@ -126,6 +126,7 @@ class ComControllerTest {
           crn = "CRN1",
           nomisId = "NOMS1",
           comName = "Staff Surname",
+          comStaffCode = "A01B02C",
           teamName = "Test Team",
           releaseDate = LocalDate.of(2021, 10, 22),
           licenceId = 1L,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ComServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ComServiceTest.kt
@@ -293,13 +293,19 @@ class ComServiceTest {
     assertThat(resultsList.size).isEqualTo(1)
 
     assertThat(offender)
-      .extracting { Tuple.tuple(it.name, it.crn, it.nomisId, it.comName, it.teamName, it.releaseDate, it.licenceId, it.licenceType, it.licenceStatus, it.isOnProbation) }
+      .extracting {
+        Tuple.tuple(
+          it.name, it.crn, it.nomisId, it.comName, it.comStaffCode, it.teamName, it.releaseDate,
+          it.licenceId, it.licenceType, it.licenceStatus, it.isOnProbation,
+        )
+      }
       .isEqualTo(
         Tuple.tuple(
           "Test Surname",
           "A123456",
           "A1234AA",
           "Staff Surname",
+          "A01B02C",
           "Test Team",
           LocalDate.parse("2021-10-22"),
           1L,
@@ -434,13 +440,19 @@ class ComServiceTest {
     assertThat(resultsList.size).isEqualTo(1)
 
     assertThat(offender)
-      .extracting { Tuple.tuple(it.name, it.crn, it.nomisId, it.comName, it.teamName, it.releaseDate, it.licenceId, it.licenceType, it.licenceStatus, it.isOnProbation) }
+      .extracting {
+        Tuple.tuple(
+          it.name, it.crn, it.nomisId, it.comName, it.comStaffCode, it.teamName, it.releaseDate,
+          it.licenceId, it.licenceType, it.licenceStatus, it.isOnProbation,
+        )
+      }
       .isEqualTo(
         Tuple.tuple(
           "Test Surname",
           "A123456",
           "A1234AA",
           "Staff Surname",
+          "A01B02C",
           "Test Team",
           LocalDate.parse("2021-10-22"),
           1L,
@@ -559,13 +571,19 @@ class ComServiceTest {
     assertThat(resultsList.size).isEqualTo(1)
 
     assertThat(offender)
-      .extracting { Tuple.tuple(it.name, it.crn, it.nomisId, it.comName, it.teamName, it.releaseDate, it.licenceId, it.licenceType, it.licenceStatus, it.isOnProbation) }
+      .extracting {
+        Tuple.tuple(
+          it.name, it.crn, it.nomisId, it.comName, it.comStaffCode, it.teamName, it.releaseDate,
+          it.licenceId, it.licenceType, it.licenceStatus, it.isOnProbation,
+        )
+      }
       .isEqualTo(
         Tuple.tuple(
           "Test Surname",
           "A123456",
           "A1234AA",
           "Staff Surname",
+          "A01B02C",
           "Test Team",
           LocalDate.parse("2021-10-22"),
           1L,
@@ -638,13 +656,19 @@ class ComServiceTest {
     assertThat(resultsList.size).isEqualTo(1)
 
     assertThat(offender)
-      .extracting { Tuple.tuple(it.name, it.crn, it.nomisId, it.comName, it.teamName, it.releaseDate, it.licenceId, it.licenceType, it.licenceStatus, it.isOnProbation) }
+      .extracting {
+        Tuple.tuple(
+          it.name, it.crn, it.nomisId, it.comName, it.comStaffCode, it.teamName, it.releaseDate,
+          it.licenceId, it.licenceType, it.licenceStatus, it.isOnProbation,
+        )
+      }
       .isEqualTo(
         Tuple.tuple(
           "Test Surname",
           "A123456",
           "A1234AA",
           "Staff Surname",
+          "A01B02C",
           "Test Team",
           LocalDate.parse("2023-07-27"),
           1L,


### PR DESCRIPTION
This PR is to include a field missed off the previous PR for staff code. 