### PR TITLE
CVSL-1516 change serviceAccountName in test1 and test2

### DIFF
--- a/helm_deploy/values-test1.yaml
+++ b/helm_deploy/values-test1.yaml
@@ -9,6 +9,8 @@ generic-service:
       - create-and-vary-a-licence-api-test1.hmpps.service.justice.gov.uk
     contextColour: green
 
+  serviceAccountName: create-and-vary-a-licence
+
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
     HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"

--- a/helm_deploy/values-test2.yaml
+++ b/helm_deploy/values-test2.yaml
@@ -9,6 +9,8 @@ generic-service:
       - create-and-vary-a-licence-api-test2.hmpps.service.justice.gov.uk
     contextColour: green
 
+  serviceAccountName: create-and-vary-a-licence
+
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
     HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"


### PR DESCRIPTION
This PR is to address an issue where the topic arn was not visible in test1 and test2, as the `serviceAccountName` for those envs is different in CP to the other API namespaces. 