### PR TITLE
CVSL-1425 Adding missing call to send reapproval email on licence edit

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceService.kt
@@ -593,6 +593,8 @@ class LicenceService(
     }
 
     val licenceCopy = copyLicenceAndConditions(licenceEntity, IN_PROGRESS)
+    notifyReApprovalNeeded(licenceEntity)
+
     return transformToLicenceSummary(licenceCopy)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceServiceTest.kt
@@ -1588,6 +1588,53 @@ class LicenceServiceTest {
   }
 
   @Test
+  fun `editing an approved licence creates and saves a new licence version and sends a reapproval email`() {
+    whenever(communityOffenderManagerRepository.findByUsernameIgnoreCase(any())).thenReturn(
+      CommunityOffenderManager(
+        -1,
+        1,
+        "user",
+        null,
+        null,
+        null,
+      ),
+    )
+    whenever(licencePolicyService.currentPolicy()).thenReturn(
+      LicencePolicy(
+        "2.1",
+        standardConditions = StandardConditions(emptyList(), emptyList()),
+        additionalConditions = AdditionalConditions(emptyList(), emptyList()),
+        changeHints = emptyList(),
+      ),
+    )
+
+    val approvedLicence = aLicenceEntity.copy(
+      statusCode = LicenceStatus.APPROVED,
+      additionalConditions = additionalConditions,
+    )
+    whenever(licenceRepository.findById(1L)).thenReturn(
+      Optional.of(approvedLicence),
+    )
+    whenever(omuService.getOmuContactEmail(any())).thenReturn(
+      OmuContact(
+        prisonCode = aLicenceEntity.prisonCode!!,
+        email = "test@OMU.testing.com",
+        dateCreated = LocalDateTime.now(),
+      ),
+    )
+    whenever(licenceRepository.save(any())).thenReturn(approvedLicence)
+
+    service.editLicence(1L)
+    verify(notifyService, times(1)).sendVariationForReApprovalEmail(
+      eq("test@OMU.testing.com"),
+      eq(aLicenceEntity.forename ?: "unknown"),
+      eq(aLicenceEntity.surname ?: "unknown"),
+      eq(aLicenceEntity.nomsId),
+      any(),
+    )
+  }
+
+  @Test
   fun `attempting to editing a licence with status other than approved results in validation exception `() {
     val activeLicence = aLicenceEntity.copy(statusCode = LicenceStatus.ACTIVE)
     whenever(licenceRepository.findById(1L)).thenReturn(
@@ -1632,6 +1679,39 @@ class LicenceServiceTest {
     assertThat(newLicenceVersion.licenceId).isEqualTo(inProgressLicenceVersion.id)
 
     verify(licenceRepository, never()).save(any())
+  }
+
+  @Test
+  fun `editing an approved licence which already has an in progress version does not send a reapproval email`() {
+    whenever(communityOffenderManagerRepository.findByUsernameIgnoreCase(any())).thenReturn(
+      CommunityOffenderManager(
+        -1,
+        1,
+        "user",
+        null,
+        null,
+        null,
+      ),
+    )
+    val approvedLicence = aLicenceEntity.copy(statusCode = LicenceStatus.APPROVED)
+    val inProgressLicenceVersion =
+      approvedLicence.copy(id = 9032, statusCode = LicenceStatus.IN_PROGRESS, versionOfId = approvedLicence.id)
+    whenever(licenceRepository.findById(1L)).thenReturn(
+      Optional.of(approvedLicence),
+    )
+    whenever(
+      licenceRepository.findAllByVersionOfIdInAndStatusCodeIn(
+        listOf(approvedLicence.id),
+        listOf(LicenceStatus.IN_PROGRESS, LicenceStatus.SUBMITTED),
+      ),
+    )
+      .thenReturn(
+        listOf(inProgressLicenceVersion),
+      )
+
+    service.editLicence(1L)
+
+    verify(notifyService, never()).sendVariationForReApprovalEmail(any(), any(), any(), any(), any())
   }
 
   @Test


### PR DESCRIPTION
By this time the code reaches the point of the added line, the only possibility is for the original licence to be APPROVED and the new edit to be IN_PROGRESS, therefore no additional checks are needed.