### PR TITLE
Migrating project to use groups in allowlist

### DIFF
--- a/helm_deploy/create-and-vary-a-licence-api/Chart.yaml
+++ b/helm_deploy/create-and-vary-a-licence-api/Chart.yaml
@@ -5,7 +5,7 @@ name: create-and-vary-a-licence-api
 version: 0.2.0
 dependencies:
   - name: generic-service
-    version: "2.7"
+    version: "2.8"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: "1.3"

--- a/helm_deploy/create-and-vary-a-licence-api/values.yaml
+++ b/helm_deploy/create-and-vary-a-licence-api/values.yaml
@@ -1,4 +1,3 @@
----
 generic-service:
   nameOverride: create-and-vary-a-licence-api
 
@@ -6,12 +5,12 @@ generic-service:
 
   image:
     repository: quay.io/hmpps/create-and-vary-a-licence-api
-    tag: app_version    # override at deployment time
+    tag: app_version # override at deployment time
     port: 8080
 
   ingress:
     enabled: true
-    hosts: app-hostname.local    # override per environment
+    hosts: app-hostname.local # override per environment
     tlsSecretName: create-and-vary-a-licence-api-cert
     v1_2_enabled: true
     v0_47_enabled: false
@@ -45,14 +44,9 @@ generic-service:
       DB_PASS: "database_password"
 
   allowlist:
-    office: "217.33.148.210/32"
-    health-kick: "35.177.252.195/32"
-    mojvpn: "81.134.202.29/32"
-    moj-global-protect: "35.176.93.186/32"
-    cloudplatform-live1-1: "35.178.209.113/32"
-    cloudplatform-live1-2: "3.8.51.207/32"
-    cloudplatform-live1-3: "35.177.252.54/32"
-    approved-premises-team: "54.76.254.148/32"
+    dxw-vpn: 54.76.254.148/32
+    groups:
+      - internal
 
 generic-prometheus-alerts:
   targetApplication: create-and-vary-a-licence-api


### PR DESCRIPTION
This PR migrates the project to use groups of IPs in their allowlist.

By referring to groups to IP addresses, we can centralize the definition of groups of ip addresses.
If these lists require changing in the future, we can change the definition once and future deploys across all services will automatically include these new IPs.

1 allowlist(s) have been detected that can be migrated.



## Allowlist: helm_deploy/create-and-vary-a-licence-api/values.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: `internal`
- The size of the allowlist defined in this file will change: `8 => 1 (7 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:


- petty-france-wifi,213.121.161.112/28
  

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:


- health-kick,35.177.252.195/32
  
