### PR TITLE
CVSL-1278 create endpoint to get licences based on prison number

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/publicApi/PublicLicenceController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/publicApi/PublicLicenceController.kt
@@ -96,7 +96,7 @@ class PublicLicenceController(private val publicLicenceService: PublicLicenceSer
     ],
   )
   fun getLicencesByPrisonNumber(@PathVariable("prisonNumber") prisonNumber: String) =
-    publicLicenceService.getAllLicencesByPrisonerNumber(prisonNumber)
+    publicLicenceService.getAllLicencesByPrisonNumber(prisonNumber)
 
   @GetMapping(value = ["/licence-summaries/crn/{crn}"])
   @ResponseBody

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/publicApi/PublicLicenceController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/publicApi/PublicLicenceController.kt
@@ -63,7 +63,7 @@ class PublicLicenceController(private val publicLicenceService: PublicLicenceSer
     return licence
   }
 
-  @GetMapping(value = ["/licences/prison-number/{prisonNumber}"])
+  @GetMapping(value = ["/licence-summaries/prison-number/{prisonNumber}"])
   @ResponseBody
   @Operation(
     summary = "Get a list of licences by prison number",
@@ -95,9 +95,8 @@ class PublicLicenceController(private val publicLicenceService: PublicLicenceSer
       ),
     ],
   )
