### PR TITLE
CVSL-1250 send the bank holiday object instead of list of dates

### DIFF
--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -35,7 +35,6 @@
     <ID>TooManyFunctions:LicenceService.kt$LicenceService</ID>
     <ID>TooManyFunctions:ToModelTransformers.kt$uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.ToModelTransformers.kt</ID>
     <ID>UnusedParameter:LicenceController.kt$LicenceController$@PathVariable conditionType: String</ID>
-    <ID>UseCheckOrError:GovUkApiClient.kt$GovUkApiClient$throw IllegalStateException("Unexpected null response from API")</ID>
     <ID>UtilityClassWithPublicConstructor:Tags.kt$Tags</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/BankHolidayController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/BankHolidayController.kt
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.BankHolidayService
-import java.time.LocalDate
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.gov.bankHolidays.BankHolidayEvent
 
 @RestController
 @RequestMapping("/", produces = [MediaType.APPLICATION_JSON_VALUE])
@@ -37,7 +37,7 @@ class BankHolidayController(private val bankHolidayService: BankHolidayService) 
       ApiResponse(
         responseCode = "200",
         description = "Bank Holidays retrieved",
-        content = [Content(mediaType = "application/json", array = ArraySchema(schema = Schema(implementation = LocalDate::class)))],
+        content = [Content(mediaType = "application/json", array = ArraySchema(schema = Schema(implementation = BankHolidayEvent::class)))],
       ),
       ApiResponse(
         responseCode = "401",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/gov/GovUkApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/gov/GovUkApiClient.kt
@@ -5,12 +5,12 @@ import org.springframework.http.MediaType
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.gov.bankHolidays.BankHoliday
-import java.time.LocalDate
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.gov.bankHolidays.BankHolidayEvent
 
 @Service
 class GovUkApiClient(@Qualifier("govUkWebClient") val govUkApiClient: WebClient) {
 
-  fun getBankHolidaysForEnglandAndWales(): List<LocalDate> {
+  fun getBankHolidaysForEnglandAndWales(): List<BankHolidayEvent> {
     val response = govUkApiClient
       .get()
       .uri("/bank-holidays.json")
@@ -19,7 +19,6 @@ class GovUkApiClient(@Qualifier("govUkWebClient") val govUkApiClient: WebClient)
       .bodyToMono(BankHoliday::class.java)
       .block()
 
-    return response?.bankHolidayResult?.events?.map { it.date }
-      ?: throw IllegalStateException("Unexpected null response from API")
+    return response?.bankHolidayResult?.events ?: error("Unexpected null response from API")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/BankHolidaysIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/BankHolidaysIntegrationTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.integration
 
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.groups.Tuple
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeAll
@@ -14,6 +15,7 @@ import org.springframework.cache.CacheManager
 import org.springframework.http.MediaType
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.integration.wiremock.GovUkMockServer
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.gov.GovUkApiClient
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.gov.bankHolidays.BankHolidayEvent
 import java.time.LocalDate
 
 class BankHolidaysIntegrationTest : IntegrationTestBase() {
@@ -40,18 +42,20 @@ class BankHolidaysIntegrationTest : IntegrationTestBase() {
       .exchange()
       .expectStatus().isOk
       .expectHeader().contentType(MediaType.APPLICATION_JSON)
-      .expectBodyList(LocalDate::class.java)
+      .expectBodyList(BankHolidayEvent::class.java)
       .returnResult().responseBody
 
-    assertThat(resultList.size).isEqualTo(4)
-    assertThat(resultList).isEqualTo(
-      listOf(
-        LocalDate.parse("2018-01-01"),
-        LocalDate.parse("2018-03-30"),
-        LocalDate.parse("2018-04-02"),
-        LocalDate.parse("2018-05-07"),
-      ),
-    )
+    assertThat(resultList?.size).isEqualTo(4)
+    assertThat(resultList)
+      .extracting<Tuple> {
+        Tuple.tuple(it.date)
+      }
+      .contains(
+        Tuple.tuple(LocalDate.parse("2018-01-01")),
+        Tuple.tuple(LocalDate.parse("2018-03-30")),
+        Tuple.tuple(LocalDate.parse("2018-04-02")),
+        Tuple.tuple(LocalDate.parse("2018-05-07")),
+      )
   }
 
   @Test
@@ -64,10 +68,10 @@ class BankHolidaysIntegrationTest : IntegrationTestBase() {
       .exchange()
       .expectStatus().isOk
       .expectHeader().contentType(MediaType.APPLICATION_JSON)
-      .expectBodyList(LocalDate::class.java)
+      .expectBodyList(BankHolidayEvent::class.java)
       .returnResult().responseBody
 
-    assertThat(resultList.size).isEqualTo(4)
+    assertThat(resultList?.size).isEqualTo(4)
 
     resultList = webTestClient.get()
       .uri("/bank-holidays")
@@ -76,10 +80,10 @@ class BankHolidaysIntegrationTest : IntegrationTestBase() {
       .exchange()
       .expectStatus().isOk
       .expectHeader().contentType(MediaType.APPLICATION_JSON)
-      .expectBodyList(LocalDate::class.java)
+      .expectBodyList(BankHolidayEvent::class.java)
       .returnResult().responseBody
 
-    assertThat(resultList.size).isEqualTo(4)
+    assertThat(resultList?.size).isEqualTo(4)
 
     verify(govUkApiClient, times(1)).getBankHolidaysForEnglandAndWales()
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/BankHolidayControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/BankHolidayControllerTest.kt
@@ -22,6 +22,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.config.ControllerAdvice
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.BankHolidayService
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.gov.bankHolidays.BankHolidayEvent
 import java.time.LocalDate
 
 @ExtendWith(SpringExtension::class)
@@ -51,7 +52,7 @@ class BankHolidayControllerTest {
   @Test
   fun `retrieve bank holidays for England and Wales`() {
     val expectedBankHolidays = listOf(
-      LocalDate.parse("2023-09-21"),
+      BankHolidayEvent(date = LocalDate.parse("2023-09-21")),
     )
     whenever(bankHolidayService.getBankHolidaysForEnglandAndWales()).thenReturn(expectedBankHolidays)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/BankHolidayServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/BankHolidayServiceTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service
 
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.groups.Tuple
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
@@ -8,6 +9,7 @@ import org.mockito.Mockito.verify
 import org.mockito.kotlin.reset
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.gov.GovUkApiClient
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.gov.bankHolidays.BankHolidayEvent
 import java.time.LocalDate
 
 class BankHolidayServiceTest {
@@ -24,7 +26,7 @@ class BankHolidayServiceTest {
   fun `retrieves bank holidays for England and Wales`() {
     whenever(govUkApiClient.getBankHolidaysForEnglandAndWales()).thenReturn(
       listOf(
-        LocalDate.parse("2024-09-21"),
+        BankHolidayEvent(date = LocalDate.parse("2024-09-21")),
       ),
     )
 
@@ -34,6 +36,12 @@ class BankHolidayServiceTest {
 
     assertThat(result).isNotEmpty
     assertThat(result.size).isEqualTo(1)
-    assertThat(result[0]).isEqualTo("2024-09-21")
+    assertThat(result[0])
+      .extracting {
+        Tuple.tuple(it.date)
+      }
+      .isEqualTo(
+        Tuple.tuple(LocalDate.parse("2024-09-21")),
+      )
   }
 }


### PR DESCRIPTION
This PR is to change the return type of the new bank-holidays endpoint so that little change would be needed on the front end to accommodate the new endpoint. 