### PR TITLE
CVSL-1516 add extra config to change port numbers for localstack locally

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,10 +24,16 @@ services:
       - hmpps
     container_name: localstack-api
     ports:
-      - "4566:4566"
+      - "4666:4666"
+      - "4610-4659:4610-4659"
     environment:
       - DEBUG=${DEBUG- }
       - DOCKER_HOST=unix:///var/run/docker.sock
+      - GATEWAY_LISTEN=0.0.0.0:4666
+      - EXTERNAL_SERVICE_PORTS_START=4610
+      - EXTERNAL_SERVICE_PORTS_END=4659
+      - MAIN_CONTAINER_NAME=localstack-api
+      - AWS_ENDPOINT_URL=http://localhost:4666
     volumes:
       - "${TMPDIR:-/tmp/localstack}:/tmp/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -35,6 +35,7 @@ hmpps:
 
 hmpps.sqs:
   provider: localstack
+  localstackUrl: http://localhost:4666
   queues:
     domaineventsqueue:
       queueName: domainevents-queue


### PR DESCRIPTION
This PR adds some changes to the `docker-compose.yml` file to allow two Localstack instances to run at the same time. Once we move events to the backend and remove Localstack from the front end, we can revert these values back to the default values. 