### PR TITLE
CVSL-999 Changes following QA feedback

### DIFF
--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -7,6 +7,7 @@
     <ID>FunctionNaming:JPASpecificationDSL.kt$fun &lt;T, R : Any&gt; KProperty1&lt;T, R?&gt;.`in`(values: Collection&lt;R&gt;): Specification&lt;T&gt;</ID>
     <ID>LargeClass:LicenceController.kt$LicenceController</ID>
     <ID>LargeClass:LicenceService.kt$LicenceService</ID>
+    <ID>LongMethod:ComService.kt$ComService$fun searchForOffenderOnStaffCaseload(body: ProbationUserSearchRequest): ProbationSearchResult</ID>
     <ID>LongMethod:LicenceService.kt$LicenceService$@Transactional fun updateLicenceStatus(licenceId: Long, request: StatusUpdateRequest)</ID>
     <ID>LongMethod:LicenceService.kt$LicenceService$private fun copyLicenceAndConditions(licence: EntityLicence, newStatus: LicenceStatus): EntityLicence</ID>
     <ID>LongMethod:ToModelTransformers.kt$fun transform(licence: EntityLicence): ModelLicence</ID>
@@ -46,7 +47,6 @@
     <ID>UnusedParameter:LicenceController.kt$LicenceController$@PathVariable conditionType: String</ID>
     <ID>UnusedParameter:OpenApiConfiguration.kt$OpenApiConfiguration$buildProperties: BuildProperties</ID>
     <ID>UnusedParameter:WebClientConfiguration.kt$WebClientConfiguration$authorizedClientManager: OAuth2AuthorizedClientManager</ID>
-    <ID>UnusedPrivateProperty:ComService.kt$ComService$val prisonerSearchResult = this.prisonerSearchApiClient.searchPrisonersByNomisIds(listOf(it.identifiers.noms))</ID>
     <ID>UseCheckOrError:CommunityApiClient.kt$CommunityApiClient$throw IllegalStateException("Unexpected null response from API")</ID>
     <ID>UseCheckOrError:LicenceService.kt$LicenceService$throw IllegalStateException("Can only update licence version when editing an existing version or creating a variation")</ID>
     <ID>UseCheckOrError:LicenceService.kt$LicenceService$throw IllegalStateException("Cannot find staff with username: $username")</ID>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/FoundProbationRecord.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/FoundProbationRecord.kt
@@ -22,7 +22,7 @@ data class FoundProbationRecord(
   val nomisId: String? = "",
 
   @Schema(description = "The forename and surname of the COM")
-  val comName: String = "",
+  val comName: String? = "",
 
   @Schema(description = "The COM's staff code")
   val comStaffCode: String? = "",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ToModelTransformers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ToModelTransformers.kt
@@ -3,6 +3,9 @@ package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.Licence
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.LicenceSummary
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation.ProbationSearchResponseResult
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceType
+import java.time.LocalDate
 import java.util.Base64
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.AdditionalCondition as EntityAdditionalCondition
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.AdditionalConditionData as EntityAdditionalConditionData
@@ -238,12 +241,12 @@ fun transform(entity: EntityLicenceEvent): ModelLicenceEvent {
   )
 }
 
