### PR TITLE
add /policy/latest endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/publicApi/PublicLicencePolicyController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/publicApi/PublicLicencePolicyController.kt
@@ -57,4 +57,34 @@ class PublicLicencePolicyController(private val publicLicencePolicyService: Publ
     ],
   )
   fun getPolicyByVersionNumber(@PathVariable("version") versionNumber: String) = publicLicencePolicyService.getLicencePolicyByVersionNumber(versionNumber)
+
+  @GetMapping(value = ["/latest"])
+  @ResponseBody
+  @Operation(
+    summary = "Get latest policy.",
+    description = "Returns latest policy." +
+      "Requires ROLE_VIEW_LICENCES.",
+    security = [SecurityRequirement(name = "ROLE_VIEW_LICENCES")],
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Policy found",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = LicencePolicy::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorised, requires a valid Oauth2 token.",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires an appropriate role.",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  fun getLatestPolicy() = publicLicencePolicyService.getLatestLicencePolicy()
+
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/publicApi/PublicLicencePolicyController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/publicApi/PublicLicencePolicyController.kt
@@ -86,5 +86,4 @@ class PublicLicencePolicyController(private val publicLicencePolicyService: Publ
     ],
   )
   fun getLatestPolicy() = publicLicencePolicyService.getLatestLicencePolicy()
-
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/publicApi/PublicLicencePolicyService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/publicApi/PublicLicencePolicyService.kt
@@ -16,4 +16,9 @@ class PublicLicencePolicyService(
 
     return policy.transformToPublicLicencePolicy()
   }
+
+  fun getLatestLicencePolicy(): PublicLicencePolicy {
+    val transformToPublicLicencePolicy = licencePolicyService.currentPolicy()
+    return transformToPublicLicencePolicy.transformToPublicLicencePolicy()
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/publicApi/PublicLicencePolicyService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/publicApi/PublicLicencePolicyService.kt
@@ -18,7 +18,6 @@ class PublicLicencePolicyService(
   }
 
   fun getLatestLicencePolicy(): PublicLicencePolicy {
-    val transformToPublicLicencePolicy = licencePolicyService.currentPolicy()
-    return transformToPublicLicencePolicy.transformToPublicLicencePolicy()
+    return licencePolicyService.currentPolicy().transformToPublicLicencePolicy()
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/publicApi/PublicLicencePolicyServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/publicApi/PublicLicencePolicyServiceIntegrationTest.kt
@@ -69,6 +69,7 @@ class PublicLicencePolicyServiceIntegrationTest : IntegrationTestBase() {
 
       Assertions.assertThat(result?.userMessage).contains("Access Denied")
     }
+
     @Test
     fun `get latest policy is v2_1 `() {
       webTestClient.get()
@@ -81,6 +82,7 @@ class PublicLicencePolicyServiceIntegrationTest : IntegrationTestBase() {
         .expectBody()
         .json(policy("V2_1"), true)
     }
+
     @Test
     fun `Get latest policy is role protected`() {
       val result = webTestClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/publicApi/PublicLicencePolicyServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/publicApi/PublicLicencePolicyServiceIntegrationTest.kt
@@ -69,5 +69,30 @@ class PublicLicencePolicyServiceIntegrationTest : IntegrationTestBase() {
 
       Assertions.assertThat(result?.userMessage).contains("Access Denied")
     }
+    @Test
+    fun `get latest policy is v2_1 `() {
+      webTestClient.get()
+        .uri("/public/policy/latest")
+        .accept(MediaType.APPLICATION_JSON)
+        .headers(setAuthorisation(roles = listOf("ROLE_VIEW_LICENCES")))
+        .exchange()
+        .expectStatus().isOk
+        .expectHeader().contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(policy("V2_1"), true)
+    }
+    @Test
+    fun `Get latest policy is role protected`() {
+      val result = webTestClient.get()
+        .uri("/public/policy/latest")
+        .accept(MediaType.APPLICATION_JSON)
+        .headers(setAuthorisation(roles = listOf("ROLE_CVL_VERY_WRONG")))
+        .exchange()
+        .expectStatus().isEqualTo(HttpStatus.FORBIDDEN.value())
+        .expectBody(ErrorResponse::class.java)
+        .returnResult().responseBody
+
+      Assertions.assertThat(result?.userMessage).contains("Access Denied")
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/publicApi/PublicLicencePolicyControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/publicApi/PublicLicencePolicyControllerTest.kt
@@ -157,4 +157,19 @@ class PublicLicencePolicyControllerTest {
       someConditionTypes,
     )
   }
+
+  @Test
+  fun `given a policy exist when get latest policy then return latest policy`() {
+    whenever(publicLicencePolicyService.getLatestLicencePolicy()).thenReturn(aLicencePolicy)
+
+    val result = mvc.perform(get("/public/policy/latest").accept(MediaType.APPLICATION_JSON))
+      .andExpect(status().isOk)
+      .andExpect(MockMvcResultMatchers.content().contentType(MediaType.APPLICATION_JSON))
+      .andReturn()
+
+    assertThat(result.response.contentAsString)
+      .isEqualTo(mapper.writeValueAsString(aLicencePolicy))
+
+    verify(publicLicencePolicyService, times(1)).getLatestLicencePolicy()
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/publicApi/PublicLicencePolicyServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/publicApi/PublicLicencePolicyServiceTest.kt
@@ -111,4 +111,13 @@ class PublicLicencePolicyServiceTest {
       .isInstanceOf(EntityNotFoundException::class.java)
       .hasMessage("Policy version 0 not found")
   }
+
+  @Test
+  fun `given policies when get latest policy then return latest policy`() {
+    whenever(licencePolicyService.currentPolicy()).thenReturn(POLICY_V2_1)
+
+    val policy = service.getLatestLicencePolicy()
+
+    assertThat(policy.version).isEqualTo(POLICY_V2_1.version)
+  }
 }


### PR DESCRIPTION
This PR adds a new endpoint /policy/latest endpoint This new endpoint returns most recent version of policy. At the moment its going to return version 2.1. This PR assumes that there is at least one policy present always.