### PR TITLE
CVSL-1280 add endpoint to get full size image for exclusion zone based on condition id

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/publicApi/PublicLicenceController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/publicApi/PublicLicenceController.kt
@@ -138,8 +138,8 @@ class PublicLicenceController(private val publicLicenceService: PublicLicenceSer
   )
   @ResponseBody
   @Operation(
-    summary = "Get the exclusion zone map image for a specified licence and condition",
-    description = "Returns the exclusion zone map image for a specified licence and condition. " +
+    summary = "Get an associated image upload for a specific licence and condition",
+    description = "Returns an associated image upload for a specified licence and condition. " +
       "Requires ROLE_VIEW_LICENCES.",
     security = [SecurityRequirement(name = "ROLE_VIEW_LICENCES")],
   )
@@ -167,10 +167,10 @@ class PublicLicenceController(private val publicLicenceService: PublicLicenceSer
       ),
     ],
   )
-  fun getExclusionZoneImageByConditionId(
+  fun getImageUpload(
     @PathVariable(name = "licenceId") licenceId: Long,
     @PathVariable(name = "conditionId") conditionId: Long,
   ): ByteArray? {
-    return publicLicenceService.getExclusionZoneImageByConditionId(licenceId, conditionId)
+    return publicLicenceService.getImageUpload(licenceId, conditionId)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/publicApi/PublicLicenceController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/publicApi/PublicLicenceController.kt
@@ -131,4 +131,46 @@ class PublicLicenceController(private val publicLicenceService: PublicLicenceSer
     ],
   )
   fun getLicenceByCrn(@PathVariable("crn") crn: String) = publicLicenceService.getAllLicencesByCrn(crn)
+
+  @GetMapping(
+    value = ["/licences/{licenceId}/conditions/{conditionId}/image-upload"],
+    produces = [MediaType.IMAGE_JPEG_VALUE],
+  )
+  @ResponseBody
+  @Operation(
+    summary = "Get the exclusion zone map image for a specified licence and condition",
+    description = "Returns the exclusion zone map image for a specified licence and condition. " +
+      "Requires ROLE_VIEW_LICENCES.",
+    security = [SecurityRequirement(name = "ROLE_VIEW_LICENCES")],
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Image returned",
+        content = [Content(mediaType = "image/jpeg")],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorised, requires a valid Oauth2 token",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires an appropriate role",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "No image was found.",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  fun getExclusionZoneImageByConditionId(
+    @PathVariable(name = "licenceId") licenceId: Long,
+    @PathVariable(name = "conditionId") conditionId: Long,
+  ): ByteArray? {
+    return publicLicenceService.getExclusionZoneImageByConditionId(licenceId, conditionId)
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/publicApi/PublicLicenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/publicApi/PublicLicenceService.kt
@@ -1,7 +1,10 @@
 package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.publicApi
 
+import jakarta.persistence.EntityNotFoundException
 import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.AdditionalConditionRepository
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.AdditionalConditionUploadDetailRepository
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.LicenceRepository
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.publicApi.model.licence.LicenceSummary
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus
@@ -9,6 +12,8 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus
 @Service
 class PublicLicenceService(
   private val licenceRepository: LicenceRepository,
+  private val additionalConditionRepository: AdditionalConditionRepository,
+  private val additionalConditionUploadDetailRepository: AdditionalConditionUploadDetailRepository,
 ) {
 
   @Transactional
@@ -23,5 +28,27 @@ class PublicLicenceService(
     val licences = licenceRepository.findAllByNomsIdAndStatusCodeIn(prisonNumber, LicenceStatus.IN_FLIGHT_LICENCES)
 
     return licences.map { it.transformToPublicLicenceSummary() }
+  }
+
+  @Transactional
+  fun getExclusionZoneImageByConditionId(licenceId: Long, conditionId: Long): ByteArray? {
+    licenceRepository
+      .findById(licenceId)
+      .orElseThrow { EntityNotFoundException("Licence $licenceId not found") }
+
+    val additionalCondition = additionalConditionRepository
+      .findById(conditionId)
+      .orElseThrow { EntityNotFoundException("Condition $conditionId not found") }
+
+    val uploadIds = additionalCondition.additionalConditionUploadSummary.map { it.uploadDetailId }
+    if (uploadIds.isEmpty()) {
+      throw EntityNotFoundException("Condition $conditionId upload details not found")
+    }
+
+    val upload = additionalConditionUploadDetailRepository
+      .findById(uploadIds.first())
+      .orElseThrow { EntityNotFoundException("Condition $conditionId upload details not found") }
+
+    return upload.fullSizeImage
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/publicApi/PublicLicenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/publicApi/PublicLicenceService.kt
@@ -31,7 +31,7 @@ class PublicLicenceService(
   }
 
   @Transactional
-  fun getExclusionZoneImageByConditionId(licenceId: Long, conditionId: Long): ByteArray? {
+  fun getImageUpload(licenceId: Long, conditionId: Long): ByteArray? {
     licenceRepository
       .findById(licenceId)
       .orElseThrow { EntityNotFoundException("Licence $licenceId not found") }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/publicApi/PublicLicenceServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/publicApi/PublicLicenceServiceIntegrationTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.integration.publicApi
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
@@ -18,132 +19,141 @@ class PublicLicenceServiceIntegrationTest : IntegrationTestBase() {
   @Autowired
   lateinit var licenceRepository: LicenceRepository
 
-  @Test
-  @Sql(
-    "classpath:test_data/seed-licence-id-1.sql",
-  )
-  fun `Get licences by CRN`() {
-    val resultList = webTestClient.get()
-      .uri("/public/licence-summaries/crn/CRN1")
-      .accept(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LICENCES")))
-      .exchange()
-      .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
-      .expectBodyList(LicenceSummary::class.java)
-      .returnResult().responseBody
+  @Nested
+  inner class `Get licences by CRN` {
+    @Test
+    @Sql(
+      "classpath:test_data/seed-licence-id-1.sql",
+    )
+    fun `Get licences by CRN`() {
+      val resultList = webTestClient.get()
+        .uri("/public/licence-summaries/crn/CRN1")
+        .accept(MediaType.APPLICATION_JSON)
+        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LICENCES")))
+        .exchange()
+        .expectStatus().isOk
+        .expectHeader().contentType(MediaType.APPLICATION_JSON)
+        .expectBodyList(LicenceSummary::class.java)
+        .returnResult().responseBody
 
-    assertThat(resultList?.size).isEqualTo(1)
+      assertThat(resultList?.size).isEqualTo(1)
 
-    val result = resultList?.first()
+      val result = resultList?.first()
 
-    assertThat(result?.id).isEqualTo(1L)
-    assertThat(result?.licenceType).isEqualTo(LicenceType.AP)
-    assertThat(result?.policyVersion).isEqualTo("1.0")
-    assertThat(result?.version).isEqualTo("1.0")
-    assertThat(result?.statusCode).isEqualTo(LicenceStatus.IN_PROGRESS)
-    assertThat(result?.prisonNumber).isEqualTo("A1234AA")
-    assertThat(result?.bookingId).isEqualTo(12345L)
-    assertThat(result?.crn).isEqualTo("CRN1")
-    assertThat(result?.createdByUsername).isEqualTo("test-client")
+      assertThat(result?.id).isEqualTo(1L)
+      assertThat(result?.licenceType).isEqualTo(LicenceType.AP)
+      assertThat(result?.policyVersion).isEqualTo("1.0")
+      assertThat(result?.version).isEqualTo("1.0")
+      assertThat(result?.statusCode).isEqualTo(LicenceStatus.IN_PROGRESS)
+      assertThat(result?.prisonNumber).isEqualTo("A1234AA")
+      assertThat(result?.bookingId).isEqualTo(12345L)
+      assertThat(result?.crn).isEqualTo("CRN1")
+      assertThat(result?.createdByUsername).isEqualTo("test-client")
+    }
+
+    @Test
+    @Sql(
+      "classpath:test_data/seed-licence-id-1.sql",
+    )
+    fun `Get licences by CRN is role protected`() {
+      val result = webTestClient.get()
+        .uri("/public/licence-summaries/crn/CRN1")
+        .accept(MediaType.APPLICATION_JSON)
+        .headers(setAuthorisation(roles = listOf("ROLE_CVL_VERY_WRONG")))
+        .exchange()
+        .expectStatus().isEqualTo(HttpStatus.FORBIDDEN.value())
+        .expectBody(ErrorResponse::class.java)
+        .returnResult().responseBody
+
+      assertThat(result?.userMessage).contains("Access Denied")
+    }
   }
 
-  @Test
-  @Sql(
-    "classpath:test_data/seed-licence-id-1.sql",
-  )
-  fun `Get licences by CRN is role protected`() {
-    val result = webTestClient.get()
-      .uri("/public/licence-summaries/crn/CRN1")
-      .accept(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("ROLE_CVL_VERY_WRONG")))
-      .exchange()
-      .expectStatus().isEqualTo(HttpStatus.FORBIDDEN.value())
-      .expectBody(ErrorResponse::class.java)
-      .returnResult().responseBody
+  @Nested
+  inner class `Get licences by prisoner number` {
+    @Test
+    @Sql(
+      "classpath:test_data/seed-licence-id-1.sql",
+    )
+    fun `Get licences by prisoner number`() {
+      val resultList = webTestClient.get()
+        .uri("/public/licence-summaries/prison-number/A1234AA")
+        .accept(MediaType.APPLICATION_JSON)
+        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LICENCES")))
+        .exchange()
+        .expectStatus().isOk
+        .expectHeader().contentType(MediaType.APPLICATION_JSON)
+        .expectBodyList(LicenceSummary::class.java)
+        .returnResult().responseBody
 
-    assertThat(result?.userMessage).contains("Access Denied")
+      assertThat(resultList?.size).isEqualTo(1)
+
+      val result = resultList?.first()
+
+      assertThat(result?.id).isEqualTo(1L)
+      assertThat(result?.licenceType).isEqualTo(LicenceType.AP)
+      assertThat(result?.policyVersion).isEqualTo("1.0")
+      assertThat(result?.version).isEqualTo("1.0")
+      assertThat(result?.statusCode).isEqualTo(LicenceStatus.IN_PROGRESS)
+      assertThat(result?.prisonNumber).isEqualTo("A1234AA")
+      assertThat(result?.bookingId).isEqualTo(12345L)
+      assertThat(result?.crn).isEqualTo("CRN1")
+      assertThat(result?.createdByUsername).isEqualTo("test-client")
+    }
+
+    @Test
+    @Sql(
+      "classpath:test_data/seed-licence-id-1.sql",
+    )
+    fun `Get licences by prisoner number is role protected`() {
+      val result = webTestClient.get()
+        .uri("/public/licence-summaries/prison-number/A1234AA")
+        .accept(MediaType.APPLICATION_JSON)
+        .headers(setAuthorisation(roles = listOf("ROLE_CVL_VERY_WRONG")))
+        .exchange()
+        .expectStatus().isEqualTo(HttpStatus.FORBIDDEN.value())
+        .expectBody(ErrorResponse::class.java)
+        .returnResult().responseBody
+
+      assertThat(result?.userMessage).contains("Access Denied")
+    }
   }
 
-  @Test
-  @Sql(
-    "classpath:test_data/seed-licence-id-1.sql",
-  )
-  fun `Get licences by prisoner number`() {
-    val resultList = webTestClient.get()
-      .uri("/public/licence-summaries/prison-number/A1234AA")
-      .accept(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LICENCES")))
-      .exchange()
-      .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
-      .expectBodyList(LicenceSummary::class.java)
-      .returnResult().responseBody
+  @Nested
+  inner class `Get exclusion zone image by condition ID` {
+    @Test
+    @Sql(
+      "classpath:test_data/seed-licence-id-2.sql",
+      "classpath:test_data/add-upload-to-licence-id-2.sql",
+    )
+    fun `Get exclusion zone image by condition ID`() {
+      val result = webTestClient.get()
+        .uri("/public/licences/2/conditions/1/image-upload")
+        .accept(MediaType.IMAGE_JPEG, MediaType.APPLICATION_JSON)
+        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LICENCES")))
+        .exchange()
+        .expectStatus().isOk
 
-    assertThat(resultList?.size).isEqualTo(1)
+      assertThat(result.expectHeader().contentType(MediaType.IMAGE_JPEG)).isNotNull
+      assertThat(result.expectBody()).isNotNull
+    }
 
-    val result = resultList?.first()
+    @Test
+    @Sql(
+      "classpath:test_data/seed-licence-id-2.sql",
+      "classpath:test_data/add-upload-to-licence-id-2.sql",
+    )
+    fun `Get exclusion zone image by condition ID is role-protected`() {
+      val result = webTestClient.get()
+        .uri("/public/licences/2/conditions/1/image-upload")
+        .accept(MediaType.IMAGE_JPEG, MediaType.APPLICATION_JSON)
+        .headers(setAuthorisation(roles = listOf("ROLE_CVL_VERY_WRONG")))
+        .exchange()
+        .expectStatus().isEqualTo(HttpStatus.FORBIDDEN.value())
+        .expectBody(ErrorResponse::class.java)
+        .returnResult().responseBody
 
-    assertThat(result?.id).isEqualTo(1L)
-    assertThat(result?.licenceType).isEqualTo(LicenceType.AP)
-    assertThat(result?.policyVersion).isEqualTo("1.0")
-    assertThat(result?.version).isEqualTo("1.0")
-    assertThat(result?.statusCode).isEqualTo(LicenceStatus.IN_PROGRESS)
-    assertThat(result?.prisonNumber).isEqualTo("A1234AA")
-    assertThat(result?.bookingId).isEqualTo(12345L)
-    assertThat(result?.crn).isEqualTo("CRN1")
-    assertThat(result?.createdByUsername).isEqualTo("test-client")
-  }
-
-  @Test
-  @Sql(
-    "classpath:test_data/seed-licence-id-1.sql",
-  )
-  fun `Get licences by prisoner number is role protected`() {
-    val result = webTestClient.get()
-      .uri("/public/licence-summaries/prison-number/A1234AA")
-      .accept(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("ROLE_CVL_VERY_WRONG")))
-      .exchange()
-      .expectStatus().isEqualTo(HttpStatus.FORBIDDEN.value())
-      .expectBody(ErrorResponse::class.java)
-      .returnResult().responseBody
-
-    assertThat(result?.userMessage).contains("Access Denied")
-  }
-
-  @Test
-  @Sql(
-    "classpath:test_data/seed-licence-id-2.sql",
-    "classpath:test_data/add-upload-to-licence-id-2.sql",
-  )
-  fun `Get exclusion zone image by condition ID`() {
-    val result = webTestClient.get()
-      .uri("/public/licences/2/conditions/1/image-upload")
-      .accept(MediaType.IMAGE_JPEG, MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LICENCES")))
-      .exchange()
-      .expectStatus().isOk
-
-    assertThat(result.expectHeader().contentType(MediaType.IMAGE_JPEG)).isNotNull
-    assertThat(result.expectBody()).isNotNull
-  }
-
-  @Test
-  @Sql(
-    "classpath:test_data/seed-licence-id-2.sql",
-    "classpath:test_data/add-upload-to-licence-id-2.sql",
-  )
-  fun `Get exclusion zone image by condition ID is role-protected`() {
-    val result = webTestClient.get()
-      .uri("/public/licences/2/conditions/1/image-upload")
-      .accept(MediaType.IMAGE_JPEG, MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf("ROLE_CVL_VERY_WRONG")))
-      .exchange()
-      .expectStatus().isEqualTo(HttpStatus.FORBIDDEN.value())
-      .expectBody(ErrorResponse::class.java)
-      .returnResult().responseBody
-
-    assertThat(result?.userMessage).contains("Access Denied")
+      assertThat(result?.userMessage).contains("Access Denied")
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/privateApi/BankHolidayControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/privateApi/BankHolidayControllerTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.privateApi
 
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -21,7 +21,6 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.config.ControllerAdvice
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.privateApi.BankHolidayController
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.BankHolidayService
 import java.time.LocalDate
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/publicApi/PublicLicenceControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/publicApi/PublicLicenceControllerTest.kt
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.core.io.ClassPathResource
 import org.springframework.http.MediaType
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
@@ -150,6 +151,20 @@ class PublicLicenceControllerTest {
     verify(publicLicenceService, times(1)).getAllLicencesByCrn("A12345")
   }
 
+  @Test
+  fun `get a full-size image for an exclusion zone`() {
+    whenever(publicLicenceService.getExclusionZoneImageByConditionId(1, 1)).thenReturn(aFullSizeMapImage)
+
+    val result = mvc.perform(get("/public/licences/1/conditions/1/image-upload").accept(MediaType.IMAGE_JPEG))
+      .andExpect(status().isOk)
+      .andExpect(MockMvcResultMatchers.content().contentType(MediaType.IMAGE_JPEG))
+      .andReturn()
+
+    assertThat(result.response.contentAsByteArray).isEqualTo(aFullSizeMapImage)
+
+    verify(publicLicenceService, times(1)).getExclusionZoneImageByConditionId(1, 1)
+  }
+
   private companion object {
     val aLicenceSummary = LicenceSummary(
       id = 1,
@@ -168,5 +183,7 @@ class PublicLicenceControllerTest {
       updatedDateTime = LocalDateTime.of(2023, 10, 11, 11, 30, 0),
       isInPssPeriod = false,
     )
+
+    val aFullSizeMapImage = ClassPathResource("test_map.jpg").inputStream.readAllBytes()
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/publicApi/PublicLicenceControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/publicApi/PublicLicenceControllerTest.kt
@@ -153,7 +153,7 @@ class PublicLicenceControllerTest {
 
   @Test
   fun `get a full-size image for an exclusion zone`() {
-    whenever(publicLicenceService.getExclusionZoneImageByConditionId(1, 1)).thenReturn(aFullSizeMapImage)
+    whenever(publicLicenceService.getImageUpload(1, 1)).thenReturn(aFullSizeMapImage)
 
     val result = mvc.perform(get("/public/licences/1/conditions/1/image-upload").accept(MediaType.IMAGE_JPEG))
       .andExpect(status().isOk)
@@ -162,7 +162,7 @@ class PublicLicenceControllerTest {
 
     assertThat(result.response.contentAsByteArray).isEqualTo(aFullSizeMapImage)
 
-    verify(publicLicenceService, times(1)).getExclusionZoneImageByConditionId(1, 1)
+    verify(publicLicenceService, times(1)).getImageUpload(1, 1)
   }
 
   private companion object {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/publicApi/PublicLicenceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/publicApi/PublicLicenceServiceTest.kt
@@ -4,6 +4,7 @@ import jakarta.persistence.EntityNotFoundException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.groups.Tuple
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
@@ -35,7 +36,11 @@ class PublicLicenceServiceTest {
   private val licenceRepository = mock<LicenceRepository>()
   private val additionalConditionRepository = mock<AdditionalConditionRepository>()
   private val additionalConditionUploadDetailRepository = mock<AdditionalConditionUploadDetailRepository>()
-  private val service = PublicLicenceService(licenceRepository, additionalConditionRepository, additionalConditionUploadDetailRepository)
+  private val service = PublicLicenceService(
+    licenceRepository,
+    additionalConditionRepository,
+    additionalConditionUploadDetailRepository,
+  )
 
   @BeforeEach
   fun reset() {
@@ -46,447 +51,456 @@ class PublicLicenceServiceTest {
     )
   }
 
-  @Test
-  fun `service returns a list of licence summaries by crn`() {
-    whenever(licenceRepository.findAllByCrnAndStatusCodeIn(any(), any())).thenReturn(
-      listOf(
-        aLicenceEntity,
-      ),
-    )
-
-    val licenceSummaries = service.getAllLicencesByCrn("A12345")
-    val licenceSummary = licenceSummaries.first()
-
-    assertThat(licenceSummaries.size).isEqualTo(1)
-
-    assertThat(licenceSummary).isExactlyInstanceOf(ModelPublicLicenceSummary::class.java)
-
-    assertThat(licenceSummary)
-      .extracting {
-        Tuple.tuple(
-          it.id, it.licenceType, it.policyVersion, it.version, it.statusCode, it.prisonNumber, it.bookingId,
-          it.crn, it.approvedByUsername, it.approvedDateTime, it.createdByUsername, it.createdDateTime,
-          it.updatedByUsername, it.updatedDateTime, it.isInPssPeriod,
-        )
-      }
-      .isEqualTo(
-        Tuple.tuple(
-          1L,
-          PublicLicenceType.AP,
-          "1.0",
-          "1.4",
-          PublicLicenceStatus.IN_PROGRESS,
-          "A1234BC",
-          987654L,
-          "A12345",
-          "testapprover",
-          LocalDateTime.parse("2023-10-11T13:00"),
-          "testcom",
-          LocalDateTime.parse("2023-10-11T11:00"),
-          "testupdater",
-          LocalDateTime.parse("2023-10-11T12:00"),
-          false,
+  @Nested
+  inner class `Get licence by CRN` {
+    @Test
+    fun `service returns a list of licence summaries by crn`() {
+      whenever(licenceRepository.findAllByCrnAndStatusCodeIn(any(), any())).thenReturn(
+        listOf(
+          aLicenceEntity,
         ),
       )
 
-    verify(licenceRepository, times(1)).findAllByCrnAndStatusCodeIn(any(), any())
-  }
+      val licenceSummaries = service.getAllLicencesByCrn("A12345")
+      val licenceSummary = licenceSummaries.first()
 
-  @Test
-  fun `service returns a list of licence summaries by crn where approved username and approved date are not present`() {
-    whenever(licenceRepository.findAllByCrnAndStatusCodeIn(any(), any())).thenReturn(
-      listOf(
-        aLicenceEntity.copy(approvedByUsername = null, approvedDate = null),
-      ),
-    )
+      assertThat(licenceSummaries.size).isEqualTo(1)
 
-    val licenceSummaries = service.getAllLicencesByCrn("A12345")
-    val licenceSummary = licenceSummaries.first()
+      assertThat(licenceSummary).isExactlyInstanceOf(ModelPublicLicenceSummary::class.java)
 
-    assertThat(licenceSummaries.size).isEqualTo(1)
-
-    assertThat(licenceSummary).isExactlyInstanceOf(ModelPublicLicenceSummary::class.java)
-
-    assertThat(licenceSummary)
-      .extracting {
-        Tuple.tuple(
-          it.id, it.licenceType, it.policyVersion, it.version, it.statusCode, it.prisonNumber, it.bookingId,
-          it.crn, it.approvedByUsername, it.approvedDateTime, it.createdByUsername, it.createdDateTime,
-          it.updatedByUsername, it.updatedDateTime, it.isInPssPeriod,
+      assertThat(licenceSummary)
+        .extracting {
+          Tuple.tuple(
+            it.id, it.licenceType, it.policyVersion, it.version, it.statusCode, it.prisonNumber, it.bookingId,
+            it.crn, it.approvedByUsername, it.approvedDateTime, it.createdByUsername, it.createdDateTime,
+            it.updatedByUsername, it.updatedDateTime, it.isInPssPeriod,
+          )
+        }
+        .isEqualTo(
+          Tuple.tuple(
+            1L,
+            PublicLicenceType.AP,
+            "1.0",
+            "1.4",
+            PublicLicenceStatus.IN_PROGRESS,
+            "A1234BC",
+            987654L,
+            "A12345",
+            "testapprover",
+            LocalDateTime.parse("2023-10-11T13:00"),
+            "testcom",
+            LocalDateTime.parse("2023-10-11T11:00"),
+            "testupdater",
+            LocalDateTime.parse("2023-10-11T12:00"),
+            false,
+          ),
         )
-      }
-      .isEqualTo(
-        Tuple.tuple(
-          1L,
-          PublicLicenceType.AP,
-          "1.0",
-          "1.4",
-          PublicLicenceStatus.IN_PROGRESS,
-          "A1234BC",
-          987654L,
-          "A12345",
-          null,
-          null,
-          "testcom",
-          LocalDateTime.parse("2023-10-11T11:00"),
-          "testupdater",
-          LocalDateTime.parse("2023-10-11T12:00"),
-          false,
+
+      verify(licenceRepository, times(1)).findAllByCrnAndStatusCodeIn(any(), any())
+    }
+
+    @Test
+    fun `service returns a list of licence summaries by crn where approved username and approved date are not present`() {
+      whenever(licenceRepository.findAllByCrnAndStatusCodeIn(any(), any())).thenReturn(
+        listOf(
+          aLicenceEntity.copy(approvedByUsername = null, approvedDate = null),
         ),
       )
 
-    verify(licenceRepository, times(1)).findAllByCrnAndStatusCodeIn(any(), any())
-  }
+      val licenceSummaries = service.getAllLicencesByCrn("A12345")
+      val licenceSummary = licenceSummaries.first()
 
-  @Test
-  fun `service returns a list of licence summaries by crn where updated username and updated date are not present`() {
-    whenever(licenceRepository.findAllByCrnAndStatusCodeIn(any(), any())).thenReturn(
-      listOf(
-        aLicenceEntity.copy(updatedByUsername = null, dateLastUpdated = null),
-      ),
-    )
+      assertThat(licenceSummaries.size).isEqualTo(1)
 
-    val licenceSummaries = service.getAllLicencesByCrn("A12345")
-    val licenceSummary = licenceSummaries.first()
+      assertThat(licenceSummary).isExactlyInstanceOf(ModelPublicLicenceSummary::class.java)
 
-    assertThat(licenceSummaries.size).isEqualTo(1)
-
-    assertThat(licenceSummary).isExactlyInstanceOf(ModelPublicLicenceSummary::class.java)
-
-    assertThat(licenceSummary)
-      .extracting {
-        Tuple.tuple(
-          it.id, it.licenceType, it.policyVersion, it.version, it.statusCode, it.prisonNumber, it.bookingId,
-          it.crn, it.approvedByUsername, it.approvedDateTime, it.createdByUsername, it.createdDateTime,
-          it.updatedByUsername, it.updatedDateTime, it.isInPssPeriod,
+      assertThat(licenceSummary)
+        .extracting {
+          Tuple.tuple(
+            it.id, it.licenceType, it.policyVersion, it.version, it.statusCode, it.prisonNumber, it.bookingId,
+            it.crn, it.approvedByUsername, it.approvedDateTime, it.createdByUsername, it.createdDateTime,
+            it.updatedByUsername, it.updatedDateTime, it.isInPssPeriod,
+          )
+        }
+        .isEqualTo(
+          Tuple.tuple(
+            1L,
+            PublicLicenceType.AP,
+            "1.0",
+            "1.4",
+            PublicLicenceStatus.IN_PROGRESS,
+            "A1234BC",
+            987654L,
+            "A12345",
+            null,
+            null,
+            "testcom",
+            LocalDateTime.parse("2023-10-11T11:00"),
+            "testupdater",
+            LocalDateTime.parse("2023-10-11T12:00"),
+            false,
+          ),
         )
-      }
-      .isEqualTo(
-        Tuple.tuple(
-          1L,
-          PublicLicenceType.AP,
-          "1.0",
-          "1.4",
-          PublicLicenceStatus.IN_PROGRESS,
-          "A1234BC",
-          987654L,
-          "A12345",
-          "testapprover",
-          LocalDateTime.parse("2023-10-11T13:00"),
-          "testcom",
-          LocalDateTime.parse("2023-10-11T11:00"),
-          null,
-          null,
-          false,
+
+      verify(licenceRepository, times(1)).findAllByCrnAndStatusCodeIn(any(), any())
+    }
+
+    @Test
+    fun `service returns a list of licence summaries by crn where updated username and updated date are not present`() {
+      whenever(licenceRepository.findAllByCrnAndStatusCodeIn(any(), any())).thenReturn(
+        listOf(
+          aLicenceEntity.copy(updatedByUsername = null, dateLastUpdated = null),
         ),
       )
 
-    verify(licenceRepository, times(1)).findAllByCrnAndStatusCodeIn(any(), any())
-  }
+      val licenceSummaries = service.getAllLicencesByCrn("A12345")
+      val licenceSummary = licenceSummaries.first()
 
-  @Test
-  fun `service throws an error for null fields when querying for a list of licence summaries by crn`() {
-    whenever(licenceRepository.findAllByCrnAndStatusCodeIn(any(), any())).thenReturn(
-      listOf(
-        aLicenceEntity.copy(createdBy = null),
-      ),
-    )
+      assertThat(licenceSummaries.size).isEqualTo(1)
 
-    val exception = assertThrows<IllegalStateException> {
-      service.getAllLicencesByCrn("A12345")
-    }
+      assertThat(licenceSummary).isExactlyInstanceOf(ModelPublicLicenceSummary::class.java)
 
-    assertThat(exception)
-      .isInstanceOf(IllegalStateException::class.java)
-      .hasMessage("Null field retrieved: createdByUsername for licence 1")
-
-    verify(licenceRepository, times(1)).findAllByCrnAndStatusCodeIn(any(), any())
-  }
-
-  @Test
-  fun `service throws an error for an unmapped field when querying a list of licence summaries by crn`() {
-    whenever(licenceRepository.findAllByCrnAndStatusCodeIn(any(), any())).thenReturn(
-      listOf(
-        aLicenceEntity.copy(statusCode = LicenceStatus.NOT_STARTED),
-      ),
-    )
-
-    val exception = assertThrows<IllegalStateException> {
-      service.getAllLicencesByCrn("A12345")
-    }
-
-    assertThat(exception)
-      .isInstanceOf(IllegalStateException::class.java)
-      .hasMessage("No matching licence status found")
-
-    verify(licenceRepository, times(1)).findAllByCrnAndStatusCodeIn(any(), any())
-  }
-
-  @Test
-  fun `service returns a list of licence summaries by prison number`() {
-    whenever(licenceRepository.findAllByNomsIdAndStatusCodeIn(any(), any())).thenReturn(
-      listOf(
-        aLicenceEntity,
-      ),
-    )
-
-    val licenceSummaries = service.getAllLicencesByPrisonNumber("A1234BC")
-    val licenceSummary = licenceSummaries.first()
-
-    assertThat(licenceSummaries.size).isEqualTo(1)
-
-    assertThat(licenceSummary).isExactlyInstanceOf(ModelPublicLicenceSummary::class.java)
-
-    assertThat(licenceSummary)
-      .extracting {
-        Tuple.tuple(
-          it.id, it.licenceType, it.policyVersion, it.version, it.statusCode, it.prisonNumber, it.bookingId,
-          it.crn, it.approvedByUsername, it.approvedDateTime, it.createdByUsername, it.createdDateTime,
-          it.updatedByUsername, it.updatedDateTime, it.isInPssPeriod,
+      assertThat(licenceSummary)
+        .extracting {
+          Tuple.tuple(
+            it.id, it.licenceType, it.policyVersion, it.version, it.statusCode, it.prisonNumber, it.bookingId,
+            it.crn, it.approvedByUsername, it.approvedDateTime, it.createdByUsername, it.createdDateTime,
+            it.updatedByUsername, it.updatedDateTime, it.isInPssPeriod,
+          )
+        }
+        .isEqualTo(
+          Tuple.tuple(
+            1L,
+            PublicLicenceType.AP,
+            "1.0",
+            "1.4",
+            PublicLicenceStatus.IN_PROGRESS,
+            "A1234BC",
+            987654L,
+            "A12345",
+            "testapprover",
+            LocalDateTime.parse("2023-10-11T13:00"),
+            "testcom",
+            LocalDateTime.parse("2023-10-11T11:00"),
+            null,
+            null,
+            false,
+          ),
         )
-      }
-      .isEqualTo(
-        Tuple.tuple(
-          1L,
-          PublicLicenceType.AP,
-          "1.0",
-          "1.4",
-          PublicLicenceStatus.IN_PROGRESS,
-          "A1234BC",
-          987654L,
-          "A12345",
-          "testapprover",
-          LocalDateTime.parse("2023-10-11T13:00"),
-          "testcom",
-          LocalDateTime.parse("2023-10-11T11:00"),
-          "testupdater",
-          LocalDateTime.parse("2023-10-11T12:00"),
-          false,
+
+      verify(licenceRepository, times(1)).findAllByCrnAndStatusCodeIn(any(), any())
+    }
+
+    @Test
+    fun `service throws an error for null fields when querying for a list of licence summaries by crn`() {
+      whenever(licenceRepository.findAllByCrnAndStatusCodeIn(any(), any())).thenReturn(
+        listOf(
+          aLicenceEntity.copy(createdBy = null),
         ),
       )
 
-    verify(licenceRepository, times(1)).findAllByNomsIdAndStatusCodeIn(any(), any())
-  }
-
-  @Test
-  fun `service returns a list of licence summaries by prison number where approved username and approved date are not present`() {
-    whenever(licenceRepository.findAllByNomsIdAndStatusCodeIn(any(), any())).thenReturn(
-      listOf(
-        aLicenceEntity.copy(approvedByUsername = null, approvedDate = null),
-      ),
-    )
-
-    val licenceSummaries = service.getAllLicencesByPrisonNumber("A1234BC")
-    val licenceSummary = licenceSummaries.first()
-
-    assertThat(licenceSummaries.size).isEqualTo(1)
-
-    assertThat(licenceSummary).isExactlyInstanceOf(ModelPublicLicenceSummary::class.java)
-
-    assertThat(licenceSummary)
-      .extracting {
-        Tuple.tuple(
-          it.id, it.licenceType, it.policyVersion, it.version, it.statusCode, it.prisonNumber, it.bookingId,
-          it.crn, it.approvedByUsername, it.approvedDateTime, it.createdByUsername, it.createdDateTime,
-          it.updatedByUsername, it.updatedDateTime, it.isInPssPeriod,
-        )
+      val exception = assertThrows<IllegalStateException> {
+        service.getAllLicencesByCrn("A12345")
       }
-      .isEqualTo(
-        Tuple.tuple(
-          1L,
-          PublicLicenceType.AP,
-          "1.0",
-          "1.4",
-          PublicLicenceStatus.IN_PROGRESS,
-          "A1234BC",
-          987654L,
-          "A12345",
-          null,
-          null,
-          "testcom",
-          LocalDateTime.parse("2023-10-11T11:00"),
-          "testupdater",
-          LocalDateTime.parse("2023-10-11T12:00"),
-          false,
+
+      assertThat(exception)
+        .isInstanceOf(IllegalStateException::class.java)
+        .hasMessage("Null field retrieved: createdByUsername for licence 1")
+
+      verify(licenceRepository, times(1)).findAllByCrnAndStatusCodeIn(any(), any())
+    }
+
+    @Test
+    fun `service throws an error for an unmapped field when querying a list of licence summaries by crn`() {
+      whenever(licenceRepository.findAllByCrnAndStatusCodeIn(any(), any())).thenReturn(
+        listOf(
+          aLicenceEntity.copy(statusCode = LicenceStatus.NOT_STARTED),
         ),
       )
 
-    verify(licenceRepository, times(1)).findAllByNomsIdAndStatusCodeIn(any(), any())
+      val exception = assertThrows<IllegalStateException> {
+        service.getAllLicencesByCrn("A12345")
+      }
+
+      assertThat(exception)
+        .isInstanceOf(IllegalStateException::class.java)
+        .hasMessage("No matching licence status found")
+
+      verify(licenceRepository, times(1)).findAllByCrnAndStatusCodeIn(any(), any())
+    }
   }
 
-  @Test
-  fun `service returns a list of licence summaries by prison number where updated username and updated date are not present`() {
-    whenever(licenceRepository.findAllByNomsIdAndStatusCodeIn(any(), any())).thenReturn(
-      listOf(
-        aLicenceEntity.copy(updatedByUsername = null, dateLastUpdated = null),
-      ),
-    )
-
-    val licenceSummaries = service.getAllLicencesByPrisonNumber("A12345")
-    val licenceSummary = licenceSummaries.first()
-
-    assertThat(licenceSummaries.size).isEqualTo(1)
-
-    assertThat(licenceSummary).isExactlyInstanceOf(ModelPublicLicenceSummary::class.java)
-
-    assertThat(licenceSummary)
-      .extracting {
-        Tuple.tuple(
-          it.id, it.licenceType, it.policyVersion, it.version, it.statusCode, it.prisonNumber, it.bookingId,
-          it.crn, it.approvedByUsername, it.approvedDateTime, it.createdByUsername, it.createdDateTime,
-          it.updatedByUsername, it.updatedDateTime, it.isInPssPeriod,
-        )
-      }
-      .isEqualTo(
-        Tuple.tuple(
-          1L,
-          PublicLicenceType.AP,
-          "1.0",
-          "1.4",
-          PublicLicenceStatus.IN_PROGRESS,
-          "A1234BC",
-          987654L,
-          "A12345",
-          "testapprover",
-          LocalDateTime.parse("2023-10-11T13:00"),
-          "testcom",
-          LocalDateTime.parse("2023-10-11T11:00"),
-          null,
-          null,
-          false,
+  @Nested
+  inner class `Get licence by prison number` {
+    @Test
+    fun `service returns a list of licence summaries by prison number`() {
+      whenever(licenceRepository.findAllByNomsIdAndStatusCodeIn(any(), any())).thenReturn(
+        listOf(
+          aLicenceEntity,
         ),
       )
 
-    verify(licenceRepository, times(1)).findAllByNomsIdAndStatusCodeIn(any(), any())
-  }
+      val licenceSummaries = service.getAllLicencesByPrisonNumber("A1234BC")
+      val licenceSummary = licenceSummaries.first()
 
-  @Test
-  fun `service throws an error for null fields when querying for a list of licence summaries by prison number`() {
-    whenever(licenceRepository.findAllByNomsIdAndStatusCodeIn(any(), any())).thenReturn(
-      listOf(
-        aLicenceEntity.copy(licenceVersion = null),
-      ),
-    )
+      assertThat(licenceSummaries.size).isEqualTo(1)
 
-    val exception = assertThrows<IllegalStateException> {
-      service.getAllLicencesByPrisonNumber("A1234BC")
+      assertThat(licenceSummary).isExactlyInstanceOf(ModelPublicLicenceSummary::class.java)
+
+      assertThat(licenceSummary)
+        .extracting {
+          Tuple.tuple(
+            it.id, it.licenceType, it.policyVersion, it.version, it.statusCode, it.prisonNumber, it.bookingId,
+            it.crn, it.approvedByUsername, it.approvedDateTime, it.createdByUsername, it.createdDateTime,
+            it.updatedByUsername, it.updatedDateTime, it.isInPssPeriod,
+          )
+        }
+        .isEqualTo(
+          Tuple.tuple(
+            1L,
+            PublicLicenceType.AP,
+            "1.0",
+            "1.4",
+            PublicLicenceStatus.IN_PROGRESS,
+            "A1234BC",
+            987654L,
+            "A12345",
+            "testapprover",
+            LocalDateTime.parse("2023-10-11T13:00"),
+            "testcom",
+            LocalDateTime.parse("2023-10-11T11:00"),
+            "testupdater",
+            LocalDateTime.parse("2023-10-11T12:00"),
+            false,
+          ),
+        )
+
+      verify(licenceRepository, times(1)).findAllByNomsIdAndStatusCodeIn(any(), any())
     }
 
-    assertThat(exception)
-      .isInstanceOf(IllegalStateException::class.java)
-      .hasMessage("Null field retrieved: policyVersion for licence 1")
+    @Test
+    fun `service returns a list of licence summaries by prison number where approved username and approved date are not present`() {
+      whenever(licenceRepository.findAllByNomsIdAndStatusCodeIn(any(), any())).thenReturn(
+        listOf(
+          aLicenceEntity.copy(approvedByUsername = null, approvedDate = null),
+        ),
+      )
 
-    verify(licenceRepository, times(1)).findAllByNomsIdAndStatusCodeIn(any(), any())
-  }
+      val licenceSummaries = service.getAllLicencesByPrisonNumber("A1234BC")
+      val licenceSummary = licenceSummaries.first()
 
-  @Test
-  fun `service throws an error for an unmapped field when querying a list of licence summaries by prison number`() {
-    whenever(licenceRepository.findAllByNomsIdAndStatusCodeIn(any(), any())).thenReturn(
-      listOf(
-        aLicenceEntity.copy(statusCode = LicenceStatus.NOT_STARTED),
-      ),
-    )
+      assertThat(licenceSummaries.size).isEqualTo(1)
 
-    val exception = assertThrows<IllegalStateException> {
-      service.getAllLicencesByPrisonNumber("A1234BC")
+      assertThat(licenceSummary).isExactlyInstanceOf(ModelPublicLicenceSummary::class.java)
+
+      assertThat(licenceSummary)
+        .extracting {
+          Tuple.tuple(
+            it.id, it.licenceType, it.policyVersion, it.version, it.statusCode, it.prisonNumber, it.bookingId,
+            it.crn, it.approvedByUsername, it.approvedDateTime, it.createdByUsername, it.createdDateTime,
+            it.updatedByUsername, it.updatedDateTime, it.isInPssPeriod,
+          )
+        }
+        .isEqualTo(
+          Tuple.tuple(
+            1L,
+            PublicLicenceType.AP,
+            "1.0",
+            "1.4",
+            PublicLicenceStatus.IN_PROGRESS,
+            "A1234BC",
+            987654L,
+            "A12345",
+            null,
+            null,
+            "testcom",
+            LocalDateTime.parse("2023-10-11T11:00"),
+            "testupdater",
+            LocalDateTime.parse("2023-10-11T12:00"),
+            false,
+          ),
+        )
+
+      verify(licenceRepository, times(1)).findAllByNomsIdAndStatusCodeIn(any(), any())
     }
 
-    assertThat(exception)
-      .isInstanceOf(IllegalStateException::class.java)
-      .hasMessage("No matching licence status found")
+    @Test
+    fun `service returns a list of licence summaries by prison number where updated username and updated date are not present`() {
+      whenever(licenceRepository.findAllByNomsIdAndStatusCodeIn(any(), any())).thenReturn(
+        listOf(
+          aLicenceEntity.copy(updatedByUsername = null, dateLastUpdated = null),
+        ),
+      )
 
-    verify(licenceRepository, times(1)).findAllByNomsIdAndStatusCodeIn(any(), any())
-  }
+      val licenceSummaries = service.getAllLicencesByPrisonNumber("A12345")
+      val licenceSummary = licenceSummaries.first()
 
-  @Test
-  fun `service returns a full-sized exclusion zone image by condition ID`() {
-    whenever(licenceRepository.findById(1L)).thenReturn(Optional.of(aLicenceEntity))
-    whenever(additionalConditionRepository.findById(1L)).thenReturn(Optional.of(anAdditionalConditionEntityWithUpload))
-    whenever(additionalConditionUploadDetailRepository.findById(1L)).thenReturn(
-      Optional.of(
-        anAdditionalConditionUploadDetailEntity,
-      ),
-    )
+      assertThat(licenceSummaries.size).isEqualTo(1)
 
-    val image = service.getExclusionZoneImageByConditionId(1L, 1L)
+      assertThat(licenceSummary).isExactlyInstanceOf(ModelPublicLicenceSummary::class.java)
 
-    assertThat(image).isEqualTo(ClassPathResource("test_map.jpg").inputStream.readAllBytes())
+      assertThat(licenceSummary)
+        .extracting {
+          Tuple.tuple(
+            it.id, it.licenceType, it.policyVersion, it.version, it.statusCode, it.prisonNumber, it.bookingId,
+            it.crn, it.approvedByUsername, it.approvedDateTime, it.createdByUsername, it.createdDateTime,
+            it.updatedByUsername, it.updatedDateTime, it.isInPssPeriod,
+          )
+        }
+        .isEqualTo(
+          Tuple.tuple(
+            1L,
+            PublicLicenceType.AP,
+            "1.0",
+            "1.4",
+            PublicLicenceStatus.IN_PROGRESS,
+            "A1234BC",
+            987654L,
+            "A12345",
+            "testapprover",
+            LocalDateTime.parse("2023-10-11T13:00"),
+            "testcom",
+            LocalDateTime.parse("2023-10-11T11:00"),
+            null,
+            null,
+            false,
+          ),
+        )
 
-    verify(licenceRepository, times(1)).findById(1L)
-    verify(additionalConditionRepository, times(1)).findById(1L)
-    verify(additionalConditionUploadDetailRepository, times(1)).findById(1L)
-  }
-
-  @Test
-  fun `service throws error retrieving a full-sized exclusion zone image by condition ID for no licence`() {
-    whenever(licenceRepository.findById(1L)).thenReturn(Optional.empty())
-
-    val exception = assertThrows<EntityNotFoundException> {
-      service.getExclusionZoneImageByConditionId(1L, 1L)
+      verify(licenceRepository, times(1)).findAllByNomsIdAndStatusCodeIn(any(), any())
     }
 
-    assertThat(exception)
-      .isInstanceOf(EntityNotFoundException::class.java)
-      .hasMessage("Licence 1 not found")
+    @Test
+    fun `service throws an error for null fields when querying for a list of licence summaries by prison number`() {
+      whenever(licenceRepository.findAllByNomsIdAndStatusCodeIn(any(), any())).thenReturn(
+        listOf(
+          aLicenceEntity.copy(licenceVersion = null),
+        ),
+      )
 
-    verify(licenceRepository, times(1)).findById(1L)
-    verify(additionalConditionRepository, times(0)).findById(1L)
-    verify(additionalConditionUploadDetailRepository, times(0)).findById(1L)
-  }
+      val exception = assertThrows<IllegalStateException> {
+        service.getAllLicencesByPrisonNumber("A1234BC")
+      }
 
-  @Test
-  fun `service throws error retrieving a full-sized exclusion zone image by condition ID for no condition`() {
-    whenever(licenceRepository.findById(1L)).thenReturn(Optional.of(aLicenceEntity))
-    whenever(additionalConditionRepository.findById(1L)).thenReturn(Optional.empty())
+      assertThat(exception)
+        .isInstanceOf(IllegalStateException::class.java)
+        .hasMessage("Null field retrieved: policyVersion for licence 1")
 
-    val exception = assertThrows<EntityNotFoundException> {
-      service.getExclusionZoneImageByConditionId(1L, 1L)
+      verify(licenceRepository, times(1)).findAllByNomsIdAndStatusCodeIn(any(), any())
     }
 
-    assertThat(exception)
-      .isInstanceOf(EntityNotFoundException::class.java)
-      .hasMessage("Condition 1 not found")
+    @Test
+    fun `service throws an error for an unmapped field when querying a list of licence summaries by prison number`() {
+      whenever(licenceRepository.findAllByNomsIdAndStatusCodeIn(any(), any())).thenReturn(
+        listOf(
+          aLicenceEntity.copy(statusCode = LicenceStatus.NOT_STARTED),
+        ),
+      )
 
-    verify(licenceRepository, times(1)).findById(1L)
-    verify(additionalConditionRepository, times(1)).findById(1L)
-    verify(additionalConditionUploadDetailRepository, times(0)).findById(1L)
+      val exception = assertThrows<IllegalStateException> {
+        service.getAllLicencesByPrisonNumber("A1234BC")
+      }
+
+      assertThat(exception)
+        .isInstanceOf(IllegalStateException::class.java)
+        .hasMessage("No matching licence status found")
+
+      verify(licenceRepository, times(1)).findAllByNomsIdAndStatusCodeIn(any(), any())
+    }
   }
 
-  @Test
-  fun `service throws error retrieving a full-sized exclusion zone image by condition ID without an upload`() {
-    whenever(licenceRepository.findById(1L)).thenReturn(Optional.of(aLicenceEntity))
-    whenever(additionalConditionRepository.findById(1L)).thenReturn(Optional.of(anAdditionalConditionEntityWithoutUpload))
+  @Nested
+  inner class `Get exclusion zone image by condition ID` {
+    @Test
+    fun `service returns an exclusion zone image by condition ID`() {
+      whenever(licenceRepository.findById(1L)).thenReturn(Optional.of(aLicenceEntity))
+      whenever(additionalConditionRepository.findById(1L)).thenReturn(Optional.of(anAdditionalConditionEntityWithUpload))
+      whenever(additionalConditionUploadDetailRepository.findById(1L)).thenReturn(
+        Optional.of(
+          anAdditionalConditionUploadDetailEntity,
+        ),
+      )
 
-    val exception = assertThrows<EntityNotFoundException> {
-      service.getExclusionZoneImageByConditionId(1L, 1L)
+      val image = service.getExclusionZoneImageByConditionId(1L, 1L)
+
+      assertThat(image).isEqualTo(ClassPathResource("test_map.jpg").inputStream.readAllBytes())
+
+      verify(licenceRepository, times(1)).findById(1L)
+      verify(additionalConditionRepository, times(1)).findById(1L)
+      verify(additionalConditionUploadDetailRepository, times(1)).findById(1L)
     }
 
-    assertThat(exception)
-      .isInstanceOf(EntityNotFoundException::class.java)
-      .hasMessage("Condition 1 upload details not found")
+    @Test
+    fun `service throws error retrieving an exclusion zone image by condition ID for no licence`() {
+      whenever(licenceRepository.findById(1L)).thenReturn(Optional.empty())
 
-    verify(licenceRepository, times(1)).findById(1L)
-    verify(additionalConditionRepository, times(1)).findById(1L)
-    verify(additionalConditionUploadDetailRepository, times(0)).findById(1L)
-  }
+      val exception = assertThrows<EntityNotFoundException> {
+        service.getExclusionZoneImageByConditionId(1L, 1L)
+      }
 
-  @Test
-  fun `service throws error retrieving a full-sized exclusion zone image by condition ID for no upload details`() {
-    whenever(licenceRepository.findById(1L)).thenReturn(Optional.of(aLicenceEntity))
-    whenever(additionalConditionRepository.findById(1L)).thenReturn(Optional.of(anAdditionalConditionEntityWithUpload))
-    whenever(additionalConditionUploadDetailRepository.findById(1L)).thenReturn(Optional.empty())
+      assertThat(exception)
+        .isInstanceOf(EntityNotFoundException::class.java)
+        .hasMessage("Licence 1 not found")
 
-    val exception = assertThrows<EntityNotFoundException> {
-      service.getExclusionZoneImageByConditionId(1L, 1L)
+      verify(licenceRepository, times(1)).findById(1L)
+      verify(additionalConditionRepository, times(0)).findById(1L)
+      verify(additionalConditionUploadDetailRepository, times(0)).findById(1L)
     }
 
-    assertThat(exception)
-      .isInstanceOf(EntityNotFoundException::class.java)
-      .hasMessage("Condition 1 upload details not found")
+    @Test
+    fun `service throws error retrieving an exclusion zone image by condition ID for no condition`() {
+      whenever(licenceRepository.findById(1L)).thenReturn(Optional.of(aLicenceEntity))
+      whenever(additionalConditionRepository.findById(1L)).thenReturn(Optional.empty())
 
-    verify(licenceRepository, times(1)).findById(1L)
-    verify(additionalConditionRepository, times(1)).findById(1L)
-    verify(additionalConditionUploadDetailRepository, times(1)).findById(1L)
+      val exception = assertThrows<EntityNotFoundException> {
+        service.getExclusionZoneImageByConditionId(1L, 1L)
+      }
+
+      assertThat(exception)
+        .isInstanceOf(EntityNotFoundException::class.java)
+        .hasMessage("Condition 1 not found")
+
+      verify(licenceRepository, times(1)).findById(1L)
+      verify(additionalConditionRepository, times(1)).findById(1L)
+      verify(additionalConditionUploadDetailRepository, times(0)).findById(1L)
+    }
+
+    @Test
+    fun `service throws error retrieving an exclusion zone image by condition ID without an upload`() {
+      whenever(licenceRepository.findById(1L)).thenReturn(Optional.of(aLicenceEntity))
+      whenever(additionalConditionRepository.findById(1L)).thenReturn(Optional.of(anAdditionalConditionEntityWithoutUpload))
+
+      val exception = assertThrows<EntityNotFoundException> {
+        service.getExclusionZoneImageByConditionId(1L, 1L)
+      }
+
+      assertThat(exception)
+        .isInstanceOf(EntityNotFoundException::class.java)
+        .hasMessage("Condition 1 upload details not found")
+
+      verify(licenceRepository, times(1)).findById(1L)
+      verify(additionalConditionRepository, times(1)).findById(1L)
+      verify(additionalConditionUploadDetailRepository, times(0)).findById(1L)
+    }
+
+    @Test
+    fun `service throws error retrieving an exclusion zone image by condition ID for no upload details`() {
+      whenever(licenceRepository.findById(1L)).thenReturn(Optional.of(aLicenceEntity))
+      whenever(additionalConditionRepository.findById(1L)).thenReturn(Optional.of(anAdditionalConditionEntityWithUpload))
+      whenever(additionalConditionUploadDetailRepository.findById(1L)).thenReturn(Optional.empty())
+
+      val exception = assertThrows<EntityNotFoundException> {
+        service.getExclusionZoneImageByConditionId(1L, 1L)
+      }
+
+      assertThat(exception)
+        .isInstanceOf(EntityNotFoundException::class.java)
+        .hasMessage("Condition 1 upload details not found")
+
+      verify(licenceRepository, times(1)).findById(1L)
+      verify(additionalConditionRepository, times(1)).findById(1L)
+      verify(additionalConditionUploadDetailRepository, times(1)).findById(1L)
+    }
   }
 
   private companion object {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/publicApi/PublicLicenceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/publicApi/PublicLicenceServiceTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.publicApi
 
+import jakarta.persistence.EntityNotFoundException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.groups.Tuple
 import org.junit.jupiter.api.BeforeEach
@@ -11,25 +12,38 @@ import org.mockito.kotlin.reset
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.springframework.core.io.ClassPathResource
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.AdditionalCondition
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.AdditionalConditionData
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.AdditionalConditionUploadDetail
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.AdditionalConditionUploadSummary
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.CommunityOffenderManager
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.Licence
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.AdditionalConditionRepository
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.AdditionalConditionUploadDetailRepository
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.LicenceRepository
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceType
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.util.*
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.publicApi.model.licence.LicenceStatus as PublicLicenceStatus
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.publicApi.model.licence.LicenceSummary as ModelPublicLicenceSummary
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.publicApi.model.licence.LicenceType as PublicLicenceType
 
 class PublicLicenceServiceTest {
   private val licenceRepository = mock<LicenceRepository>()
-
-  private val service = PublicLicenceService(licenceRepository)
+  private val additionalConditionRepository = mock<AdditionalConditionRepository>()
+  private val additionalConditionUploadDetailRepository = mock<AdditionalConditionUploadDetailRepository>()
+  private val service = PublicLicenceService(licenceRepository, additionalConditionRepository, additionalConditionUploadDetailRepository)
 
   @BeforeEach
   fun reset() {
-    reset(licenceRepository)
+    reset(
+      licenceRepository,
+      additionalConditionRepository,
+      additionalConditionUploadDetailRepository,
+    )
   }
 
   @Test
@@ -383,6 +397,98 @@ class PublicLicenceServiceTest {
 
     verify(licenceRepository, times(1)).findAllByNomsIdAndStatusCodeIn(any(), any())
   }
+
+  @Test
+  fun `service returns a full-sized exclusion zone image by condition ID`() {
+    whenever(licenceRepository.findById(1L)).thenReturn(Optional.of(aLicenceEntity))
+    whenever(additionalConditionRepository.findById(1L)).thenReturn(Optional.of(anAdditionalConditionEntityWithUpload))
+    whenever(additionalConditionUploadDetailRepository.findById(1L)).thenReturn(
+      Optional.of(
+        anAdditionalConditionUploadDetailEntity,
+      ),
+    )
+
+    val image = service.getExclusionZoneImageByConditionId(1L, 1L)
+
+    assertThat(image).isEqualTo(ClassPathResource("test_map.jpg").inputStream.readAllBytes())
+
+    verify(licenceRepository, times(1)).findById(1L)
+    verify(additionalConditionRepository, times(1)).findById(1L)
+    verify(additionalConditionUploadDetailRepository, times(1)).findById(1L)
+  }
+
+  @Test
+  fun `service throws error retrieving a full-sized exclusion zone image by condition ID for no licence`() {
+    whenever(licenceRepository.findById(1L)).thenReturn(Optional.empty())
+
+    val exception = assertThrows<EntityNotFoundException> {
+      service.getExclusionZoneImageByConditionId(1L, 1L)
+    }
+
+    assertThat(exception)
+      .isInstanceOf(EntityNotFoundException::class.java)
+      .hasMessage("Licence 1 not found")
+
+    verify(licenceRepository, times(1)).findById(1L)
+    verify(additionalConditionRepository, times(0)).findById(1L)
+    verify(additionalConditionUploadDetailRepository, times(0)).findById(1L)
+  }
+
+  @Test
+  fun `service throws error retrieving a full-sized exclusion zone image by condition ID for no condition`() {
+    whenever(licenceRepository.findById(1L)).thenReturn(Optional.of(aLicenceEntity))
+    whenever(additionalConditionRepository.findById(1L)).thenReturn(Optional.empty())
+
+    val exception = assertThrows<EntityNotFoundException> {
+      service.getExclusionZoneImageByConditionId(1L, 1L)
+    }
+
+    assertThat(exception)
+      .isInstanceOf(EntityNotFoundException::class.java)
+      .hasMessage("Condition 1 not found")
+
+    verify(licenceRepository, times(1)).findById(1L)
+    verify(additionalConditionRepository, times(1)).findById(1L)
+    verify(additionalConditionUploadDetailRepository, times(0)).findById(1L)
+  }
+
+  @Test
+  fun `service throws error retrieving a full-sized exclusion zone image by condition ID without an upload`() {
+    whenever(licenceRepository.findById(1L)).thenReturn(Optional.of(aLicenceEntity))
+    whenever(additionalConditionRepository.findById(1L)).thenReturn(Optional.of(anAdditionalConditionEntityWithoutUpload))
+
+    val exception = assertThrows<EntityNotFoundException> {
+      service.getExclusionZoneImageByConditionId(1L, 1L)
+    }
+
+    assertThat(exception)
+      .isInstanceOf(EntityNotFoundException::class.java)
+      .hasMessage("Condition 1 upload details not found")
+
+    verify(licenceRepository, times(1)).findById(1L)
+    verify(additionalConditionRepository, times(1)).findById(1L)
+    verify(additionalConditionUploadDetailRepository, times(0)).findById(1L)
+  }
+
+  @Test
+  fun `service throws error retrieving a full-sized exclusion zone image by condition ID for no upload details`() {
+    whenever(licenceRepository.findById(1L)).thenReturn(Optional.of(aLicenceEntity))
+    whenever(additionalConditionRepository.findById(1L)).thenReturn(Optional.of(anAdditionalConditionEntityWithUpload))
+    whenever(additionalConditionUploadDetailRepository.findById(1L)).thenReturn(Optional.empty())
+
+    val exception = assertThrows<EntityNotFoundException> {
+      service.getExclusionZoneImageByConditionId(1L, 1L)
+    }
+
+    assertThat(exception)
+      .isInstanceOf(EntityNotFoundException::class.java)
+      .hasMessage("Condition 1 upload details not found")
+
+    verify(licenceRepository, times(1)).findById(1L)
+    verify(additionalConditionRepository, times(1)).findById(1L)
+    verify(additionalConditionUploadDetailRepository, times(1)).findById(1L)
+  }
+
   private companion object {
 
     val aCom = CommunityOffenderManager(
@@ -411,6 +517,63 @@ class PublicLicenceServiceTest {
       dateLastUpdated = LocalDateTime.of(2023, 10, 11, 12, 0, 0),
       updatedByUsername = "testupdater",
       createdBy = aCom,
+    )
+
+    val someAdditionalConditionData = listOf(
+      AdditionalConditionData(
+        id = 1,
+        dataField = "outOfBoundArea",
+        dataValue = "Bristol town centre",
+        additionalCondition = AdditionalCondition(licence = aLicenceEntity, conditionVersion = "1.0"),
+      ),
+      AdditionalConditionData(
+        id = 2,
+        dataField = "outOfBoundFile",
+        dataValue = "test.pdf",
+        additionalCondition = AdditionalCondition(licence = aLicenceEntity, conditionVersion = "1.0"),
+      ),
+    )
+
+    val someUploadSummaryData = AdditionalConditionUploadSummary(
+      id = 1,
+      filename = "test.pdf",
+      fileType = "application/pdf",
+      description = "Description",
+      thumbnailImage = ByteArray(0),
+      additionalCondition = someAdditionalConditionData[0].additionalCondition,
+      uploadDetailId = 1,
+    )
+
+    val anAdditionalConditionEntityWithUpload = AdditionalCondition(
+      id = 1,
+      conditionVersion = "1.0",
+      licence = aLicenceEntity,
+      conditionCode = "outOfBounds",
+      conditionCategory = "Freedom of movement",
+      conditionSequence = 1,
+      conditionText = "text",
+      additionalConditionData = someAdditionalConditionData,
+      additionalConditionUploadSummary = listOf(someUploadSummaryData),
+    )
+
+    val anAdditionalConditionUploadDetailEntity = AdditionalConditionUploadDetail(
+      id = 1,
+      licenceId = 1,
+      additionalConditionId = 1,
+      fullSizeImage = ClassPathResource("test_map.jpg").inputStream.readAllBytes(),
+      originalData = ClassPathResource("Test_map_2021-12-06_112550.pdf").inputStream.readAllBytes(),
+    )
+
+    val anAdditionalConditionEntityWithoutUpload = AdditionalCondition(
+      id = 1,
+      licence = aLicenceEntity,
+      conditionVersion = "1.0",
+      conditionCode = "outOfBounds",
+      conditionCategory = "Freedom of movement",
+      conditionSequence = 1,
+      conditionText = "text",
+      additionalConditionData = someAdditionalConditionData,
+      additionalConditionUploadSummary = emptyList(),
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/publicApi/PublicLicenceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/publicApi/PublicLicenceServiceTest.kt
@@ -421,7 +421,7 @@ class PublicLicenceServiceTest {
         ),
       )
 
-      val image = service.getExclusionZoneImageByConditionId(1L, 1L)
+      val image = service.getImageUpload(1L, 1L)
 
       assertThat(image).isEqualTo(ClassPathResource("test_map.jpg").inputStream.readAllBytes())
 
@@ -435,7 +435,7 @@ class PublicLicenceServiceTest {
       whenever(licenceRepository.findById(1L)).thenReturn(Optional.empty())
 
       val exception = assertThrows<EntityNotFoundException> {
-        service.getExclusionZoneImageByConditionId(1L, 1L)
+        service.getImageUpload(1L, 1L)
       }
 
       assertThat(exception)
@@ -453,7 +453,7 @@ class PublicLicenceServiceTest {
       whenever(additionalConditionRepository.findById(1L)).thenReturn(Optional.empty())
 
       val exception = assertThrows<EntityNotFoundException> {
-        service.getExclusionZoneImageByConditionId(1L, 1L)
+        service.getImageUpload(1L, 1L)
       }
 
       assertThat(exception)
@@ -471,7 +471,7 @@ class PublicLicenceServiceTest {
       whenever(additionalConditionRepository.findById(1L)).thenReturn(Optional.of(anAdditionalConditionEntityWithoutUpload))
 
       val exception = assertThrows<EntityNotFoundException> {
-        service.getExclusionZoneImageByConditionId(1L, 1L)
+        service.getImageUpload(1L, 1L)
       }
 
       assertThat(exception)
@@ -490,7 +490,7 @@ class PublicLicenceServiceTest {
       whenever(additionalConditionUploadDetailRepository.findById(1L)).thenReturn(Optional.empty())
 
       val exception = assertThrows<EntityNotFoundException> {
-        service.getExclusionZoneImageByConditionId(1L, 1L)
+        service.getImageUpload(1L, 1L)
       }
 
       assertThat(exception)


### PR DESCRIPTION
This PR is to add a new endpoint to the CVL public API to allow a JPEG image of an exclusion zone to be returned based on the ID of the condition that is required.