### PR TITLE
CVSL-1412 add page size to licence caseload call

### DIFF
--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -23,6 +23,7 @@
     <ID>MagicNumber:ExclusionZoneService.kt$ExclusionZoneService$500</ID>
     <ID>MagicNumber:LicenceActivationService.kt$LicenceActivationService$4</ID>
     <ID>MagicNumber:LicenceService.kt$LicenceService$14L</ID>
+    <ID>MagicNumber:ProbationSearchApiClient.kt$ProbationSearchApiClient$2000</ID>
     <ID>MatchingDeclarationName:EventSpecifications.kt$EventQueryObject</ID>
     <ID>MatchingDeclarationName:LicenceFunctions.kt$SentenceChanges</ID>
     <ID>MatchingDeclarationName:LicenceSpecifications.kt$LicenceQueryObject</ID>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ComService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ComService.kt
@@ -150,8 +150,6 @@ class ComService(
 
     val prisoners = this.prisonerSearchApiClient.searchPrisonersByNomisIds(prisonNumbers)
 
-    println(prisoners)
-
     if (prisoners.isEmpty()) {
       return emptyMap()
     }
@@ -162,8 +160,6 @@ class ComService(
       }
 
     val prisonerBookingsWithHdc = initialCvlEligiblePrisoners.findBookingsWithHdc()
-
-    println(prisonerBookingsWithHdc)
 
     val eligibleForCvlPrisoners = initialCvlEligiblePrisoners.filterNot { prisonerBookingsWithHdc.contains(it.bookingId.toLong()) }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/ProbationSearchApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/ProbationSearchApiClient.kt
@@ -21,6 +21,7 @@ class ProbationSearchApiClient(@Qualifier("oauthProbationSearchApiClient") val p
       teamCodes,
       query,
       sortOptions,
+      2000,
     )
 
     val probationOffenderSearchResponse = probationSearchApiClient

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/model/request/LicenceCaseloadSearchRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/model/request/LicenceCaseloadSearchRequest.kt
@@ -4,4 +4,5 @@ data class LicenceCaseloadSearchRequest(
   val teamCodes: List<String>,
   val query: String,
   val sortBy: List<ProbationSearchSortByRequest>,
+  val pageSize: Int,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/ComIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/ComIntegrationTest.kt
@@ -186,6 +186,7 @@ class ComIntegrationTest : IntegrationTestBase() {
       listOf(
         ProbationSearchSortByRequest("name.forename", "asc"),
       ),
+      2000,
     )
 
     @JvmStatic


### PR DESCRIPTION
This PR is to add the page size to the initial licence caseload search call we make when using search. This is off the back of initial investigation around search results following the addition of the Eligibility Service. There are too few results being returned and this seems like the culprit. 