### PR TITLE
Rename existing classes to match what is being returned

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ComService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ComService.kt
@@ -13,9 +13,9 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.LicenceR
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.prison.PrisonApiClient
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.prison.PrisonerSearchApiClient
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.prison.PrisonerSearchPrisoner
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation.CaseloadResult
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation.CommunityApiClient
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation.ProbationSearchApiClient
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation.ProbationSearchResponseResult
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation.model.request.ProbationSearchSortByRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceType
@@ -103,7 +103,7 @@ class ComService(
       body.getSortBy(),
     )
 
-    val resultsWithLicences: List<Pair<ProbationSearchResponseResult, Licence?>> =
+    val resultsWithLicences: List<Pair<CaseloadResult, Licence?>> =
       teamCaseloadResult.map { it to getLicence(it) }
 
     val resultsWithUnstartedLicences = findPrisonersForUnstartedRecords(resultsWithLicences)
@@ -142,7 +142,7 @@ class ComService(
 
   private fun PrisonerSearchPrisoner.getReleaseDate() = confirmedReleaseDate ?: releaseDate
 
-  private fun getLicence(result: ProbationSearchResponseResult): Licence? {
+  private fun getLicence(result: CaseloadResult): Licence? {
     val licences =
       licenceRepository.findAllByCrnAndStatusCodeIn(result.identifiers.crn, LicenceStatus.IN_FLIGHT_LICENCES)
     return if (licences.isEmpty()) {
@@ -153,7 +153,7 @@ class ComService(
     }
   }
 
-  private fun findPrisonersForUnstartedRecords(record: List<Pair<ProbationSearchResponseResult, Licence?>>): Map<String, PrisonerSearchPrisoner> {
+  private fun findPrisonersForUnstartedRecords(record: List<Pair<CaseloadResult, Licence?>>): Map<String, PrisonerSearchPrisoner> {
     val prisonNumbers = record
       .filter { (_, licence) -> licence == null }
       .mapNotNull { (result, _) -> result.identifiers.noms }
@@ -177,7 +177,7 @@ class ComService(
     return eligibleForCvlPrisoners.associateBy { it.prisonerNumber }
   }
 
-  private fun ProbationSearchResponseResult.createUnstartedRecord(
+  private fun CaseloadResult.createUnstartedRecord(
     prisoner: PrisonerSearchPrisoner?,
   ) = when {
     // no match for prisoner in Delius
@@ -193,7 +193,7 @@ class ComService(
     )
   }
 
-  private fun ProbationSearchResponseResult.createRecord(licence: Licence) =
+  private fun CaseloadResult.createRecord(licence: Licence) =
     this.transformToModelFoundProbationRecord(licence)
 
   private fun ProbationUserSearchRequest.getSortBy() =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ToModelTransformers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ToModelTransformers.kt
@@ -2,7 +2,7 @@ package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service
 
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.Licence
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.LicenceSummary
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation.ProbationSearchResponseResult
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation.CaseloadResult
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceType
 import java.time.LocalDate
@@ -250,7 +250,7 @@ fun transform(entity: EntityLicenceEvent): ModelLicenceEvent {
   )
 }
 
-fun ProbationSearchResponseResult.transformToModelFoundProbationRecord(licence: Licence?): ModelFoundProbationRecord {
+fun CaseloadResult.transformToModelFoundProbationRecord(licence: Licence?): ModelFoundProbationRecord {
   return ModelFoundProbationRecord(
     name = "${name.forename} ${name.surname}".convertToTitleCase(),
     crn = licence?.crn,
@@ -266,7 +266,7 @@ fun ProbationSearchResponseResult.transformToModelFoundProbationRecord(licence: 
   )
 }
 
-fun ProbationSearchResponseResult.transformToUnstartedRecord(
+fun CaseloadResult.transformToUnstartedRecord(
   releaseDate: LocalDate?,
   licenceType: LicenceType?,
   licenceStatus: LicenceStatus?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/CaseloadResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/CaseloadResponse.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation
+
+data class CaseloadResponse(
+  val content: List<CaseloadResult>,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/CaseloadResult.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/CaseloadResult.kt
@@ -1,6 +1,6 @@
 package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation
 
-data class ProbationSearchResponseResult(
+data class CaseloadResult(
   val name: Name,
   val identifiers: Identifiers,
   val manager: Manager,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/ProbationSearchApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/ProbationSearchApiClient.kt
@@ -14,7 +14,7 @@ class ProbationSearchApiClient(@Qualifier("oauthProbationSearchApiClient") val p
     query: String,
     teamCodes: List<String>,
     sortBy: List<ProbationSearchSortByRequest> = emptyList(),
-  ): List<ProbationSearchResponseResult> {
+  ): List<CaseloadResult> {
     val sortOptions = sortBy.ifEmpty { listOf(ProbationSearchSortByRequest()) }
 
     val licenceCaseLoadRequestBody = LicenceCaseloadSearchRequest(
@@ -30,7 +30,7 @@ class ProbationSearchApiClient(@Qualifier("oauthProbationSearchApiClient") val p
       .bodyValue(licenceCaseLoadRequestBody)
       .accept(MediaType.APPLICATION_JSON)
       .retrieve()
-      .bodyToMono(ProbationSearchResponse::class.java)
+      .bodyToMono(CaseloadResponse::class.java)
       .block()
 
     return probationOffenderSearchResponse?.content ?: error("Unexpected null response from API")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/ProbationSearchResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/ProbationSearchResponse.kt
@@ -1,5 +1,0 @@
-package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation
-
-data class ProbationSearchResponse(
-  val content: List<ProbationSearchResponseResult>,
-)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ComServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ComServiceTest.kt
@@ -24,12 +24,12 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.prison.Pris
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.prison.PrisonerHdcStatus
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.prison.PrisonerSearchApiClient
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.prison.PrisonerSearchPrisoner
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation.CaseloadResult
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation.CommunityApiClient
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation.Identifiers
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation.Manager
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation.Name
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation.ProbationSearchApiClient
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation.ProbationSearchResponseResult
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation.Team
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation.model.request.ProbationSearchSortByRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceKind
@@ -283,7 +283,7 @@ class ComServiceTest {
     )
     whenever(probationSearchApiClient.searchLicenceCaseloadByTeam("Test", listOf("A01B02"))).thenReturn(
       listOf(
-        ProbationSearchResponseResult(
+        CaseloadResult(
           Name("Test", "Surname"),
           Identifiers("A123456", "A1234AA"),
           Manager(
@@ -366,7 +366,7 @@ class ComServiceTest {
       ),
     ).thenReturn(
       listOf(
-        ProbationSearchResponseResult(
+        CaseloadResult(
           Name("Test", "Surname"),
           Identifiers("A123456", "A1234AA"),
           Manager(
@@ -424,7 +424,7 @@ class ComServiceTest {
     )
     whenever(probationSearchApiClient.searchLicenceCaseloadByTeam("Test", listOf("A01B02"))).thenReturn(
       listOf(
-        ProbationSearchResponseResult(
+        CaseloadResult(
           Name("Test", "Surname"),
           Identifiers("A123456", "A1234AA"),
           Manager(
@@ -510,7 +510,7 @@ class ComServiceTest {
     )
     whenever(probationSearchApiClient.searchLicenceCaseloadByTeam("Test", listOf("A01B02"))).thenReturn(
       listOf(
-        ProbationSearchResponseResult(
+        CaseloadResult(
           Name("Test", "Surname"),
           Identifiers("A123456", "A1234AA"),
           Manager(
@@ -596,7 +596,7 @@ class ComServiceTest {
     )
     whenever(probationSearchApiClient.searchLicenceCaseloadByTeam("Test", listOf("A01B02"))).thenReturn(
       listOf(
-        ProbationSearchResponseResult(
+        CaseloadResult(
           Name("Test", "Surname"),
           Identifiers("A123456", "A1234AA"),
           Manager(
@@ -684,7 +684,7 @@ class ComServiceTest {
     )
     whenever(probationSearchApiClient.searchLicenceCaseloadByTeam("Test", listOf("A01B02"))).thenReturn(
       listOf(
-        ProbationSearchResponseResult(
+        CaseloadResult(
           Name("Test", "Surname"),
           Identifiers("A123456", "A1234AA"),
           Manager(
@@ -780,7 +780,7 @@ class ComServiceTest {
     )
     whenever(probationSearchApiClient.searchLicenceCaseloadByTeam("Test", listOf("A01B02"))).thenReturn(
       listOf(
-        ProbationSearchResponseResult(
+        CaseloadResult(
           Name("Test", "Surname"),
           Identifiers("A123456", null),
           Manager(
@@ -842,7 +842,7 @@ class ComServiceTest {
     )
     whenever(probationSearchApiClient.searchLicenceCaseloadByTeam("Test", listOf("A01B02"))).thenReturn(
       listOf(
-        ProbationSearchResponseResult(
+        CaseloadResult(
           Name("Test", "Surname"),
           Identifiers("A123456", "A1234AA"),
           Manager(
@@ -937,7 +937,7 @@ class ComServiceTest {
     )
     whenever(probationSearchApiClient.searchLicenceCaseloadByTeam("Test", listOf("A01B02"))).thenReturn(
       listOf(
-        ProbationSearchResponseResult(
+        CaseloadResult(
           Name("Test", "Surname"),
           Identifiers("A123456", "A1234AA"),
           Manager(
@@ -1035,7 +1035,7 @@ class ComServiceTest {
     )
     whenever(probationSearchApiClient.searchLicenceCaseloadByTeam("Test", listOf("A01B02"))).thenReturn(
       listOf(
-        ProbationSearchResponseResult(
+        CaseloadResult(
           Name("Test", "Surname"),
           Identifiers("A123456", "A1234AA"),
           Manager(
@@ -1134,7 +1134,7 @@ class ComServiceTest {
     )
     whenever(probationSearchApiClient.searchLicenceCaseloadByTeam("Test", listOf("A01B02"))).thenReturn(
       listOf(
-        ProbationSearchResponseResult(
+        CaseloadResult(
           Name("Test", "Surname"),
           Identifiers("A123456", "A1234AA"),
           Manager(
@@ -1233,7 +1233,7 @@ class ComServiceTest {
     )
     whenever(probationSearchApiClient.searchLicenceCaseloadByTeam("Test", listOf("A01B02"))).thenReturn(
       listOf(
-        ProbationSearchResponseResult(
+        CaseloadResult(
           Name("Test", "Surname"),
           Identifiers("A123456", "A1234AA"),
           Manager(
@@ -1307,7 +1307,7 @@ class ComServiceTest {
     )
     whenever(probationSearchApiClient.searchLicenceCaseloadByTeam("Test", listOf("A01B02"))).thenReturn(
       listOf(
-        ProbationSearchResponseResult(
+        CaseloadResult(
           Name("Test", "Surname"),
           Identifiers("A123456", "A1234AA"),
           Manager(
@@ -1405,7 +1405,7 @@ class ComServiceTest {
     )
     whenever(probationSearchApiClient.searchLicenceCaseloadByTeam("Test", listOf("A01B02"))).thenReturn(
       listOf(
-        ProbationSearchResponseResult(
+        CaseloadResult(
           Name("Test", "Surname"),
           Identifiers("A123456", "A1234AA"),
           Manager(
@@ -1476,7 +1476,7 @@ class ComServiceTest {
     )
     whenever(probationSearchApiClient.searchLicenceCaseloadByTeam("Test", listOf("A01B02"))).thenReturn(
       listOf(
-        ProbationSearchResponseResult(
+        CaseloadResult(
           Name("Test", "Surname"),
           Identifiers("A123456", "A1234AA"),
           Manager(
@@ -1580,7 +1580,7 @@ class ComServiceTest {
     )
     whenever(probationSearchApiClient.searchLicenceCaseloadByTeam("Test", listOf("A01B02"))).thenReturn(
       listOf(
-        ProbationSearchResponseResult(
+        CaseloadResult(
           Name("Test", "Surname"),
           Identifiers("A123456", "A1234AA"),
           Manager(
@@ -1661,7 +1661,7 @@ class ComServiceTest {
     )
     whenever(probationSearchApiClient.searchLicenceCaseloadByTeam("Test", listOf("A01B02"))).thenReturn(
       listOf(
-        ProbationSearchResponseResult(
+        CaseloadResult(
           Name("Test", "Surname"),
           Identifiers("A123456", "A1234AA"),
           Manager(


### PR DESCRIPTION
This PR is a simple one to rename some of the classes around the Probation Search API so they are indicative of what is being returned. 