### PR TITLE
CVSL-1505 add probation search call to api client

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/OffenderDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/OffenderDetail.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation
+
+data class OffenderDetail(
+  val offenderId: Int,
+  val otherIds: OtherIds,
+  val offenderManagers: List<OffenderManager>,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/OffenderManager.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/OffenderManager.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+class OffenderManager(
+  @JsonProperty("staff")
+  val staffDetail: StaffDetail,
+  val active: Boolean,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/OtherIds.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/OtherIds.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation
+
+class OtherIds(
+  val crn: String,
+  val croNumber: String,
+  val pncNumber: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/ProbationSearchApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/ProbationSearchApiClient.kt
@@ -4,7 +4,9 @@ import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.typeReference
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation.model.request.LicenceCaseloadSearchRequest
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation.model.request.OffenderSearchRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation.model.request.ProbationSearchSortByRequest
 
 @Component
@@ -34,5 +36,19 @@ class ProbationSearchApiClient(@Qualifier("oauthProbationSearchApiClient") val p
       .block()
 
     return probationOffenderSearchResponse?.content ?: error("Unexpected null response from API")
+  }
+
+  fun searchForPersonOnProbation(
+    nomisId: String,
+  ): OffenderDetail {
+    val probationOffenderSearchResponse = probationSearchApiClient
+      .post()
+      .uri("/search")
+      .bodyValue(OffenderSearchRequest(nomsNumber = nomisId))
+      .accept(MediaType.APPLICATION_JSON)
+      .retrieve()
+      .bodyToMono(typeReference<List<OffenderDetail>>())
+      .block()
+    return probationOffenderSearchResponse?.get(0) ?: error("Unexpected null response from API")
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/StaffDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/StaffDetail.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation
+
+class StaffDetail(
+  val code: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/model/request/OffenderSearchRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/model/request/OffenderSearchRequest.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation.model.request
+
+data class OffenderSearchRequest(
+  val nomsNumber: String,
+)


### PR DESCRIPTION
This PR is to add a `/search` call from the Probation Search API client as this is needed to move the licence creation to the backend. 