### PR TITLE
CVSL-1516 add testcontainers config

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -81,6 +81,7 @@ dependencies {
   testImplementation("org.mockito:mockito-inline:5.2.0")
   testImplementation("io.projectreactor:reactor-test")
   testImplementation("com.h2database:h2")
+  testImplementation("org.testcontainers:localstack:1.19.3")
 }
 
 repositories {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/config/LocalStackContainer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/config/LocalStackContainer.kt
@@ -43,7 +43,7 @@ object LocalStackContainer {
 
   private fun localstackIsRunning(): Boolean =
     try {
-      val serverSocket = ServerSocket(4666)
+      val serverSocket = ServerSocket(4566)
       serverSocket.localPort == 0
     } catch (e: IOException) {
       true

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/config/LocalStackContainer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/config/LocalStackContainer.kt
@@ -10,7 +10,7 @@ import java.io.IOException
 import java.net.ServerSocket
 
 /**
- * This is a localstack container configuration to create a Testcontainers LocalStack instance
+ * This is a LocalStack container configuration to create a Testcontainers LocalStack instance
  * only if a standalone LocalStack instance is not already running. This means that if you check out the library and
  * run the tests then Testcontainers will jump in and start a LocalStack instance for you.
  */
@@ -43,7 +43,7 @@ object LocalStackContainer {
 
   private fun localstackIsRunning(): Boolean =
     try {
-      val serverSocket = ServerSocket(4566)
+      val serverSocket = ServerSocket(4666)
       serverSocket.localPort == 0
     } catch (e: IOException) {
       true

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/config/LocalStackContainer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/config/LocalStackContainer.kt
@@ -1,0 +1,51 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.config
+
+import org.slf4j.LoggerFactory
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.testcontainers.containers.localstack.LocalStackContainer
+import org.testcontainers.containers.output.Slf4jLogConsumer
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.utility.DockerImageName
+import java.io.IOException
+import java.net.ServerSocket
+
+/**
+ * This is a localstack container configuration to create a Testcontainers LocalStack instance
+ * only if a standalone LocalStack instance is not already running. This means that if you check out the library and
+ * run the tests then Testcontainers will jump in and start a LocalStack instance for you.
+ */
+object LocalStackContainer {
+  private val log = LoggerFactory.getLogger(this::class.java)
+  val instance by lazy { startLocalstackIfNotRunning() }
+
+  fun setLocalStackProperties(localStackContainer: LocalStackContainer, registry: DynamicPropertyRegistry) {
+    val localstackUrl = localStackContainer.getEndpointOverride(LocalStackContainer.Service.SNS).toString()
+    val region = localStackContainer.region
+    registry.add("hmpps.sqs.localstackUrl") { localstackUrl }
+    registry.add("hmpps.sqs.region") { region }
+  }
+
+  private fun startLocalstackIfNotRunning(): LocalStackContainer? {
+    if (localstackIsRunning()) return null
+    val logConsumer = Slf4jLogConsumer(log).withPrefix("localstack")
+    return LocalStackContainer(
+      DockerImageName.parse("localstack/localstack").withTag("3"),
+    ).apply {
+      withServices(LocalStackContainer.Service.SQS, LocalStackContainer.Service.SNS)
+      withEnv("DEFAULT_REGION", "eu-west-2")
+      waitingFor(
+        Wait.forLogMessage(".*Running on.*", 1),
+      )
+      start()
+      followOutput(logConsumer)
+    }
+  }
+
+  private fun localstackIsRunning(): Boolean =
+    try {
+      val serverSocket = ServerSocket(4566)
+      serverSocket.localPort == 0
+    } catch (e: IOException) {
+      true
+    }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/IntegrationTestBase.kt
@@ -12,10 +12,14 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDO
 import org.springframework.boot.test.mock.mockito.SpyBean
 import org.springframework.http.HttpHeaders
 import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.context.jdbc.SqlMergeMode
 import org.springframework.test.web.reactive.server.WebTestClient
 import software.amazon.awssdk.services.sqs.model.PurgeQueueRequest
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.config.LocalStackContainer
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.config.LocalStackContainer.setLocalStackProperties
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.helpers.JwtAuthHelper
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.integration.wiremock.OAuthExtension
 import uk.gov.justice.hmpps.sqs.HmppsQueueService
@@ -81,5 +85,12 @@ abstract class IntegrationTestBase {
 
   companion object {
     val log: Logger = LoggerFactory.getLogger(this::class.java)
+    private val localStackContainer = LocalStackContainer.instance
+
+    @JvmStatic
+    @DynamicPropertySource
+    fun testcontainers(registry: DynamicPropertyRegistry) {
+      localStackContainer?.also { setLocalStackProperties(it, registry) }
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/IntegrationTestBase.kt
@@ -90,6 +90,7 @@ abstract class IntegrationTestBase {
     @JvmStatic
     @DynamicPropertySource
     fun testcontainers(registry: DynamicPropertyRegistry) {
+      log.info("Using a Testcontainers instance of LocalStack")
       localStackContainer?.also { setLocalStackProperties(it, registry) }
     }
   }


### PR DESCRIPTION
This PR is to add a Testcontainers option when running integration tests so that if a LocalStack instance does not exist for testing, a Testcontainers instance of LocalStack is created. 