-  fun getLicencesByPrisonNumber(): List<LicenceSummary>? {
-    return emptyList()
-  }
+  fun getLicencesByPrisonNumber(@PathVariable("prisonNumber") prisonNumber: String) =
+    publicLicenceService.getAllLicencesByPrisonerNumber(prisonNumber)
 
   @GetMapping(value = ["/licence-summaries/crn/{crn}"])
   @ResponseBody

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/publicApi/PublicLicenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/publicApi/PublicLicenceService.kt
@@ -5,9 +5,6 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.LicenceRepository
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.publicApi.model.licence.LicenceSummary
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceType
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.publicApi.model.licence.LicenceStatus as PublicLicenceStatus
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.publicApi.model.licence.LicenceType as PublicLicenceType
 
 @Service
 class PublicLicenceService(
@@ -18,32 +15,6 @@ class PublicLicenceService(
   fun getAllLicencesByCrn(crn: String): List<LicenceSummary> {
     val licences = licenceRepository.findAllByCrnAndStatusCodeIn(crn, LicenceStatus.IN_FLIGHT_LICENCES)
 
-    val modelLicenceSummary = licences.map {
-      it.transformToPublicLicenceSummary(it.typeCode.mapToPublicLicenceType(), it.statusCode.mapToPublicLicenceStatus())
-    }
-
-    return modelLicenceSummary
+    return licences.map { it.transformToPublicLicenceSummary() }
   }
-
-  private fun LicenceType.mapToPublicLicenceType() =
-    when {
-      this == LicenceType.AP -> PublicLicenceType.AP
-      this == LicenceType.PSS -> PublicLicenceType.PSS
-      this == LicenceType.AP_PSS -> PublicLicenceType.AP_PSS
-      else -> error("No matching licence type found")
-    }
-
-  private fun LicenceStatus.mapToPublicLicenceStatus() =
-    when {
-      this == LicenceStatus.IN_PROGRESS -> PublicLicenceStatus.IN_PROGRESS
-      this == LicenceStatus.SUBMITTED -> PublicLicenceStatus.SUBMITTED
-      this == LicenceStatus.APPROVED -> PublicLicenceStatus.APPROVED
-      this == LicenceStatus.ACTIVE -> PublicLicenceStatus.ACTIVE
-      this == LicenceStatus.REJECTED -> PublicLicenceStatus.REJECTED
-      this == LicenceStatus.INACTIVE -> PublicLicenceStatus.INACTIVE
-      this == LicenceStatus.VARIATION_IN_PROGRESS -> PublicLicenceStatus.VARIATION_IN_PROGRESS
-      this == LicenceStatus.VARIATION_SUBMITTED -> PublicLicenceStatus.VARIATION_SUBMITTED
-      this == LicenceStatus.VARIATION_APPROVED -> PublicLicenceStatus.VARIATION_APPROVED
-      else -> error("No matching licence status found")
-    }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/publicApi/PublicLicenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/publicApi/PublicLicenceService.kt
@@ -17,4 +17,11 @@ class PublicLicenceService(
 
     return licences.map { it.transformToPublicLicenceSummary() }
   }
+
+  @Transactional
+  fun getAllLicencesByPrisonerNumber(prisonNumber: String): List<LicenceSummary> {
+    val licences = licenceRepository.findAllByNomsIdAndStatusCodeIn(prisonNumber, LicenceStatus.IN_FLIGHT_LICENCES)
+
+    return licences.map { it.transformToPublicLicenceSummary() }
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/publicApi/PublicLicenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/publicApi/PublicLicenceService.kt
@@ -19,7 +19,7 @@ class PublicLicenceService(
   }
 
   @Transactional
-  fun getAllLicencesByPrisonerNumber(prisonNumber: String): List<LicenceSummary> {
+  fun getAllLicencesByPrisonNumber(prisonNumber: String): List<LicenceSummary> {
     val licences = licenceRepository.findAllByNomsIdAndStatusCodeIn(prisonNumber, LicenceStatus.IN_FLIGHT_LICENCES)
 
     return licences.map { it.transformToPublicLicenceSummary() }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/publicApi/ToModelTransformers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/publicApi/ToModelTransformers.kt
@@ -3,7 +3,9 @@ package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.publicApi
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.Licence
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceType
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.publicApi.model.licence.LicenceStatus as PublicLicenceStatus
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.publicApi.model.licence.LicenceSummary as ModelPublicLicenceSummary
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.publicApi.model.licence.LicenceType as PublicLicenceType
 
 /*
 ** Functions which transform JPA entity objects into their public API model equivalents.
@@ -34,22 +36,22 @@ private fun Licence.valueNotPresent(fieldName: String): Nothing = error("Null fi
 
 private fun LicenceType.mapToPublicLicenceType() =
   when {
-    this == LicenceType.AP -> uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.publicApi.model.licence.LicenceType.AP
-    this == LicenceType.PSS -> uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.publicApi.model.licence.LicenceType.PSS
-    this == LicenceType.AP_PSS -> uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.publicApi.model.licence.LicenceType.AP_PSS
+    this == LicenceType.AP -> PublicLicenceType.AP
+    this == LicenceType.PSS -> PublicLicenceType.PSS
+    this == LicenceType.AP_PSS -> PublicLicenceType.AP_PSS
     else -> error("No matching licence type found")
   }
 
 private fun LicenceStatus.mapToPublicLicenceStatus() =
   when {
-    this == LicenceStatus.IN_PROGRESS -> uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.publicApi.model.licence.LicenceStatus.IN_PROGRESS
-    this == LicenceStatus.SUBMITTED -> uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.publicApi.model.licence.LicenceStatus.SUBMITTED
-    this == LicenceStatus.APPROVED -> uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.publicApi.model.licence.LicenceStatus.APPROVED
-    this == LicenceStatus.ACTIVE -> uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.publicApi.model.licence.LicenceStatus.ACTIVE
-    this == LicenceStatus.REJECTED -> uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.publicApi.model.licence.LicenceStatus.REJECTED
-    this == LicenceStatus.INACTIVE -> uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.publicApi.model.licence.LicenceStatus.INACTIVE
-    this == LicenceStatus.VARIATION_IN_PROGRESS -> uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.publicApi.model.licence.LicenceStatus.VARIATION_IN_PROGRESS
-    this == LicenceStatus.VARIATION_SUBMITTED -> uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.publicApi.model.licence.LicenceStatus.VARIATION_SUBMITTED
-    this == LicenceStatus.VARIATION_APPROVED -> uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.publicApi.model.licence.LicenceStatus.VARIATION_APPROVED
+    this == LicenceStatus.IN_PROGRESS -> PublicLicenceStatus.IN_PROGRESS
+    this == LicenceStatus.SUBMITTED -> PublicLicenceStatus.SUBMITTED
+    this == LicenceStatus.APPROVED -> PublicLicenceStatus.APPROVED
+    this == LicenceStatus.ACTIVE -> PublicLicenceStatus.ACTIVE
+    this == LicenceStatus.REJECTED -> PublicLicenceStatus.REJECTED
+    this == LicenceStatus.INACTIVE -> PublicLicenceStatus.INACTIVE
+    this == LicenceStatus.VARIATION_IN_PROGRESS -> PublicLicenceStatus.VARIATION_IN_PROGRESS
+    this == LicenceStatus.VARIATION_SUBMITTED -> PublicLicenceStatus.VARIATION_SUBMITTED
+    this == LicenceStatus.VARIATION_APPROVED -> PublicLicenceStatus.VARIATION_APPROVED
     else -> error("No matching licence status found")
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/publicApi/ToModelTransformers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/publicApi/ToModelTransformers.kt
@@ -1,25 +1,22 @@
 package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.publicApi
 
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.Licence
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.publicApi.model.licence.LicenceStatus as ModelPublicLicenceStatus
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceType
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.publicApi.model.licence.LicenceSummary as ModelPublicLicenceSummary
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.publicApi.model.licence.LicenceType as ModelPublicLicenceType
 
 /*
 ** Functions which transform JPA entity objects into their public API model equivalents.
 ** Mostly pass-thru but some translations, so useful to keep the database objects separate from API objects.
 */
 
-fun Licence.transformToPublicLicenceSummary(
-  licenceType: ModelPublicLicenceType,
-  statusCode: ModelPublicLicenceStatus,
-): ModelPublicLicenceSummary {
+fun Licence.transformToPublicLicenceSummary(): ModelPublicLicenceSummary {
   return ModelPublicLicenceSummary(
     id = this.id,
-    licenceType = licenceType,
+    licenceType = this.typeCode.mapToPublicLicenceType(),
     policyVersion = this.licenceVersion ?: this.valueNotPresent("policyVersion"),
     version = this.version ?: this.valueNotPresent("version"),
-    statusCode = statusCode,
+    statusCode = this.statusCode.mapToPublicLicenceStatus(),
     prisonNumber = this.nomsId ?: this.valueNotPresent("prisonNumber"),
     bookingId = this.bookingId ?: this.valueNotPresent("bookingId"),
     crn = this.crn ?: this.valueNotPresent("crn"),
@@ -34,3 +31,25 @@ fun Licence.transformToPublicLicenceSummary(
 }
 
 private fun Licence.valueNotPresent(fieldName: String): Nothing = error("Null field retrieved: $fieldName for licence ${this.id}")
+
+private fun LicenceType.mapToPublicLicenceType() =
+  when {
+    this == LicenceType.AP -> uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.publicApi.model.licence.LicenceType.AP
+    this == LicenceType.PSS -> uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.publicApi.model.licence.LicenceType.PSS
+    this == LicenceType.AP_PSS -> uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.publicApi.model.licence.LicenceType.AP_PSS
+    else -> error("No matching licence type found")
+  }
+
+private fun LicenceStatus.mapToPublicLicenceStatus() =
+  when {
+    this == LicenceStatus.IN_PROGRESS -> uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.publicApi.model.licence.LicenceStatus.IN_PROGRESS
+    this == LicenceStatus.SUBMITTED -> uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.publicApi.model.licence.LicenceStatus.SUBMITTED
+    this == LicenceStatus.APPROVED -> uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.publicApi.model.licence.LicenceStatus.APPROVED
+    this == LicenceStatus.ACTIVE -> uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.publicApi.model.licence.LicenceStatus.ACTIVE
+    this == LicenceStatus.REJECTED -> uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.publicApi.model.licence.LicenceStatus.REJECTED
+    this == LicenceStatus.INACTIVE -> uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.publicApi.model.licence.LicenceStatus.INACTIVE
+    this == LicenceStatus.VARIATION_IN_PROGRESS -> uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.publicApi.model.licence.LicenceStatus.VARIATION_IN_PROGRESS
+    this == LicenceStatus.VARIATION_SUBMITTED -> uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.publicApi.model.licence.LicenceStatus.VARIATION_SUBMITTED
+    this == LicenceStatus.VARIATION_APPROVED -> uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.publicApi.model.licence.LicenceStatus.VARIATION_APPROVED
+    else -> error("No matching licence status found")
+  }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/publicApi/PublicLicenceServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/publicApi/PublicLicenceServiceIntegrationTest.kt
@@ -64,4 +64,34 @@ class PublicLicenceServiceIntegrationTest : IntegrationTestBase() {
 
     assertThat(result?.userMessage).contains("Access Denied")
   }
+
+  @Test
+  @Sql(
+    "classpath:test_data/seed-licence-id-1.sql",
+  )
+  fun `Get licences by prisoner number`() {
+    val resultList = webTestClient.get()
+      .uri("/public/licence-summaries/prison-number/A1234AA")
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LICENCES")))
+      .exchange()
+      .expectStatus().isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBodyList(LicenceSummary::class.java)
+      .returnResult().responseBody
+
+    assertThat(resultList?.size).isEqualTo(1)
+
+    val result = resultList?.first()
+
+    assertThat(result?.id).isEqualTo(1L)
+    assertThat(result?.licenceType).isEqualTo(LicenceType.AP)
+    assertThat(result?.policyVersion).isEqualTo("1.0")
+    assertThat(result?.version).isEqualTo("1.0")
+    assertThat(result?.statusCode).isEqualTo(LicenceStatus.IN_PROGRESS)
+    assertThat(result?.prisonNumber).isEqualTo("A1234AA")
+    assertThat(result?.bookingId).isEqualTo(12345L)
+    assertThat(result?.crn).isEqualTo("CRN1")
+    assertThat(result?.createdByUsername).isEqualTo("test-client")
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/publicApi/PublicLicenceControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/publicApi/PublicLicenceControllerTest.kt
@@ -72,7 +72,7 @@ class PublicLicenceControllerTest {
 
   @Test
   fun `get licences by prison number`() {
-    whenever(publicLicenceService.getAllLicencesByPrisonerNumber("A1234AA")).thenReturn(listOf(aLicenceSummary))
+    whenever(publicLicenceService.getAllLicencesByPrisonNumber("A1234AA")).thenReturn(listOf(aLicenceSummary))
 
     val result = mvc.perform(get("/public/licence-summaries/prison-number/A1234AA").accept(MediaType.APPLICATION_JSON))
       .andExpect(status().isOk)
@@ -100,7 +100,7 @@ class PublicLicenceControllerTest {
     assertThat(result.response.contentAsString)
       .isEqualTo(mapper.writeValueAsString(listOf(aLicenceSummary)))
 
-    verify(publicLicenceService, times(1)).getAllLicencesByPrisonerNumber("A1234AA")
+    verify(publicLicenceService, times(1)).getAllLicencesByPrisonNumber("A1234AA")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/publicApi/PublicLicenceControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/publicApi/PublicLicenceControllerTest.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import jakarta.persistence.EntityNotFoundException
 import org.assertj.core.api.AssertionsForClassTypes.assertThat
 import org.hamcrest.Matchers.contains
-import org.hamcrest.Matchers.`is`
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -73,9 +72,35 @@ class PublicLicenceControllerTest {
 
   @Test
   fun `get licences by prison number`() {
-    mvc.perform(get("/public/licences/prison-number/A1234AA").accept(MediaType.APPLICATION_JSON))
+    whenever(publicLicenceService.getAllLicencesByPrisonerNumber("A1234AA")).thenReturn(listOf(aLicenceSummary))
+
+    val result = mvc.perform(get("/public/licence-summaries/prison-number/A1234AA").accept(MediaType.APPLICATION_JSON))
       .andExpect(status().isOk)
-      .andExpect(jsonPath("$", `is`(emptyList<Any>())))
+      .andExpect(MockMvcResultMatchers.content().contentType(MediaType.APPLICATION_JSON))
+      .andExpect(
+        jsonPath(
+          "\$..createdDateTime",
+          contains("2023-10-11T11:00:00"),
+        ),
+      )
+      .andExpect(
+        jsonPath(
+          "\$..approvedDateTime",
+          contains("2023-10-11T12:00:00"),
+        ),
+      )
+      .andExpect(
+        jsonPath(
+          "\$..updatedDateTime",
+          contains("2023-10-11T11:30:00"),
+        ),
+      )
+      .andReturn()
+
+    assertThat(result.response.contentAsString)
+      .isEqualTo(mapper.writeValueAsString(listOf(aLicenceSummary)))
+
+    verify(publicLicenceService, times(1)).getAllLicencesByPrisonerNumber("A1234AA")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/publicApi/PublicLicenceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/publicApi/PublicLicenceServiceTest.kt
@@ -216,7 +216,7 @@ class PublicLicenceServiceTest {
       ),
     )
 
-    val licenceSummaries = service.getAllLicencesByPrisonerNumber("A1234BC")
+    val licenceSummaries = service.getAllLicencesByPrisonNumber("A1234BC")
     val licenceSummary = licenceSummaries.first()
 
     assertThat(licenceSummaries.size).isEqualTo(1)
@@ -262,7 +262,7 @@ class PublicLicenceServiceTest {
       ),
     )
 
-    val licenceSummaries = service.getAllLicencesByPrisonerNumber("A1234BC")
+    val licenceSummaries = service.getAllLicencesByPrisonNumber("A1234BC")
     val licenceSummary = licenceSummaries.first()
 
     assertThat(licenceSummaries.size).isEqualTo(1)
@@ -308,7 +308,7 @@ class PublicLicenceServiceTest {
       ),
     )
 
-    val licenceSummaries = service.getAllLicencesByPrisonerNumber("A12345")
+    val licenceSummaries = service.getAllLicencesByPrisonNumber("A12345")
     val licenceSummary = licenceSummaries.first()
 
     assertThat(licenceSummaries.size).isEqualTo(1)
@@ -355,7 +355,7 @@ class PublicLicenceServiceTest {
     )
 
     val exception = assertThrows<IllegalStateException> {
-      service.getAllLicencesByPrisonerNumber("A1234BC")
+      service.getAllLicencesByPrisonNumber("A1234BC")
     }
 
     assertThat(exception)
@@ -374,7 +374,7 @@ class PublicLicenceServiceTest {
     )
 
     val exception = assertThrows<IllegalStateException> {
-      service.getAllLicencesByPrisonerNumber("A1234BC")
+      service.getAllLicencesByPrisonNumber("A1234BC")
     }
 
     assertThat(exception)


### PR DESCRIPTION
This PR is to add a new endpoint to the CVL public API to allow a list of licence summary representations to be returned based on prison number.