### PR TITLE
CVSL-1515 add localstack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,24 @@ services:
       timeout: 5s
       retries: 5
 
+  localstack:
+    image: localstack/localstack:2.2.0
+    networks:
+      - hmpps
+    container_name: localstack
+    ports:
+      - "4566:4566"
+    environment:
+      - DEBUG=${DEBUG- }
+      - DOCKER_HOST=unix:///var/run/docker.sock
+    volumes:
+      - "${TMPDIR:-/tmp/localstack}:/tmp/localstack"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+    healthcheck:
+      test: awslocal sqs list-queues
+      interval: 5s
+      timeout: 3s
+      retries: 5
 
 networks:
   hmpps:

--- a/run-local.sh
+++ b/run-local.sh
@@ -27,6 +27,9 @@ restart_docker () {
   until [ "`docker inspect -f {{.State.Health.Status}} licences-db`" == "healthy" ]; do
       sleep 0.1;
   done;
+  until [ "`docker inspect -f {{.State.Health.Status}} localstack`" == "healthy" ]; do
+      sleep 0.1;
+  done;
 
   echo "Back end containers are now ready"
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -32,3 +32,14 @@ hmpps:
   prisonersearch:
     api:
       url: "https://prisoner-search-dev.prison.service.justice.gov.uk"
+
+hmpps.sqs:
+  provider: localstack
+  queues:
+    domaineventsqueue:
+      queueName: domainevents-queue
+      dlqName: domainevents-queue-dlq
+      subscribeTopicId: domainevents
+  topics:
+    domainevents:
+      arn: arn:aws:sns:eu-west-2:000000000000:domainevents-topic

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -79,3 +79,14 @@ cache:
   evict:
     bank-holidays:
       cron: "0 45 23 * * ?"
+
+hmpps.sqs:
+  provider: localstack
+  queues:
+    domaineventsqueue:
+      queueName: domainevents-queue
+      dlqName: domainevents-queue-dlq
+      subscribeTopicId: domainevents
+  topics:
+    domainevents:
+      arn: arn:aws:sns:eu-west-2:000000000000:domainevents-topic


### PR DESCRIPTION
This PR is to add localstack to CVL which will enable us to create mock versions of AWS services such as queues and notifications within our integration tests and locally, making tests queues, a lot easier. 