### PR TITLE
CVSL-1450 Setting isReviewNeeded to be false when a licence is not ACTIVE

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ToModelTransformers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ToModelTransformers.kt
@@ -73,7 +73,7 @@ fun transformToLicenceSummary(licence: EntityLicence): LicenceSummary {
     licenceVersion = licence.licenceVersion,
     versionOf = if (licence is CrdLicence) licence.versionOfId else null,
     isReviewNeeded = when (licence) {
-      is HardStopLicence -> licence.reviewDate == null
+      is HardStopLicence -> (licence.statusCode == LicenceStatus.ACTIVE && licence.reviewDate == null)
       else -> false
     },
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceServiceTest.kt
@@ -367,11 +367,11 @@ class LicenceServiceTest {
   }
 
   @Test
-  fun `review needed - when review date not set`() {
+  fun `review needed - when review date not set on ACTIVE licence`() {
     val licenceQueryObject = LicenceQueryObject(pdus = listOf("A", "B"))
     whenever(licenceRepository.findAll(any<Specification<EntityLicence>>(), any<Sort>())).thenReturn(
       listOf(
-        createHardStopLicence().copy(reviewDate = null),
+        createHardStopLicence().copy(statusCode = LicenceStatus.ACTIVE, reviewDate = null),
       ),
     )
 
@@ -386,6 +386,20 @@ class LicenceServiceTest {
     whenever(licenceRepository.findAll(any<Specification<EntityLicence>>(), any<Sort>())).thenReturn(
       listOf(
         createHardStopLicence().copy(reviewDate = LocalDateTime.now()),
+      ),
+    )
+
+    val licenceSummaries = service.findLicencesMatchingCriteria(licenceQueryObject)
+
+    assertThat(licenceSummaries[0].isReviewNeeded).isFalse()
+  }
+
+  @Test
+  fun `review not needed - when review date not set on non-ACTIVE licence`() {
+    val licenceQueryObject = LicenceQueryObject(pdus = listOf("A", "B"))
+    whenever(licenceRepository.findAll(any<Specification<EntityLicence>>(), any<Sort>())).thenReturn(
+      listOf(
+        createHardStopLicence().copy(reviewDate = null),
       ),
     )
 


### PR DESCRIPTION
Without this change, HARD_STOP licences that were not approved in time for release would show in the vary tab for PPs.