### PR TITLE
CVSL-1505 add parameters needed to create licences in the backend

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/prison/PrisonerSearchPrisoner.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/prison/PrisonerSearchPrisoner.kt
@@ -41,4 +41,31 @@ data class PrisonerSearchPrisoner(
   val indeterminateSentence: Boolean,
 
   val recall: Boolean,
+
+  val prisonId: String,
+
+  val bookNumber: String,
+
+  val firstName: String,
+
+  val middleNames: String? = null,
+
+  val lastName: String,
+
+  @JsonFormat(pattern = "yyyy-MM-dd")
+  val dateOfBirth: LocalDate,
+
+  @JsonFormat(pattern = "yyyy-MM-dd")
+  val conditionalReleaseDateOverrideDate: LocalDate? = null,
+
+  @JsonFormat(pattern = "yyyy-MM-dd")
+  val sentenceStartDate: LocalDate? = null,
+
+  @JsonFormat(pattern = "yyyy-MM-dd")
+  val sentenceExpiryDate: LocalDate? = null,
+
+  @JsonFormat(pattern = "yyyy-MM-dd")
+  val topUpSupervisionStartDate: LocalDate? = null,
+
+  val croNumber: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/CommunityOrPrisonOffenderManager.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/CommunityOrPrisonOffenderManager.kt
@@ -4,5 +4,5 @@ data class CommunityOrPrisonOffenderManager(
   val staffCode: String,
   val staffId: Long,
   val team: TeamDetail,
-  val probationArea: ProbationAreaDetail,
+  val probationArea: Detail,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/CommunityOrPrisonOffenderManager.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/CommunityOrPrisonOffenderManager.kt
@@ -2,4 +2,7 @@ package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation
 
 data class CommunityOrPrisonOffenderManager(
   val staffCode: String,
+  val staffId: Long,
+  val team: TeamDetail,
+  val probationArea: ProbationAreaDetail,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/Detail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/Detail.kt
@@ -1,6 +1,6 @@
 package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation
 
-data class Team(
+data class Detail(
   val code: String,
   val description: String?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/Manager.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/Manager.kt
@@ -3,5 +3,5 @@ package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation
 data class Manager(
   val code: String?,
   val name: Name?,
-  val team: Team,
+  val team: Detail,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/OffenderDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/OffenderDetail.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation
 
 data class OffenderDetail(
-  val offenderId: Int,
+  val offenderId: Long,
   val otherIds: OtherIds,
   val offenderManagers: List<OffenderManager>,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/OtherIds.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/OtherIds.kt
@@ -2,6 +2,6 @@ package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation
 
 data class OtherIds(
   val crn: String,
-  val croNumber: String,
-  val pncNumber: String,
+  val croNumber: String? = null,
+  val pncNumber: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/ProbationAreaDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/ProbationAreaDetail.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation
 
-data class User(
-  val teams: List<Detail>,
+data class ProbationAreaDetail(
+  val code: String,
+  val description: String?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/ProbationAreaDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/ProbationAreaDetail.kt
@@ -1,6 +1,0 @@
-package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation
-
-data class ProbationAreaDetail(
-  val code: String,
-  val description: String?,
-)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/TeamDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/TeamDetail.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation
+
+data class TeamDetail(
+  val code: String,
+  val description: String,
+  val borough: Detail,
+  val district: Detail,
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/wiremock/PrisonerSearchMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/wiremock/PrisonerSearchMockServer.kt
@@ -21,21 +21,39 @@ class PrisonerSearchMockServer : WireMockServer(8099) {
                   "bookingId": "456",
                   "status": "INACTIVE",
                   "legalStatus": "SENTENCED",
-                  "indeterminateSentence": false
+                  "indeterminateSentence": false,
+                  "recall": false,
+                  "prisonId": "ABC",
+                  "bookNumber": "12345A",
+                  "firstName": "Test1",
+                  "lastName": "Person1",
+                  "dateOfBirth": "1985-01-01"
                },
-                               {
+               {
                   "prisonerNumber": "G5613GT",
                   "bookingId": "789",
                   "status": "INACTIVE",
                   "legalStatus": "SENTENCED",
-                  "indeterminateSentence": false
+                  "indeterminateSentence": false,
+                  "recall": false,
+                  "prisonId": "DEF",
+                  "bookNumber": "67890B",
+                  "firstName": "Test2",
+                  "lastName": "Person2",
+                  "dateOfBirth": "1986-01-01"
                },
-                               {
+               {
                   "prisonerNumber": "G4169UO",
                   "bookingId": "432",
                   "status": "INACTIVE",
                   "legalStatus": "SENTENCED",
-                  "indeterminateSentence": false
+                  "indeterminateSentence": false,
+                  "recall": false,
+                  "prisonId": "GHI",
+                  "bookNumber": "12345C",
+                  "firstName": "Test3",
+                  "lastName": "Person3",
+                  "dateOfBirth": "1987-01-01"
                }
               ]
             """.trimIndent(),
@@ -69,7 +87,12 @@ class PrisonerSearchMockServer : WireMockServer(8099) {
                   "postRecallReleaseDate": null,
                   "legalStatus": "SENTENCED",
                   "indeterminateSentence": false,
-                  "recall": false
+                  "recall": false,
+                  "prisonId": "ABC",
+                  "bookNumber": "12345A",
+                  "firstName": "Test1",
+                  "lastName": "Person1",
+                  "dateOfBirth": "1985-01-01"
                },
                {
                   "prisonerNumber": "A1234AB",
@@ -87,7 +110,12 @@ class PrisonerSearchMockServer : WireMockServer(8099) {
                   "postRecallReleaseDate": null,
                   "legalStatus": "SENTENCED",
                   "indeterminateSentence": false,
-                  "recall": false
+                  "recall": false,
+                  "prisonId": "DEF",
+                  "bookNumber": "67890B",
+                  "firstName": "Test2",
+                  "lastName": "Person2",
+                  "dateOfBirth": "1986-01-01"
                },
                {
                   "prisonerNumber": "A1234AC",
@@ -105,7 +133,12 @@ class PrisonerSearchMockServer : WireMockServer(8099) {
                   "postRecallReleaseDate": null,
                   "legalStatus": "SENTENCED",
                   "indeterminateSentence": false,
-                  "recall": false
+                  "recall": false,
+                  "prisonId": "GHI",
+                  "bookNumber": "12345C",
+                  "firstName": "Test3",
+                  "lastName": "Person3",
+                  "dateOfBirth": "1987-01-01"
                }
               ]
             """.trimIndent(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ComServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ComServiceTest.kt
@@ -24,11 +24,11 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.prison.Pris
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.prison.PrisonerSearchPrisoner
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation.CaseloadResult
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation.CommunityApiClient
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation.Detail
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation.Identifiers
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation.Manager
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation.Name
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation.ProbationSearchApiClient
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation.Team
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation.model.request.ProbationSearchSortByRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceType
@@ -285,7 +285,7 @@ class ComServiceTest {
           Manager(
             "A01B02C",
             Name("Staff", "Surname"),
-            Team("A01B02", "Test Team"),
+            Detail("A01B02", "Test Team"),
           ),
           "2023/05/24",
         ),
@@ -368,7 +368,7 @@ class ComServiceTest {
           Manager(
             "A01B02C",
             Name("Staff", "Surname"),
-            Team("A01B02", "Test Team"),
+            Detail("A01B02", "Test Team"),
           ),
           "2023/05/24",
         ),
@@ -426,7 +426,7 @@ class ComServiceTest {
           Manager(
             "A01B02C",
             Name("Staff", "Surname"),
-            Team("A01B02", "Test Team"),
+            Detail("A01B02", "Test Team"),
           ),
           "2023/05/24",
         ),
@@ -512,7 +512,7 @@ class ComServiceTest {
           Manager(
             "A01B02C",
             Name("Staff", "Surname"),
-            Team("A01B02", "Test Team"),
+            Detail("A01B02", "Test Team"),
           ),
           "2023/05/24",
         ),
@@ -598,7 +598,7 @@ class ComServiceTest {
           Manager(
             "A01B02C",
             Name("Staff", "Surname"),
-            Team("A01B02", "Test Team"),
+            Detail("A01B02", "Test Team"),
           ),
           "2023/05/24",
         ),
@@ -686,7 +686,7 @@ class ComServiceTest {
           Manager(
             "A01B02C",
             Name("Staff", "Surname"),
-            Team("A01B02", "Test Team"),
+            Detail("A01B02", "Test Team"),
           ),
           "2023/05/24",
         ),
@@ -782,7 +782,7 @@ class ComServiceTest {
           Manager(
             "A01B02C",
             Name("Staff", "Surname"),
-            Team("A01B02", "Test Team"),
+            Detail("A01B02", "Test Team"),
           ),
           "2023/05/24",
         ),
@@ -844,7 +844,7 @@ class ComServiceTest {
           Manager(
             "A01B02C",
             Name("Staff", "Surname"),
-            Team("A01B02", "Test Team"),
+            Detail("A01B02", "Test Team"),
           ),
           "2023/05/24",
         ),
@@ -939,7 +939,7 @@ class ComServiceTest {
           Manager(
             "A01B02C",
             Name("Staff", "Surname"),
-            Team("A01B02", "Test Team"),
+            Detail("A01B02", "Test Team"),
           ),
           "2023/05/24",
         ),
@@ -1037,7 +1037,7 @@ class ComServiceTest {
           Manager(
             "A01B02C",
             Name("Staff", "Surname"),
-            Team("A01B02", "Test Team"),
+            Detail("A01B02", "Test Team"),
           ),
           "2023/05/24",
         ),
@@ -1136,7 +1136,7 @@ class ComServiceTest {
           Manager(
             "A01B02C",
             Name("Staff", "Surname"),
-            Team("A01B02", "Test Team"),
+            Detail("A01B02", "Test Team"),
           ),
           "2023/05/24",
         ),
@@ -1235,7 +1235,7 @@ class ComServiceTest {
           Manager(
             "A01B02C",
             Name("Staff", "Surname"),
-            Team("A01B02", "Test Team"),
+            Detail("A01B02", "Test Team"),
           ),
           "2023/05/24",
         ),
@@ -1309,7 +1309,7 @@ class ComServiceTest {
           Manager(
             "A01B02C",
             Name("Staff", "Surname"),
-            Team("A01B02", "Test Team"),
+            Detail("A01B02", "Test Team"),
           ),
           "2023/05/24",
         ),
@@ -1407,7 +1407,7 @@ class ComServiceTest {
           Manager(
             "A01B02C",
             Name("Staff", "Surname"),
-            Team("A01B02", "Test Team"),
+            Detail("A01B02", "Test Team"),
           ),
           "2023/05/24",
         ),
@@ -1478,7 +1478,7 @@ class ComServiceTest {
           Manager(
             "A01B02C",
             Name("Staff", "Surname"),
-            Team("A01B02", "Test Team"),
+            Detail("A01B02", "Test Team"),
           ),
           "2023/05/24",
         ),
@@ -1582,7 +1582,7 @@ class ComServiceTest {
           Manager(
             "A01B02C",
             Name("Staff", "Surname"),
-            Team("A01B02", "Test Team"),
+            Detail("A01B02", "Test Team"),
           ),
           "2023/05/24",
         ),
@@ -1663,7 +1663,7 @@ class ComServiceTest {
           Manager(
             "A01B02C",
             Name("Staff", "Surname"),
-            Team("A01B02", "Test Team"),
+            Detail("A01B02", "Test Team"),
           ),
           "2023/05/24",
         ),
@@ -1790,6 +1790,17 @@ class ComServiceTest {
       legalStatus = "SENTENCED",
       indeterminateSentence = false,
       recall = false,
+      prisonId = "ABC",
+      bookNumber = "12345A",
+      firstName = "Jane",
+      middleNames = null,
+      lastName = "Doe",
+      dateOfBirth = LocalDate.parse("1985-01-01"),
+      conditionalReleaseDateOverrideDate = null,
+      sentenceStartDate = LocalDate.parse("2023-09-14"),
+      sentenceExpiryDate = LocalDate.parse("2024-09-14"),
+      topUpSupervisionStartDate = null,
+      croNumber = null,
     )
 
     val aPrisonerHdcStatus = PrisonerHdcStatus(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/EligibilityServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/EligibilityServiceTest.kt
@@ -236,6 +236,17 @@ class EligibilityServiceTest {
       legalStatus = "SENTENCED",
       indeterminateSentence = false,
       recall = false,
+      prisonId = "ABC",
+      bookNumber = "12345A",
+      firstName = "Jane",
+      middleNames = null,
+      lastName = "Doe",
+      dateOfBirth = LocalDate.parse("1985-01-01"),
+      conditionalReleaseDateOverrideDate = null,
+      sentenceStartDate = LocalDate.parse("2023-09-14"),
+      sentenceExpiryDate = LocalDate.parse("2024-09-14"),
+      topUpSupervisionStartDate = null,
+      croNumber = null,
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/IS91DeterminationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/IS91DeterminationServiceTest.kt
@@ -83,5 +83,16 @@ class IS91DeterminationServiceTest {
     legalStatus = "SENTENCED",
     indeterminateSentence = false,
     recall = false,
+    prisonId = "ABC",
+    bookNumber = "12345A",
+    firstName = "Jane",
+    middleNames = null,
+    lastName = "Doe",
+    dateOfBirth = LocalDate.parse("1985-01-01"),
+    conditionalReleaseDateOverrideDate = null,
+    sentenceStartDate = LocalDate.parse("2023-09-14"),
+    sentenceExpiryDate = LocalDate.parse("2024-09-14"),
+    topUpSupervisionStartDate = null,
+    croNumber = null,
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/jobs/LicenceActivationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/jobs/LicenceActivationServiceTest.kt
@@ -355,6 +355,17 @@ class LicenceActivationServiceTest {
     legalStatus = "SENTENCED",
     indeterminateSentence = false,
     recall = false,
+    prisonId = "ABC",
+    bookNumber = "12345A",
+    firstName = "Jane",
+    middleNames = null,
+    lastName = "Doe",
+    dateOfBirth = LocalDate.parse("1985-01-01"),
+    conditionalReleaseDateOverrideDate = null,
+    sentenceStartDate = LocalDate.parse("2023-09-14"),
+    sentenceExpiryDate = LocalDate.parse("2024-09-14"),
+    topUpSupervisionStartDate = null,
+    croNumber = null,
   )
 
   val hdcLicence = aLicenceEntity


### PR DESCRIPTION
This latest PR introduces some extra variables we will need to expose from responses to various external API's in order to create the licence in the backend. 