### PR TITLE
CVSL-1677 add application event publisher

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/domainEvents/DomainEventsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/domainEvents/DomainEventsService.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.domainEvents
 
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.Licence
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus
@@ -12,8 +13,8 @@ import java.time.format.DateTimeFormatter
 @Service
 class DomainEventsService(
   @Value("\${self.api.link}") private val baseUrl: String,
-  private val outboundEventsPublisher: OutboundEventsPublisher,
   private val clock: Clock,
+  private val applicationEventPublisher: ApplicationEventPublisher,
 ) {
   fun recordDomainEvent(licence: Licence, licenceStatus: LicenceStatus) {
     when (licenceStatus) {
@@ -25,11 +26,7 @@ class DomainEventsService(
           licence.nomsId,
           "Licence activated for Licence ID ${licence.id}",
         )
-        outboundEventsPublisher
-          .publishDomainEvent(
-            domainEvent,
-            licence.id.toString(),
-          )
+        applicationEventPublisher.publishEvent(domainEvent)
       }
 
       LicenceStatus.INACTIVE -> {
@@ -40,11 +37,7 @@ class DomainEventsService(
           licence.nomsId,
           "Licence inactivated for Licence ID ${licence.id}",
         )
-        outboundEventsPublisher
-          .publishDomainEvent(
-            domainEvent,
-            licence.id.toString(),
-          )
+        applicationEventPublisher.publishEvent(domainEvent)
       }
       else -> return
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/domainEvents/OutboundEventsPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/domainEvents/OutboundEventsPublisher.kt
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
 import software.amazon.awssdk.services.sns.model.MessageAttributeValue
 import software.amazon.awssdk.services.sns.model.PublishRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.domainEvents.DomainEventsService.HMPPSDomainEvent
@@ -26,9 +28,10 @@ class OutboundEventsPublisher(
   }
   private val domainEventsTopicClient by lazy { domainEventsTopic.snsClient }
 
-  fun publishDomainEvent(event: HMPPSDomainEvent, licenceId: String) {
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  fun publishDomainEvent(event: HMPPSDomainEvent) {
     val eventType = event.eventType
-    log.debug("Event {} for licence ID {}", eventType, licenceId)
+    log.debug("Event {} for licence ID {}", eventType, event.additionalInformation?.licenceId)
     domainEventsTopicClient.publish(
       PublishRequest.builder()
         .topicArn(domainEventsTopic.arn)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/DeactivateLicencesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/DeactivateLicencesTest.kt
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
@@ -74,7 +73,7 @@ class DeactivateLicencesTest : IntegrationTestBase() {
       )
 
     argumentCaptor<HMPPSDomainEvent>().apply {
-      verify(eventsPublisher, times(3)).publishDomainEvent(capture(), any())
+      verify(eventsPublisher, times(3)).publishDomainEvent(capture())
       assertThat(allValues).allMatch { it.eventType == LicenceDomainEventType.LICENCE_INACTIVATED.value }
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/LicenceActivationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/LicenceActivationIntegrationTest.kt
@@ -6,7 +6,6 @@ import org.assertj.core.groups.Tuple.tuple
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
@@ -44,7 +43,7 @@ class LicenceActivationIntegrationTest : IntegrationTestBase() {
       .expectStatus().isOk
 
     argumentCaptor<HMPPSDomainEvent>().apply {
-      verify(eventsPublisher, times(5)).publishDomainEvent(capture(), any())
+      verify(eventsPublisher, times(5)).publishDomainEvent(capture())
       val activationEvents = allValues.filter { it.eventType == LicenceDomainEventType.LICENCE_ACTIVATED.value }
       assertThat(activationEvents).hasSize(3)
       val inactivatedEvents = allValues.filter { it.eventType == LicenceDomainEventType.LICENCE_INACTIVATED.value }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/LicenceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/LicenceIntegrationTest.kt
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.verify
 import org.springframework.beans.factory.annotation.Autowired
@@ -459,7 +458,7 @@ class LicenceIntegrationTest : IntegrationTestBase() {
     assertThat(result?.statusCode).isEqualTo(aStatusToActiveUpdateRequest.status)
 
     argumentCaptor<HMPPSDomainEvent>().apply {
-      verify(eventsPublisher).publishDomainEvent(capture(), any())
+      verify(eventsPublisher).publishDomainEvent(capture())
       assertThat(firstValue.eventType).isEqualTo(LicenceDomainEventType.LICENCE_ACTIVATED.value)
     }
   }
@@ -489,7 +488,7 @@ class LicenceIntegrationTest : IntegrationTestBase() {
 
     assertThat(result?.statusCode).isEqualTo(aStatusToInactiveUpdateRequest.status)
     argumentCaptor<HMPPSDomainEvent>().apply {
-      verify(eventsPublisher).publishDomainEvent(capture(), any())
+      verify(eventsPublisher).publishDomainEvent(capture())
       assertThat(firstValue.eventType).isEqualTo(LicenceDomainEventType.LICENCE_INACTIVATED.value)
     }
   }
@@ -519,7 +518,7 @@ class LicenceIntegrationTest : IntegrationTestBase() {
 
     assertThat(result?.statusCode).isEqualTo(aStatusToActiveUpdateRequest.status)
     argumentCaptor<HMPPSDomainEvent>().apply {
-      verify(eventsPublisher).publishDomainEvent(capture(), any())
+      verify(eventsPublisher).publishDomainEvent(capture())
       assertThat(firstValue.eventType).isEqualTo(LicenceDomainEventType.LICENCE_VARIATION_ACTIVATED.value)
     }
   }
@@ -549,7 +548,7 @@ class LicenceIntegrationTest : IntegrationTestBase() {
 
     assertThat(result?.statusCode).isEqualTo(aStatusToInactiveUpdateRequest.status)
     argumentCaptor<HMPPSDomainEvent>().apply {
-      verify(eventsPublisher).publishDomainEvent(capture(), any())
+      verify(eventsPublisher).publishDomainEvent(capture())
       assertThat(firstValue.eventType).isEqualTo(LicenceDomainEventType.LICENCE_VARIATION_INACTIVATED.value)
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/LicenceOverrideIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/LicenceOverrideIntegrationTest.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.integration
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
@@ -73,7 +72,7 @@ class LicenceOverrideIntegrationTest : IntegrationTestBase() {
       .isAccepted
 
     argumentCaptor<HMPPSDomainEvent>().apply {
-      verify(eventsPublisher).publishDomainEvent(capture(), any())
+      verify(eventsPublisher).publishDomainEvent(capture())
       assertThat(firstValue.eventType).isEqualTo(LicenceDomainEventType.LICENCE_ACTIVATED.value)
     }
 
@@ -122,7 +121,7 @@ class LicenceOverrideIntegrationTest : IntegrationTestBase() {
       .isAccepted
 
     argumentCaptor<HMPPSDomainEvent>().apply {
-      verify(eventsPublisher).publishDomainEvent(capture(), any())
+      verify(eventsPublisher).publishDomainEvent(capture())
       assertThat(firstValue.eventType).isEqualTo(LicenceDomainEventType.LICENCE_INACTIVATED.value)
     }
 
@@ -156,7 +155,7 @@ class LicenceOverrideIntegrationTest : IntegrationTestBase() {
     assertThat(licenceEventRepository.count()).isEqualTo(1)
 
     argumentCaptor<HMPPSDomainEvent>().apply {
-      verify(eventsPublisher).publishDomainEvent(capture(), any())
+      verify(eventsPublisher).publishDomainEvent(capture())
       assertThat(firstValue.eventType).isEqualTo(LicenceDomainEventType.LICENCE_VARIATION_ACTIVATED.value)
     }
   }
@@ -185,7 +184,7 @@ class LicenceOverrideIntegrationTest : IntegrationTestBase() {
     assertThat(licenceEventRepository.count()).isEqualTo(1)
 
     argumentCaptor<HMPPSDomainEvent>().apply {
-      verify(eventsPublisher).publishDomainEvent(capture(), any())
+      verify(eventsPublisher).publishDomainEvent(capture())
       assertThat(firstValue.eventType).isEqualTo(LicenceDomainEventType.LICENCE_VARIATION_INACTIVATED.value)
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/domainEvents/DomainEventsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/domainEvents/DomainEventsServiceTest.kt
@@ -2,12 +2,12 @@ package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.domainEven
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
+import org.springframework.context.ApplicationEventPublisher
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.TestData
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.domainEvents.DomainEventsService.HMPPSDomainEvent
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.domainEvents.DomainEventsService.LicenceDomainEventType
@@ -17,13 +17,13 @@ import java.time.Instant
 import java.time.ZoneId
 
 class DomainEventsServiceTest {
-  private val outboundEventsPublisher = mock<OutboundEventsPublisher>()
   private val clock: Clock = Clock.fixed(Instant.parse("2023-12-05T00:00:00Z"), ZoneId.systemDefault())
+  private val applicationEventPublisher = mock<ApplicationEventPublisher>()
 
   private val domainEventsService = DomainEventsService(
     "http://test123",
-    outboundEventsPublisher,
     clock,
+    applicationEventPublisher,
   )
 
   @Test
@@ -32,7 +32,7 @@ class DomainEventsServiceTest {
 
     domainEventsService.recordDomainEvent(TestData.createCrdLicence(), LicenceStatus.ACTIVE)
 
-    verify(outboundEventsPublisher, times(1)).publishDomainEvent(eventCaptor.capture(), any())
+    verify(applicationEventPublisher, times(1)).publishEvent(eventCaptor.capture())
 
     assertThat(eventCaptor.firstValue.eventType).isEqualTo(LicenceDomainEventType.LICENCE_ACTIVATED.value)
 
@@ -45,7 +45,7 @@ class DomainEventsServiceTest {
 
     domainEventsService.recordDomainEvent(TestData.createCrdLicence(), LicenceStatus.INACTIVE)
 
-    verify(outboundEventsPublisher, times(1)).publishDomainEvent(eventCaptor.capture(), any())
+    verify(applicationEventPublisher, times(1)).publishEvent(eventCaptor.capture())
 
     assertThat(eventCaptor.firstValue.eventType).isEqualTo(LicenceDomainEventType.LICENCE_INACTIVATED.value)
 
@@ -58,7 +58,7 @@ class DomainEventsServiceTest {
 
     domainEventsService.recordDomainEvent(TestData.createVariationLicence(), LicenceStatus.ACTIVE)
 
-    verify(outboundEventsPublisher, times(1)).publishDomainEvent(eventCaptor.capture(), any())
+    verify(applicationEventPublisher, times(1)).publishEvent(eventCaptor.capture())
 
     assertThat(eventCaptor.firstValue.eventType).isEqualTo(LicenceDomainEventType.LICENCE_VARIATION_ACTIVATED.value)
 
@@ -71,7 +71,7 @@ class DomainEventsServiceTest {
 
     domainEventsService.recordDomainEvent(TestData.createVariationLicence(), LicenceStatus.INACTIVE)
 
-    verify(outboundEventsPublisher, times(1)).publishDomainEvent(eventCaptor.capture(), any())
+    verify(applicationEventPublisher, times(1)).publishEvent(eventCaptor.capture())
 
     assertThat(eventCaptor.firstValue.eventType).isEqualTo(LicenceDomainEventType.LICENCE_VARIATION_INACTIVATED.value)
 
@@ -84,7 +84,7 @@ class DomainEventsServiceTest {
 
     domainEventsService.recordDomainEvent(TestData.createHardStopLicence(), LicenceStatus.ACTIVE)
 
-    verify(outboundEventsPublisher, times(1)).publishDomainEvent(eventCaptor.capture(), any())
+    verify(applicationEventPublisher, times(1)).publishEvent(eventCaptor.capture())
 
     assertThat(eventCaptor.firstValue.eventType).isEqualTo(LicenceDomainEventType.LICENCE_ACTIVATED.value)
 
@@ -97,7 +97,7 @@ class DomainEventsServiceTest {
 
     domainEventsService.recordDomainEvent(TestData.createHardStopLicence(), LicenceStatus.INACTIVE)
 
-    verify(outboundEventsPublisher, times(1)).publishDomainEvent(eventCaptor.capture(), any())
+    verify(applicationEventPublisher, times(1)).publishEvent(eventCaptor.capture())
 
     assertThat(eventCaptor.firstValue.eventType).isEqualTo(LicenceDomainEventType.LICENCE_INACTIVATED.value)
 
@@ -108,6 +108,6 @@ class DomainEventsServiceTest {
   fun `does not create and publishes a domain event when status is not ACTIVE or INACTIVE`() {
     domainEventsService.recordDomainEvent(TestData.createCrdLicence(), LicenceStatus.SUBMITTED)
 
-    verifyNoInteractions(outboundEventsPublisher)
+    verifyNoInteractions(applicationEventPublisher)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/domainEvents/OutboundEventsPublisherTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/domainEvents/OutboundEventsPublisherTest.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import net.javacrumbs.jsonunit.assertj.assertThatJson
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentCaptor
@@ -13,7 +14,9 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import software.amazon.awssdk.services.sns.SnsAsyncClient
+import software.amazon.awssdk.services.sns.model.MessageAttributeValue
 import software.amazon.awssdk.services.sns.model.PublishRequest
+import software.amazon.awssdk.services.sns.model.PublishResponse
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.domainEvents.DomainEventsService.AdditionalInformation
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.domainEvents.DomainEventsService.HMPPSDomainEvent
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.domainEvents.DomainEventsService.Identifiers
@@ -21,6 +24,7 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.domainEvent
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.domainEvents.DomainEventsService.PersonReference
 import uk.gov.justice.hmpps.sqs.HmppsQueueService
 import uk.gov.justice.hmpps.sqs.HmppsTopic
+import java.util.concurrent.CompletableFuture
 
 class OutboundEventsPublisherTest {
   private val hmppsQueueServiceMock = mock<HmppsQueueService>()
@@ -42,32 +46,25 @@ class OutboundEventsPublisherTest {
   inner class LicenceActivatedDomainEvent {
     @Test
     fun `publishes licence activated event to SNS`() {
-      val licenceId = "1"
-      val crn = "crn"
-      val nomsNumber = "nomsNumber"
+      whenever(hmppsQueueServiceMock.findByTopicId("domainevents")).thenReturn(mockHmppsTopic)
+      whenever(mockHmppsTopic.arn).thenReturn(anArn)
+      whenever(mockHmppsTopic.snsClient).thenReturn(snsClient)
 
       val requestCaptor = ArgumentCaptor.forClass(PublishRequest::class.java)
 
-      whenever(hmppsQueueServiceMock.findByTopicId("domainevents")).thenReturn(mockHmppsTopic)
-      whenever(mockHmppsTopic.arn).thenReturn("arn:aws:sns:eu-west-2:000000000000:domainevents-topic")
-      whenever(mockHmppsTopic.snsClient).thenReturn(snsClient)
-
-      val domainEvent = HMPPSDomainEvent(
-        LicenceDomainEventType.LICENCE_ACTIVATED.value,
-        AdditionalInformation(licenceId),
-        "https://create-and-vary-a-licence-api.hmpps.service.justice.gov.uk/public/licences/id/1",
-        1,
-        "2023-12-05T00:00:00Z",
-        "Licence activated for 1",
-        PersonReference(
-          listOf(
-            Identifiers("CRN", crn),
-            Identifiers("NOMS", nomsNumber),
+      val publishRequest = PublishRequest.builder()
+        .topicArn(anArn)
+        .message(objectMapper.writeValueAsString(aHMPPSDomainEvent))
+        .messageAttributes(
+          mapOf(
+            "eventType" to MessageAttributeValue.builder().dataType("String").stringValue(aHMPPSDomainEvent.eventType).build(),
           ),
-        ),
-      )
+        )
+        .build()
 
-      outboundEventsPublisher.publishDomainEvent(domainEvent)
+      whenever(snsClient.publish(publishRequest)).thenReturn(CompletableFuture.completedFuture(aPublishResponse))
+
+      outboundEventsPublisher.publishDomainEvent(aHMPPSDomainEvent)
 
       verify(snsClient, times(1)).publish(requestCaptor.capture())
 
@@ -86,11 +83,11 @@ class OutboundEventsPublisherTest {
                 "identifiers": [
                   {
                     "type": "CRN",
-                    "value": "crn"
+                    "value": "A123456"
                   },
                   {
                     "type": "NOMS",
-                    "value": "nomsNumber"
+                    "value": "A1234BC"
                   }
                 ]
               }
@@ -101,30 +98,27 @@ class OutboundEventsPublisherTest {
 
     @Test
     fun `publishes licence variation activated event to SNS`() {
-      val licenceId = "1"
-      val crn = "crn"
-      val nomsNumber = "nomsNumber"
+      whenever(hmppsQueueServiceMock.findByTopicId("domainevents")).thenReturn(mockHmppsTopic)
+      whenever(mockHmppsTopic.arn).thenReturn(anArn)
+      whenever(mockHmppsTopic.snsClient).thenReturn(snsClient)
 
       val requestCaptor = ArgumentCaptor.forClass(PublishRequest::class.java)
 
-      whenever(hmppsQueueServiceMock.findByTopicId("domainevents")).thenReturn(mockHmppsTopic)
-      whenever(mockHmppsTopic.arn).thenReturn("arn:aws:sns:eu-west-2:000000000000:domainevents-topic")
-      whenever(mockHmppsTopic.snsClient).thenReturn(snsClient)
-
-      val payload = HMPPSDomainEvent(
-        LicenceDomainEventType.LICENCE_VARIATION_ACTIVATED.value,
-        AdditionalInformation(licenceId),
-        "https://create-and-vary-a-licence-api.hmpps.service.justice.gov.uk/public/licences/id/1",
-        1,
-        "2023-12-05T00:00:00Z",
-        "Licence activated for 1",
-        PersonReference(
-          listOf(
-            Identifiers("CRN", crn),
-            Identifiers("NOMS", nomsNumber),
-          ),
-        ),
+      val payload = aHMPPSDomainEvent.copy(
+        eventType = LicenceDomainEventType.LICENCE_VARIATION_ACTIVATED.value,
       )
+
+      val publishRequest = PublishRequest.builder()
+        .topicArn(anArn)
+        .message(objectMapper.writeValueAsString(payload))
+        .messageAttributes(
+          mapOf(
+            "eventType" to MessageAttributeValue.builder().dataType("String").stringValue(payload.eventType).build(),
+          ),
+        )
+        .build()
+
+      whenever(snsClient.publish(publishRequest)).thenReturn(CompletableFuture.completedFuture(aPublishResponse))
 
       outboundEventsPublisher.publishDomainEvent(payload)
 
@@ -145,11 +139,11 @@ class OutboundEventsPublisherTest {
                 "identifiers": [
                   {
                     "type": "CRN",
-                    "value": "crn"
+                    "value": "A123456"
                   },
                   {
                     "type": "NOMS",
-                    "value": "nomsNumber"
+                    "value": "A1234BC"
                   }
                 ]
               }
@@ -163,30 +157,28 @@ class OutboundEventsPublisherTest {
   inner class LicenceInactivatedDomainEvent {
     @Test
     fun `publishes licence inactivated event to SNS`() {
-      val licenceId = "1"
-      val crn = "crn"
-      val nomsNumber = "nomsNumber"
+      whenever(hmppsQueueServiceMock.findByTopicId("domainevents")).thenReturn(mockHmppsTopic)
+      whenever(mockHmppsTopic.arn).thenReturn(anArn)
+      whenever(mockHmppsTopic.snsClient).thenReturn(snsClient)
 
       val requestCaptor = ArgumentCaptor.forClass(PublishRequest::class.java)
 
-      whenever(hmppsQueueServiceMock.findByTopicId("domainevents")).thenReturn(mockHmppsTopic)
-      whenever(mockHmppsTopic.arn).thenReturn("arn:aws:sns:eu-west-2:000000000000:domainevents-topic")
-      whenever(mockHmppsTopic.snsClient).thenReturn(snsClient)
-
-      val payload = HMPPSDomainEvent(
-        LicenceDomainEventType.LICENCE_INACTIVATED.value,
-        AdditionalInformation(licenceId),
-        "https://create-and-vary-a-licence-api.hmpps.service.justice.gov.uk/public/licences/id/1",
-        1,
-        "2023-12-05T00:00:00Z",
-        "Licence activated for 1",
-        PersonReference(
-          listOf(
-            Identifiers("CRN", crn),
-            Identifiers("NOMS", nomsNumber),
-          ),
-        ),
+      val payload = aHMPPSDomainEvent.copy(
+        eventType = LicenceDomainEventType.LICENCE_INACTIVATED.value,
+        description = "Licence inactivated for 1",
       )
+
+      val publishRequest = PublishRequest.builder()
+        .topicArn(anArn)
+        .message(objectMapper.writeValueAsString(payload))
+        .messageAttributes(
+          mapOf(
+            "eventType" to MessageAttributeValue.builder().dataType("String").stringValue(payload.eventType).build(),
+          ),
+        )
+        .build()
+
+      whenever(snsClient.publish(publishRequest)).thenReturn(CompletableFuture.completedFuture(aPublishResponse))
 
       outboundEventsPublisher.publishDomainEvent(payload)
 
@@ -202,16 +194,16 @@ class OutboundEventsPublisherTest {
               "detailUrl": "https://create-and-vary-a-licence-api.hmpps.service.justice.gov.uk/public/licences/id/1",
               "version": 1,
               "occurredAt": "2023-12-05T00:00:00Z",
-              "description": "Licence activated for 1",
+              "description": "Licence inactivated for 1",
               "personReference": {
                 "identifiers": [
                   {
                     "type": "CRN",
-                    "value": "crn"
+                    "value": "A123456"
                   },
                   {
                     "type": "NOMS",
-                    "value": "nomsNumber"
+                    "value": "A1234BC"
                   }
                 ]
               }
@@ -222,30 +214,28 @@ class OutboundEventsPublisherTest {
 
     @Test
     fun `publishes licence variation inactivated event to SNS`() {
-      val licenceId = "1"
-      val crn = "crn"
-      val nomsNumber = "nomsNumber"
+      whenever(hmppsQueueServiceMock.findByTopicId("domainevents")).thenReturn(mockHmppsTopic)
+      whenever(mockHmppsTopic.arn).thenReturn(anArn)
+      whenever(mockHmppsTopic.snsClient).thenReturn(snsClient)
 
       val requestCaptor = ArgumentCaptor.forClass(PublishRequest::class.java)
 
-      whenever(hmppsQueueServiceMock.findByTopicId("domainevents")).thenReturn(mockHmppsTopic)
-      whenever(mockHmppsTopic.arn).thenReturn("arn:aws:sns:eu-west-2:000000000000:domainevents-topic")
-      whenever(mockHmppsTopic.snsClient).thenReturn(snsClient)
-
-      val payload = HMPPSDomainEvent(
-        LicenceDomainEventType.LICENCE_VARIATION_INACTIVATED.value,
-        AdditionalInformation(licenceId),
-        "https://create-and-vary-a-licence-api.hmpps.service.justice.gov.uk/public/licences/id/1",
-        1,
-        "2023-12-05T00:00:00Z",
-        "Licence activated for 1",
-        PersonReference(
-          listOf(
-            Identifiers("CRN", crn),
-            Identifiers("NOMS", nomsNumber),
-          ),
-        ),
+      val payload = aHMPPSDomainEvent.copy(
+        eventType = LicenceDomainEventType.LICENCE_VARIATION_INACTIVATED.value,
+        description = "Licence inactivated for 1",
       )
+
+      val publishRequest = PublishRequest.builder()
+        .topicArn(anArn)
+        .message(objectMapper.writeValueAsString(payload))
+        .messageAttributes(
+          mapOf(
+            "eventType" to MessageAttributeValue.builder().dataType("String").stringValue(payload.eventType).build(),
+          ),
+        )
+        .build()
+
+      whenever(snsClient.publish(publishRequest)).thenReturn(CompletableFuture.completedFuture(aPublishResponse))
 
       outboundEventsPublisher.publishDomainEvent(payload)
 
@@ -261,16 +251,16 @@ class OutboundEventsPublisherTest {
               "detailUrl": "https://create-and-vary-a-licence-api.hmpps.service.justice.gov.uk/public/licences/id/1",
               "version": 1,
               "occurredAt": "2023-12-05T00:00:00Z",
-              "description": "Licence activated for 1",
+              "description": "Licence inactivated for 1",
               "personReference": {
                 "identifiers": [
                   {
                     "type": "CRN",
-                    "value": "crn"
+                    "value": "A123456"
                   },
                   {
                     "type": "NOMS",
-                    "value": "nomsNumber"
+                    "value": "A1234BC"
                   }
                 ]
               }
@@ -284,30 +274,32 @@ class OutboundEventsPublisherTest {
   inner class LicenceDomainEventWithoutIdentifiers {
     @Test
     fun `licence activated event publishes to SNS without CRN`() {
-      val licenceId = "1"
-      val crn = null
-      val nomsNumber = "nomsNumber"
+      whenever(hmppsQueueServiceMock.findByTopicId("domainevents")).thenReturn(mockHmppsTopic)
+      whenever(mockHmppsTopic.arn).thenReturn(anArn)
+      whenever(mockHmppsTopic.snsClient).thenReturn(snsClient)
 
       val requestCaptor = ArgumentCaptor.forClass(PublishRequest::class.java)
 
-      whenever(hmppsQueueServiceMock.findByTopicId("domainevents")).thenReturn(mockHmppsTopic)
-      whenever(mockHmppsTopic.arn).thenReturn("arn:aws:sns:eu-west-2:000000000000:domainevents-topic")
-      whenever(mockHmppsTopic.snsClient).thenReturn(snsClient)
-
-      val payload = HMPPSDomainEvent(
-        LicenceDomainEventType.LICENCE_ACTIVATED.value,
-        AdditionalInformation(licenceId),
-        "https://create-and-vary-a-licence-api.hmpps.service.justice.gov.uk/public/licences/id/1",
-        1,
-        "2023-12-05T00:00:00Z",
-        "Licence activated for 1",
-        PersonReference(
+      val payload = aHMPPSDomainEvent.copy(
+        personReference = PersonReference(
           listOf(
-            Identifiers("CRN", crn),
-            Identifiers("NOMS", nomsNumber),
+            Identifiers("CRN", null),
+            Identifiers("NOMS", "A1234BC"),
           ),
         ),
       )
+
+      val publishRequest = PublishRequest.builder()
+        .topicArn(anArn)
+        .message(objectMapper.writeValueAsString(payload))
+        .messageAttributes(
+          mapOf(
+            "eventType" to MessageAttributeValue.builder().dataType("String").stringValue(payload.eventType).build(),
+          ),
+        )
+        .build()
+
+      whenever(snsClient.publish(publishRequest)).thenReturn(CompletableFuture.completedFuture(aPublishResponse))
 
       outboundEventsPublisher.publishDomainEvent(payload)
 
@@ -332,7 +324,7 @@ class OutboundEventsPublisherTest {
                   },
                   {
                     "type": "NOMS",
-                    "value": "nomsNumber"
+                    "value": "A1234BC"
                   }
                 ]
               }
@@ -343,30 +335,31 @@ class OutboundEventsPublisherTest {
 
     @Test
     fun `licence variation activated event publishes to SNS without NOMIS number`() {
-      val licenceId = "1"
-      val crn = "crn"
-      val nomsNumber = null
-
-      val requestCaptor = ArgumentCaptor.forClass(PublishRequest::class.java)
-
       whenever(hmppsQueueServiceMock.findByTopicId("domainevents")).thenReturn(mockHmppsTopic)
-      whenever(mockHmppsTopic.arn).thenReturn("arn:aws:sns:eu-west-2:000000000000:domainevents-topic")
+      whenever(mockHmppsTopic.arn).thenReturn(anArn)
       whenever(mockHmppsTopic.snsClient).thenReturn(snsClient)
 
-      val payload = HMPPSDomainEvent(
-        LicenceDomainEventType.LICENCE_VARIATION_ACTIVATED.value,
-        AdditionalInformation(licenceId),
-        "https://create-and-vary-a-licence-api.hmpps.service.justice.gov.uk/public/licences/id/1",
-        1,
-        "2023-12-05T00:00:00Z",
-        "Licence activated for 1",
-        PersonReference(
+      val requestCaptor = ArgumentCaptor.forClass(PublishRequest::class.java)
+      val payload = aHMPPSDomainEvent.copy(
+        eventType = LicenceDomainEventType.LICENCE_VARIATION_ACTIVATED.value,
+        personReference = PersonReference(
           listOf(
-            Identifiers("CRN", crn),
-            Identifiers("NOMS", nomsNumber),
+            Identifiers("CRN", "A123456"),
+            Identifiers("NOMS", null),
           ),
         ),
       )
+      val publishRequest = PublishRequest.builder()
+        .topicArn(anArn)
+        .message(objectMapper.writeValueAsString(payload))
+        .messageAttributes(
+          mapOf(
+            "eventType" to MessageAttributeValue.builder().dataType("String").stringValue(payload.eventType).build(),
+          ),
+        )
+        .build()
+
+      whenever(snsClient.publish(publishRequest)).thenReturn(CompletableFuture.completedFuture(aPublishResponse))
 
       outboundEventsPublisher.publishDomainEvent(payload)
 
@@ -387,7 +380,7 @@ class OutboundEventsPublisherTest {
                 "identifiers": [
                   {
                     "type": "CRN",
-                    "value": "crn"
+                    "value": "A123456"
                   },
                   {
                     "type": "NOMS",
@@ -399,5 +392,79 @@ class OutboundEventsPublisherTest {
         """.trimIndent(),
       )
     }
+  }
+
+  @Nested
+  inner class BuildEvent {
+
+    @Test
+    fun `build event completes successfully`() {
+      whenever(hmppsQueueServiceMock.findByTopicId("domainevents")).thenReturn(mockHmppsTopic)
+      whenever(mockHmppsTopic.arn).thenReturn(anArn)
+      whenever(mockHmppsTopic.snsClient).thenReturn(snsClient)
+
+      val publishRequest = PublishRequest.builder()
+        .topicArn(anArn)
+        .message(objectMapper.writeValueAsString(aHMPPSDomainEvent))
+        .messageAttributes(
+          mapOf(
+            "eventType" to MessageAttributeValue.builder().dataType("String").stringValue(aHMPPSDomainEvent.eventType)
+              .build(),
+          ),
+        )
+        .build()
+
+      whenever(snsClient.publish(publishRequest)).thenReturn(CompletableFuture.completedFuture(aPublishResponse))
+
+      val publishedEvent = outboundEventsPublisher.buildDomainEvent(aHMPPSDomainEvent)
+
+      assertThat(publishedEvent.isDone).isTrue()
+    }
+
+    @Test
+    fun `failed future completes exceptionally when building an event`() {
+      whenever(hmppsQueueServiceMock.findByTopicId("domainevents")).thenReturn(mockHmppsTopic)
+      whenever(mockHmppsTopic.arn).thenReturn(anArn)
+      whenever(mockHmppsTopic.snsClient).thenReturn(snsClient)
+
+      val publishRequest = PublishRequest.builder()
+        .topicArn(anArn)
+        .message(objectMapper.writeValueAsString(aHMPPSDomainEvent))
+        .messageAttributes(
+          mapOf(
+            "eventType" to MessageAttributeValue.builder().dataType("String").stringValue(aHMPPSDomainEvent.eventType).build(),
+          ),
+        )
+        .build()
+
+      whenever(snsClient.publish(publishRequest)).thenReturn(CompletableFuture.failedFuture(Exception("Exception")))
+
+      val publishedEvent = outboundEventsPublisher.buildDomainEvent(aHMPPSDomainEvent)
+
+      assertThat(publishedEvent.isCompletedExceptionally).isTrue()
+    }
+  }
+
+  private companion object {
+    val anArn = "arn:aws:sns:eu-west-2:000000000000:domainevents-topic"
+
+    val aHMPPSDomainEvent = HMPPSDomainEvent(
+      LicenceDomainEventType.LICENCE_ACTIVATED.value,
+      AdditionalInformation("1"),
+      "https://create-and-vary-a-licence-api.hmpps.service.justice.gov.uk/public/licences/id/1",
+      1,
+      "2023-12-05T00:00:00Z",
+      "Licence activated for 1",
+      PersonReference(
+        listOf(
+          Identifiers("CRN", "A123456"),
+          Identifiers("NOMS", "A1234BC"),
+        ),
+      ),
+    )
+
+    val aPublishResponse = PublishResponse.builder()
+      .messageId("a1bc-d2efg-hi3j-4567-k89l")
+      .build()
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/domainEvents/OutboundEventsPublisherTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/domainEvents/OutboundEventsPublisherTest.kt
@@ -67,7 +67,7 @@ class OutboundEventsPublisherTest {
         ),
       )
 
-      outboundEventsPublisher.publishDomainEvent(domainEvent, licenceId)
+      outboundEventsPublisher.publishDomainEvent(domainEvent)
 
       verify(snsClient, times(1)).publish(requestCaptor.capture())
 
@@ -126,7 +126,7 @@ class OutboundEventsPublisherTest {
         ),
       )
 
-      outboundEventsPublisher.publishDomainEvent(payload, licenceId)
+      outboundEventsPublisher.publishDomainEvent(payload)
 
       verify(snsClient, times(1)).publish(requestCaptor.capture())
 
@@ -188,7 +188,7 @@ class OutboundEventsPublisherTest {
         ),
       )
 
-      outboundEventsPublisher.publishDomainEvent(payload, licenceId)
+      outboundEventsPublisher.publishDomainEvent(payload)
 
       verify(snsClient, times(1)).publish(requestCaptor.capture())
 
@@ -247,7 +247,7 @@ class OutboundEventsPublisherTest {
         ),
       )
 
-      outboundEventsPublisher.publishDomainEvent(payload, licenceId)
+      outboundEventsPublisher.publishDomainEvent(payload)
 
       verify(snsClient, times(1)).publish(requestCaptor.capture())
 
@@ -309,7 +309,7 @@ class OutboundEventsPublisherTest {
         ),
       )
 
-      outboundEventsPublisher.publishDomainEvent(payload, licenceId)
+      outboundEventsPublisher.publishDomainEvent(payload)
 
       verify(snsClient, times(1)).publish(requestCaptor.capture())
 
@@ -368,7 +368,7 @@ class OutboundEventsPublisherTest {
         ),
       )
 
-      outboundEventsPublisher.publishDomainEvent(payload, licenceId)
+      outboundEventsPublisher.publishDomainEvent(payload)
 
       verify(snsClient, times(1)).publish(requestCaptor.capture())
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/jobs/DeactivateLicencesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/jobs/DeactivateLicencesServiceTest.kt
@@ -25,9 +25,6 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.jobs.Deacti
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.AuditEventType
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceEventType
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus
-import java.time.Clock
-import java.time.Instant
-import java.time.ZoneId
 
 class DeactivateLicencesServiceTest {
   private val licenceRepository = mock<LicenceRepository>()
@@ -122,7 +119,6 @@ class DeactivateLicencesServiceTest {
   }
 
   private companion object {
-    val clock: Clock = Clock.fixed(Instant.parse("2023-12-05T00:00:00Z"), ZoneId.systemDefault())
     val aLicenceEntity = TestData.createCrdLicence().copy()
   }
 }


### PR DESCRIPTION
This PR is in response to the Delius integrations team's question around ensuring that we raise events once the transaction for activation and inactivations are committed to the DB. It replaces the `outboundEventsPublisher` calls to publish with its own call to `publishEvent` which then searches for the relevant process to action based on the `@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)` annotation. 