### PR TITLE
CVSL-1680 add endpoint to show review counts for PP

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/ComReviewCount.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/ComReviewCount.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model
+
+import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.TeamCountsDto
+
+@Schema(description = "Describes the counts of cases needed for review by a Probation Practitioner")
+data class ComReviewCount(
+
+  @Schema(description = "A count of cases that the probation practitioner needs to review", example = "42")
+  val myCount: Long,
+
+  @Schema(description = "A list of teams, the probation practitioner is attached and the count of cases that need review")
+  val teams: List<TeamCountsDto>,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/privateApi/StaffController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/privateApi/StaffController.kt
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.config.ErrorResponse
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.ComReviewCount
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.ProbationSearchResult
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.UpdateComRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.UpdatePrisonCaseAdminRequest

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/privateApi/StaffController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/privateApi/StaffController.kt
@@ -177,7 +177,7 @@ class StaffController(private val caseloadService: CaseloadService, private val 
         content = [
           Content(
             mediaType = "application/json",
-            schema = Schema(implementation = ProbationSearchResult::class),
+            schema = Schema(implementation = ComReviewCount::class),
           ),
         ],
       ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/privateApi/StaffController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/privateApi/StaffController.kt
@@ -10,6 +10,8 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -119,7 +121,7 @@ class StaffController(private val caseloadService: CaseloadService, private val 
   @PreAuthorize("hasAnyRole('SYSTEM_USER', 'CVL_ADMIN')")
   @Operation(
     summary = "Search for offenders on a given staff member's caseload.",
-    description = "Search for offenders on a given staff member's caseload.. Requires ROLE_SYSTEM_USER or ROLE_CVL_ADMIN.",
+    description = "Search for offenders on a given staff member's caseload. Requires ROLE_SYSTEM_USER or ROLE_CVL_ADMIN.",
     security = [SecurityRequirement(name = "ROLE_SYSTEM_USER"), SecurityRequirement(name = "ROLE_CVL_ADMIN")],
   )
   @ApiResponses(
@@ -155,4 +157,48 @@ class StaffController(private val caseloadService: CaseloadService, private val 
     @Valid @RequestBody
     body: ProbationUserSearchRequest,
   ) = caseloadService.searchForOffenderOnStaffCaseload(body)
+
+  @Tag(name = Tags.COM)
+  @GetMapping(
+    value = ["/com/{staffIdentifier}/review-counts"],
+    produces = [MediaType.APPLICATION_JSON_VALUE],
+  )
+  @PreAuthorize("hasAnyRole('SYSTEM_USER', 'CVL_ADMIN')")
+  @Operation(
+    summary = "Retrieve the individual and team count of cases that the probation practitioner needs to review",
+    description = "Retrieve the individual and team count of cases that the probation practitioner needs to review. Requires ROLE_SYSTEM_USER or ROLE_CVL_ADMIN.",
+    security = [SecurityRequirement(name = "ROLE_SYSTEM_USER"), SecurityRequirement(name = "ROLE_CVL_ADMIN")],
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "The review counts were retrieved successfully",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ProbationSearchResult::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Bad request, request body must be valid",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorised, requires a valid Oauth2 token",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires an appropriate role",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  fun retrieveReviewCounts(
+    @PathVariable("staffIdentifier") staffIdentifier: Long,
+  ) = this.staffService.getReviewCounts(staffIdentifier)
 }

--- a/src/test/resources/test_data/seed-hard-stop-licences.sql
+++ b/src/test/resources/test_data/seed-hard-stop-licences.sql
@@ -1,0 +1,14 @@
+insert into licence (
+    id,
+    kind,
+    version,
+    responsible_com_id,
+    created_by_com_id,
+    type_code,
+    status_code,
+    probation_team_code,
+    review_date
+) values
+      (1,'HARD_STOP','1.0',1,4,'AP','APPROVED', 'A01B02', null),
+      (2,'CRD','1.0',2,5,'AP','APPROVED', 'A01B02', null),
+      (3,'HARD_STOP','1.0',1,6,'AP','APPROVED', 'A01B02', null);


### PR DESCRIPTION
This PR is to introduce a new endpoint to retrieve  the counts of cases that the probation practitioner needs to review for hard stop. This provides the counts for the PP's own cases and the count for the team(s) the PP is attached to as well. 