### PR TITLE
CVSL-1364 Removing filtering to APPROVED licences for licence deactivation endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceService.kt
@@ -555,7 +555,7 @@ class LicenceService(
   @Transactional
   fun inActivateLicencesByIds(licenceIds: List<Long>) {
     val matchingLicences =
-      licenceRepository.findAllById(licenceIds).filter { it.statusCode == APPROVED }
+      licenceRepository.findAllById(licenceIds)
     inactivateLicences(matchingLicences)
   }
 


### PR DESCRIPTION
The only call to this endpoint currently comes from the licenceExpiryService, which deactivates active licences, so the limitation of only finding `APPROVED` licences needs to be removed.