### PR TITLE
CVSL-1517 amend detail url

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -20,6 +20,7 @@ generic-service:
     HMPPS_PRISONERSEARCH_API_URL: "https://prisoner-search-dev.prison.service.justice.gov.uk"
     HMPPS_PROBATIONSEARCH_API_URL: "https://cvl-probation-mock.hmpps.service.justice.gov.uk"
     SELF_LINK: "https://create-and-vary-a-licence-dev.hmpps.service.justice.gov.uk"
+    SELF_API_LINK: "https://create-and-vary-a-licence-api-dev.hmpps.service.justice.gov.uk"
 
 # CloudPlatform AlertManager receiver to route promethues alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -20,6 +20,7 @@ generic-service:
     HMPPS_PRISONERSEARCH_API_URL: "https://prisoner-search-preprod.prison.service.justice.gov.uk"
     HMPPS_PROBATIONSEARCH_API_URL: "https://probation-offender-search-preprod.hmpps.service.justice.gov.uk"
     SELF_LINK: "https://create-and-vary-a-licence-preprod.hmpps.service.justice.gov.uk"
+    SELF_API_LINK: "https://create-and-vary-a-licence-api-preprod.hmpps.service.justice.gov.uk"
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -20,6 +20,7 @@ generic-service:
     HMPPS_PRISONERSEARCH_API_URL: "https://prisoner-search.prison.service.justice.gov.uk"
     HMPPS_PROBATIONSEARCH_API_URL: "https://probation-offender-search.hmpps.service.justice.gov.uk"
     SELF_LINK: "https://create-and-vary-a-licence.hmpps.service.justice.gov.uk"
+    SELF_API_LINK: "https://create-and-vary-a-licence-api.hmpps.service.justice.gov.uk"
 
   postgresDatabaseRestore:
     enabled: true

--- a/helm_deploy/values-test1.yaml
+++ b/helm_deploy/values-test1.yaml
@@ -22,6 +22,7 @@ generic-service:
     HMPPS_PRISONERSEARCH_API_URL: "https://prisoner-search-dev.prison.service.justice.gov.uk"
     HMPPS_PROBATIONSEARCH_API_URL: "https://cvl-probation-mock.hmpps.service.justice.gov.uk"
     SELF_LINK: "https://create-and-vary-a-licence-test1.hmpps.service.justice.gov.uk"
+    SELF_API_LINK: "https://create-and-vary-a-licence-api-test1.hmpps.service.justice.gov.uk"
 
 # CloudPlatform AlertManager receiver to route promethues alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-test2.yaml
+++ b/helm_deploy/values-test2.yaml
@@ -22,6 +22,7 @@ generic-service:
     HMPPS_PRISONERSEARCH_API_URL: "https://prisoner-search-dev.prison.service.justice.gov.uk"
     HMPPS_PROBATIONSEARCH_API_URL: "https://probation-offender-search-dev.hmpps.service.justice.gov.uk"
     SELF_LINK: "https://create-and-vary-a-licence-test2.hmpps.service.justice.gov.uk"
+    SELF_API_LINK: "https://create-and-vary-a-licence-api-test2.hmpps.service.justice.gov.uk"
 
 # CloudPlatform AlertManager receiver to route promethues alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/domainEvents/DomainEventsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/domainEvents/DomainEventsService.kt
@@ -11,7 +11,7 @@ import java.time.format.DateTimeFormatter
 
 @Service
 class DomainEventsService(
-  @Value("\${self.link}") private val baseUrl: String,
+  @Value("\${self.api.link}") private val baseUrl: String,
   private val outboundEventsPublisher: OutboundEventsPublisher,
   private val clock: Clock,
 ) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -125,6 +125,8 @@ internalEmailAddress: 'testemail@probation.gov.uk'
 # Overridden in real environments
 self:
   link: "http://localhost:3000"
+  api:
+    link: "http://localhost:8089"
 
 springdoc:
   api-docs:


### PR DESCRIPTION
 This PR is following feedback from the Delius integration team that the `detailUrl` is pointing to the frontend and not the API so this means the link is obsolete. Changed the link to ensure the public API licence URL points to the API and not the frontend.