### PR TITLE
CVSL-1516 add localstack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,8 +23,6 @@ jobs:
     executor:
       name: hmpps/java
       tag: << pipeline.parameters.java-version >>
-      localstack_tag: << pipeline.parameters.localstack-version >>
-      services: "sns,sqs"
     steps:
       - checkout
       - restore_cache:
@@ -65,6 +63,8 @@ jobs:
     executor:
       name: hmpps/java
       tag: << pipeline.parameters.java-version >>
+      localstack_tag: << pipeline.parameters.localstack-version >>
+      services: "sns,sqs"
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,9 @@ parameters:
   java-version:
     type: string
     default: "19.0"
+  localstack-version:
+    type: string
+    default: "3.0.2"
 
 jobs:
   validate:
@@ -58,8 +61,10 @@ jobs:
 
   integration-test:
     executor:
-      name: hmpps/java
-      tag: << pipeline.parameters.java-version >>
+      name: hmpps/java_localstack
+      jdk_tag: << pipeline.parameters.java-version >>
+      localstack_tag: << pipeline.parameters.localstack-version >>
+      services: "sns,sqs"
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,8 +63,7 @@ jobs:
     executor:
       name: hmpps/java
       tag: << pipeline.parameters.java-version >>
-      localstack_tag: << pipeline.parameters.localstack-version >>
-      services: "sns,sqs"
+      localstack_tag: "3.0.2"
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,9 +72,6 @@ jobs:
             - gradle-{{ checksum "build.gradle.kts" }}
             - gradle-
       - run:
-          name: Wait for localstack to be ready
-          command: curl -4 --connect-timeout 30 --retry-connrefused --retry 20 --retry-delay 5 http://localhost:4566
-      - run:
           command: ./gradlew -Dorg.gradle.jvmargs="--illegal-access=permit" -Dkotlin.daemon.jvm.options="--illegal-access=permit" integrationTest
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
 
   integration-test:
     executor:
-      name: hmpps/java_localstack
+      name: hmpps/localstack
       jdk_tag: << pipeline.parameters.java-version >>
       localstack_tag: << pipeline.parameters.localstack-version >>
       services: "sns,sqs"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,12 +14,17 @@ parameters:
   java-version:
     type: string
     default: "19.0"
+  localstack-version:
+    type: string
+    default: "3.0.2"
 
 jobs:
   validate:
     executor:
       name: hmpps/java
       tag: << pipeline.parameters.java-version >>
+      localstack_tag: << pipeline.parameters.localstack-version >>
+      services: "sns,sqs"
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
 
   integration-test:
     executor:
-      name: hmpps/localstack
+      name: hmpps/java
       tag: << pipeline.parameters.java-version >>
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,9 +14,6 @@ parameters:
   java-version:
     type: string
     default: "19.0"
-  localstack-version:
-    type: string
-    default: "3.0.2"
 
 jobs:
   validate:
@@ -61,15 +58,17 @@ jobs:
 
   integration-test:
     executor:
-      name: hmpps/java
+      name: hmpps/localstack
       tag: << pipeline.parameters.java-version >>
-      localstack_tag: "3.0.2"
     steps:
       - checkout
       - restore_cache:
           keys:
             - gradle-{{ checksum "build.gradle.kts" }}
             - gradle-
+      - run:
+          name: Wait for localstack to be ready
+          command: curl -4 --connect-timeout 30 --retry-connrefused --retry 20 --retry-delay 5 http://localhost:4566
       - run:
           command: ./gradlew -Dorg.gradle.jvmargs="--illegal-access=permit" -Dkotlin.daemon.jvm.options="--illegal-access=permit" integrationTest
       - save_cache:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,24 @@ services:
       timeout: 5s
       retries: 5
 
+  localstack:
+    image: localstack/localstack:2.2.0
+    networks:
+      - hmpps
+    container_name: localstack
+    ports:
+      - "4566:4566"
+    environment:
+      - DEBUG=${DEBUG- }
+      - DOCKER_HOST=unix:///var/run/docker.sock
+    volumes:
+      - "${TMPDIR:-/tmp/localstack}:/tmp/localstack"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+    healthcheck:
+      test: awslocal sqs list-queues
+      interval: 5s
+      timeout: 3s
+      retries: 5
 
 networks:
   hmpps:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       retries: 5
 
   localstack:
-    image: localstack/localstack:2.2.0
+    image: localstack/localstack:3.0.2
     networks:
       - hmpps
     container_name: localstack