-fun ProbationSearchResponseResult.transformToModelFoundProbationRecord(licence: Licence?): ModelFoundProbationRecord {
+fun ProbationSearchResponseResult.transformToModelFoundProbationRecord(licence: Licence?, comName: String?): ModelFoundProbationRecord {
   return ModelFoundProbationRecord(
     name = "${name.forename} ${name.surname}".convertToTitleCase(),
     crn = licence?.crn,
     nomisId = licence?.nomsId,
-    comName = "${manager.name?.forename} ${manager.name?.surname}".convertToTitleCase(),
+    comName = comName,
     comStaffCode = manager.code,
     teamName = manager.team.description ?: licence?.probationTeamDescription,
     releaseDate = licence?.conditionalReleaseDate ?: licence?.actualReleaseDate,
@@ -251,5 +254,26 @@ fun ProbationSearchResponseResult.transformToModelFoundProbationRecord(licence: 
     licenceType = licence?.typeCode,
     licenceStatus = licence?.statusCode,
     isOnProbation = licence?.statusCode?.isOnProbation(),
+  )
+}
+
+fun ProbationSearchResponseResult.transformToModelFoundProbationRecordWithoutLicence(
+  comName: String?,
+  releaseDate: LocalDate?,
+  licenceType: LicenceType?,
+  licenceStatus: LicenceStatus?,
+): ModelFoundProbationRecord {
+  return ModelFoundProbationRecord(
+    name = "${name.forename} ${name.surname}".convertToTitleCase(),
+    crn = identifiers.crn,
+    nomisId = identifiers.noms,
+    comName = comName,
+    comStaffCode = manager.code,
+    teamName = manager.team.description,
+    releaseDate = releaseDate,
+    licenceId = null,
+    licenceType = licenceType,
+    licenceStatus = licenceStatus,
+    isOnProbation = false,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/prison/PrisonerSearchApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/prison/PrisonerSearchApiClient.kt
@@ -22,7 +22,7 @@ class PrisonerSearchApiClient(@Qualifier("oauthPrisonerSearchClient") val prison
       .bodyToMono(typeReference<List<PrisonerSearchPrisoner>>())
       .block() ?: emptyList()
   }
-  fun searchPrisonersByNomisIds(nomisIds: List<String>): List<PrisonerSearchPrisoner> {
+  fun searchPrisonersByNomisIds(nomisIds: List<String?>): List<PrisonerSearchPrisoner> {
     if (nomisIds.isEmpty()) return emptyList()
     return prisonerSearchApiWebClient
       .post()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/prison/PrisonerSearchPrisoner.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/prison/PrisonerSearchPrisoner.kt
@@ -4,4 +4,8 @@ data class PrisonerSearchPrisoner(
   val prisonerNumber: String,
   val bookingId: String,
   val status: String? = null,
+  val licenceExpiryDate: String? = null,
+  val topUpSupervisionExpiryDate: String? = null,
+  val releaseDate: String? = null,
+  val confirmedReleaseDate: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/prison/model/request/PrisonerSearchByPrisonerNumbersRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/prison/model/request/PrisonerSearchByPrisonerNumbersRequest.kt
@@ -1,5 +1,5 @@
 package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.prison.model.request
 
 data class PrisonerSearchByPrisonerNumbersRequest(
-  val prisonerNumbers: List<String>,
+  val prisonerNumbers: List<String?>,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/Identifiers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/Identifiers.kt
@@ -2,5 +2,5 @@ package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation
 
 class Identifiers(
   val crn: String,
-  val noms: String,
+  val noms: String?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/model/request/ProbationSearchSortByRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/model/request/ProbationSearchSortByRequest.kt
@@ -1,6 +1,6 @@
 package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation.model.request
 
 data class ProbationSearchSortByRequest(
-  val field: String = "name.forename",
+  val field: String = "name.surname",
   val direction: String = "asc",
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/util/LicenceEventType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/util/LicenceEventType.kt
@@ -16,4 +16,5 @@ enum class LicenceEventType {
   INACTIVE,
   RECALLED,
   VERSION_CREATED,
+  NOT_STARTED,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/util/LicenceStatus.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/util/LicenceStatus.kt
@@ -12,6 +12,7 @@ enum class LicenceStatus {
   VARIATION_SUBMITTED,
   VARIATION_REJECTED,
   VARIATION_APPROVED,
+  NOT_STARTED,
   ;
 
   fun isOnProbation() = ON_PROBATION_STATUSES.contains(this)
@@ -30,6 +31,7 @@ enum class LicenceStatus {
         VARIATION_APPROVED -> LicenceEventType.VARIATION_APPROVED
         INACTIVE -> LicenceEventType.INACTIVE
         RECALLED -> LicenceEventType.RECALLED
+        NOT_STARTED -> LicenceEventType.NOT_STARTED
       }
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/wiremock/PrisonerSearchMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/wiremock/PrisonerSearchMockServer.kt
@@ -49,19 +49,46 @@ class PrisonerSearchMockServer : WireMockServer(8099) {
                 {
                   "prisonerNumber": "A1234AA",
                   "bookingId": "123",
-                  "status": "INACTIVE"
+                  "status": "INACTIVE",
+                  "licenceExpiryDate": "2024-09-14",
+                  "topUpSupervisionExpiryDate": "2024-09-14",
+                  "releaseDate": "2023-09-14",
+                  "confirmedReleaseDate": "2023-09-14"
                },
                                {
                   "prisonerNumber": "A1234AB",
                   "bookingId": "456",
-                  "status": "INACTIVE"
+                  "status": "INACTIVE",
+                  "licenceExpiryDate": "2024-09-14",
+                  "topUpSupervisionExpiryDate": "2024-09-14",
+                  "releaseDate": null,
+                  "confirmedReleaseDate": "2023-09-14"
                },
-                               {
+               {
                   "prisonerNumber": "A1234AC",
                   "bookingId": "789",
-                  "status": "INACTIVE"
+                  "status": "INACTIVE",
+                  "licenceExpiryDate": null,
+                  "topUpSupervisionExpiryDate": null,
+                  "releaseDate": null,
+                  "confirmedReleaseDate": null
                }
               ]
+            """.trimIndent(),
+          ).withStatus(200),
+        ),
+    )
+  }
+
+  fun stubSearchPrisonersByNomisIdsNoResult() {
+    stubFor(
+      post(urlEqualTo("/api/prisoner-search/prisoner-numbers"))
+        .willReturn(
+          aResponse().withHeader(
+            "Content-Type",
+            "application/json",
+          ).withBody(
+            """[]
             """.trimIndent(),
           ).withStatus(200),
         ),


### PR DESCRIPTION
This PR is to allow the retrieval of search results where the corresponding person does not currently have a licence. It includes logic to return a search result without licence details as well as associated changes to tests and logic in the `ComService`. 