### PR TITLE
Example of adding test to detect unprotected endpoints

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/ControllerAnnotations.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/ControllerAnnotations.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+annotation class ProtectedByIngress
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+annotation class PublicEndpoint

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/EndpointSecurityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/EndpointSecurityTest.kt
@@ -1,0 +1,63 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.fail
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider
+import org.springframework.core.type.filter.AnnotationTypeFilter
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.RestController
+import java.lang.reflect.AnnotatedElement
+import java.lang.reflect.Method
+
+class EndpointSecurityTest {
+  private data class EndpointInfo(
+    val method: String,
+    val hasEndpointLevelProtection: Boolean,
+  )
+
+  private data class ControllerInfo(
+    val controller: String,
+    val unprotectedEndpoints: List<EndpointInfo>,
+  ) {
+    override fun toString(): String {
+      val endpointDescription = unprotectedEndpoints.joinToString(separator = "\n * ", prefix = "\n * ") { it.method }
+      return "\n$controller:$endpointDescription".trimEnd()
+    }
+  }
+
+  @Test
+  fun `Ensure endpoints are checking roles`() {
+    val controllers = getAllUnprotectedControllers()
+
+    if (controllers.isNotEmpty()) {
+      fail("Role checks missing in following locations: ${controllers.joinToString("\n")}\n")
+    }
+  }
+
+  private fun getAllUnprotectedControllers() = ClassPathScanningCandidateComponentProvider(false)
+    .also { it.addIncludeFilter(AnnotationTypeFilter(RestController::class.java)) }
+    .findCandidateComponents("uk.gov.justice")
+    .map { Class.forName(it.beanClassName) }
+    .filter { !it.isProtectedByAnnotation() }
+    .map { ControllerInfo(it.toString(), it.getUnprotectedEndpoints()) }
+    .filter { it.unprotectedEndpoints.isNotEmpty() }
+
+  private fun Class<*>.getUnprotectedEndpoints() = this.methods
+    .filter { it.isEndpoint() }
+    .map { EndpointInfo(it.toString(), it.isProtectedByAnnotation()) }
+    .filter { ep -> !ep.hasEndpointLevelProtection }
+
+  private fun Method.isEndpoint() = this.annotations.any {
+    it.annotationClass.qualifiedName!!.startsWith("org.springframework.web.bind.annotation")
+  }
+
+  private fun AnnotatedElement.isProtectedByAnnotation(): Boolean {
+    if (ANNOTATIONS_THAT_DENOTE_EXCLUSION.any { this.isAnnotationPresent(it) }) return true
+    val annotation = getAnnotation(PreAuthorize::class.java) ?: return false
+    return annotation.value.contains("hasAnyRole") || annotation.value.contains("hasRole")
+  }
+
+  companion object {
+    val ANNOTATIONS_THAT_DENOTE_EXCLUSION = setOf(ProtectedByIngress::class.java, PublicEndpoint::class.java)
+  }
+}


### PR DESCRIPTION
Produces the following junit test failure:

```
Role checks missing in following locations: 
class uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.ComController:
 * public void uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.ComController.updateComDetails(uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.UpdateComRequest)

class uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.LicenceController:
 * public uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.LicenceSummary uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.LicenceController.createLicence(uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.request.CreateLicenceRequest)
 * public void uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.LicenceController.updateAppointmentPerson(long,uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AppointmentPersonRequest)
 * public void uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.LicenceController.updateAppointmentAddress(long,uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.AppointmentAddressRequest)
```
