### PR TITLE
CVSL-1483 change check to run all eligibility checks against a person in prison

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/CaseloadService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/CaseloadService.kt
@@ -109,7 +109,7 @@ class CaseloadService(
   private fun createRecord(deliusOffender: CaseloadResult, licence: Licence, prisonOffender: PrisonerSearchPrisoner?): FoundProbationRecord? =
     when {
       licence.statusCode.isOnProbation() -> deliusOffender.transformToModelFoundProbationRecord(licence)
-      prisonOffender != null && eligibilityService.isExistingLicenceEligible(prisonOffender) -> deliusOffender.transformToModelFoundProbationRecord(licence)
+      prisonOffender != null && eligibilityService.isEligibleForCvl(prisonOffender) -> deliusOffender.transformToModelFoundProbationRecord(licence)
 
       else -> null
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/EligibilityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/EligibilityService.kt
@@ -25,25 +25,11 @@ class EligibilityService(
     !isRecallCase() describedAs "is a recall case",
   )
 
-  val existingLicenceChecks = listOf(
-    hasReleaseDateInTheFuture() describedAs "release date in past",
-    hasActivePrisonStatus() describedAs "is not active in prison",
-  )
-
   fun isEligibleForCvl(prisoner: PrisonerSearchPrisoner): Boolean {
     return getIneligibilityReasons(prisoner).isEmpty()
   }
-
-  fun isExistingLicenceEligible(prisoner: PrisonerSearchPrisoner): Boolean {
-    return getIneligibilityReasonsForExistingLicence(prisoner).isEmpty()
-  }
-
   fun getIneligibilityReasons(prisoner: PrisonerSearchPrisoner): List<String> {
     return checks.mapNotNull { (test, message) -> if (!test(prisoner)) message else null }
-  }
-
-  fun getIneligibilityReasonsForExistingLicence(prisoner: PrisonerSearchPrisoner): List<String> {
-    return existingLicenceChecks.mapNotNull { (test, message) -> if (!test(prisoner)) message else null }
   }
 
   private fun isPersonParoleEligible(): EligibilityCheck = early@{

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/CaseloadServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/CaseloadServiceTest.kt
@@ -92,7 +92,7 @@ class CaseloadServiceTest {
       ),
     )
 
-    whenever(eligibilityService.isExistingLicenceEligible(aPrisonerSearchResult)).thenReturn(
+    whenever(eligibilityService.isEligibleForCvl(aPrisonerSearchResult)).thenReturn(
       true,
     )
 
@@ -108,7 +108,7 @@ class CaseloadServiceTest {
       communityApiClient.getTeamsCodesForUser(request.staffIdentifier),
     )
 
-    verify(eligibilityService).isExistingLicenceEligible(
+    verify(eligibilityService).isEligibleForCvl(
       aPrisonerSearchResult,
     )
 
@@ -190,7 +190,7 @@ class CaseloadServiceTest {
       ),
     )
 
-    whenever(eligibilityService.isExistingLicenceEligible(aPrisonerSearchResult)).thenReturn(
+    whenever(eligibilityService.isEligibleForCvl(aPrisonerSearchResult)).thenReturn(
       true,
     )
 
@@ -214,7 +214,7 @@ class CaseloadServiceTest {
       ),
     )
 
-    verify(eligibilityService).isExistingLicenceEligible(
+    verify(eligibilityService).isEligibleForCvl(
       aPrisonerSearchResult,
     )
 
@@ -273,7 +273,7 @@ class CaseloadServiceTest {
         aPrisonerSearchResult,
       ),
     )
-    whenever(eligibilityService.isExistingLicenceEligible(any())).thenReturn(
+    whenever(eligibilityService.isEligibleForCvl(any())).thenReturn(
       true,
     )
 
@@ -359,7 +359,7 @@ class CaseloadServiceTest {
           ),
       )
 
-    whenever(eligibilityService.isExistingLicenceEligible(aPrisonerSearchResult)).thenReturn(
+    whenever(eligibilityService.isEligibleForCvl(aPrisonerSearchResult)).thenReturn(
       true,
     )
 


### PR DESCRIPTION
This PR follows testing of CVSL-1483 where we have found that just having two existing licence checks for an ARD/CRD in the future and an active prison status is problematic, when checking existing licences. Instead, for any person in prison with a non probation licence status :

- `IN_PROGRESS`
- `SUBMITTED`
- `APPROVED`

we will carry out a full eligibility check and will continue to do so while their licence is in any of the statuses above. If the person has a licence in the status above and fails eligibility, they will not be returned in the results as they are now ineligible to use CVL. We would only stop checking eligibility when their licence becomes `ACTIVE` or another probation licence status (`VARIATION_*`)