--- a/run-local.sh
+++ b/run-local.sh
@@ -27,6 +27,9 @@ restart_docker () {
   until [ "`docker inspect -f {{.State.Health.Status}} licences-db`" == "healthy" ]; do
       sleep 0.1;
   done;
+  until [ "`docker inspect -f {{.State.Health.Status}} localstack`" == "healthy" ]; do
+      sleep 0.1;
+  done;
 
   echo "Back end containers are now ready"
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -32,3 +32,14 @@ hmpps:
   prisonersearch:
     api:
       url: "https://prisoner-search-dev.prison.service.justice.gov.uk"
+
+hmpps.sqs:
+  provider: localstack
+  queues:
+    domaineventsqueue:
+      queueName: domainevents-queue
+      dlqName: domainevents-queue-dlq
+      subscribeTopicId: domainevents
+  topics:
+    domainevents:
+      arn: arn:aws:sns:eu-west-2:000000000000:domainevents-topic

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/IntegrationTestBase.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.integration
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.gson.GsonBuilder
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.extension.ExtendWith
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -13,8 +14,13 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.context.jdbc.SqlMergeMode
 import org.springframework.test.web.reactive.server.WebTestClient
+import software.amazon.awssdk.services.sqs.model.PurgeQueueRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.helpers.JwtAuthHelper
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.integration.wiremock.OAuthExtension
+import uk.gov.justice.hmpps.sqs.HmppsQueueService
+import uk.gov.justice.hmpps.sqs.HmppsSqsProperties
+import uk.gov.justice.hmpps.sqs.MissingQueueException
+import uk.gov.justice.hmpps.sqs.MissingTopicException
 
 /*
 ** The abstract parent class for integration tests.
@@ -38,6 +44,17 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.integration.wiremoc
 )
 abstract class IntegrationTestBase {
 
+  @BeforeEach
+  fun `Clear queues`() {
+    domainEventsQueue.sqsClient.purgeQueue(PurgeQueueRequest.builder().queueUrl(domainEventsQueue.queueUrl).build())
+  }
+
+  private val domainEventsQueue by lazy { hmppsQueueService.findByQueueId("domaineventsqueue") ?: throw MissingQueueException("HmppsQueue domaineventsqueue not found") }
+//  private val domainEventsTopic by lazy { hmppsQueueService.findByTopicId("domainevents") ?: throw MissingQueueException("HmppsTopic domainevents not found") }
+
+//  protected val domainEventsTopicSnsClient by lazy { domainEventsTopic.snsClient }
+//  protected val domainEventsTopicArn by lazy { domainEventsTopic.arn }
+
   @Suppress("SpringJavaInjectionPointsAutowiringInspection")
   @Autowired
   lateinit var webTestClient: WebTestClient
@@ -48,7 +65,14 @@ abstract class IntegrationTestBase {
   @Autowired
   lateinit var mapper: ObjectMapper
 
+  @Autowired
+  protected lateinit var hmppsQueueService: HmppsQueueService
+
   internal val gson = GsonBuilder().setPrettyPrinting().create()
+
+  fun HmppsSqsProperties.domaineventsTopicConfig() =
+    topics["domainevents"]
+      ?: throw MissingTopicException("domainevents has not been loaded from configuration properties")
 
   internal fun setAuthorisation(
     user: String = "test-client",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/IntegrationTestBase.kt
@@ -50,10 +50,6 @@ abstract class IntegrationTestBase {
   }
 
   private val domainEventsQueue by lazy { hmppsQueueService.findByQueueId("domaineventsqueue") ?: throw MissingQueueException("HmppsQueue domaineventsqueue not found") }
-//  private val domainEventsTopic by lazy { hmppsQueueService.findByTopicId("domainevents") ?: throw MissingQueueException("HmppsTopic domainevents not found") }
-
-//  protected val domainEventsTopicSnsClient by lazy { domainEventsTopic.snsClient }
-//  protected val domainEventsTopicArn by lazy { domainEventsTopic.arn }
 
   @Suppress("SpringJavaInjectionPointsAutowiringInspection")
   @Autowired

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -79,3 +79,14 @@ cache:
   evict:
     bank-holidays:
       cron: "0 45 23 * * ?"
+
+hmpps.sqs:
+  provider: localstack
+  queues:
+    domaineventsqueue:
+      queueName: domainevents-queue
+      dlqName: domainevents-queue-dlq
+      subscribeTopicId: domainevents
+  topics:
+    domainevents:
+      arn: arn:aws:sns:eu-west-2:000000000000:domainevents-topic


### PR DESCRIPTION
This PR is to add localstack to CVL which will enable us to create mock versions of AWS services such as queues and notifications within our integration tests and locally, making tests queues, a lot easier.