### PR TITLE
CVSL-1724 add working days service as needed to calculate early release cases

### DIFF
--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -67,5 +67,6 @@
     <ID>TooManyFunctions:ToModelTransformers.kt$uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.publicApi.ToModelTransformers.kt</ID>
     <ID>TooManyFunctions:VariationLicence.kt$VariationLicence : Licence</ID>
     <ID>UnusedParameter:ConditionController.kt$ConditionController$@PathVariable conditionType: String</ID>
+    <ID>UnusedPrivateProperty:WorkingDaysService.kt$WorkingDaysService$i</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/WorkingDaysService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/WorkingDaysService.kt
@@ -1,0 +1,35 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service
+
+import org.springframework.stereotype.Service
+import java.time.DayOfWeek
+import java.time.LocalDate
+
+@Service
+class WorkingDaysService(private val bankHolidayService: BankHolidayService) {
+
+  fun addWorkingDays(date: LocalDate, workingDays: Int): LocalDate {
+    val bankHolidays = bankHolidayService.getBankHolidaysForEnglandAndWales()
+    var adjustedDate = date
+    for (i in 0 until workingDays) {
+      adjustedDate = getNextWorkingDay(bankHolidays, adjustedDate)
+    }
+    return adjustedDate
+  }
+
+  fun isWeekend(date: LocalDate): Boolean {
+    val weekend = listOf(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY)
+    return date.dayOfWeek in weekend
+  }
+
+  fun isNonWorkingDay(bankHolidays: List<LocalDate>, date: LocalDate): Boolean {
+    return isWeekend(date) || bankHolidays.contains(date)
+  }
+
+  fun getNextWorkingDay(bankHolidays: List<LocalDate>, date: LocalDate): LocalDate {
+    var adjustedDate = date.plusDays(1)
+    while (isNonWorkingDay(bankHolidays, adjustedDate)) {
+      adjustedDate = adjustedDate.plusDays(1)
+    }
+    return adjustedDate
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/WorkingDaysServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/WorkingDaysServiceTest.kt
@@ -1,0 +1,125 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.reset
+import org.mockito.kotlin.whenever
+import java.time.LocalDate
+
+class WorkingDaysServiceTest {
+  private val bankHolidayService = mock<BankHolidayService>()
+  private val service = WorkingDaysService(bankHolidayService)
+
+  @BeforeEach
+  fun reset() {
+    reset(bankHolidayService)
+    whenever(bankHolidayService.getBankHolidaysForEnglandAndWales()).thenReturn(someBankHolidays)
+  }
+
+  @Test
+  fun `is date on the weekend`() {
+    val today = LocalDate.of(2024, 3, 23)
+    val isWeekend = service.isWeekend(today)
+    assertTrue(isWeekend)
+  }
+
+  @Test
+  fun `is date not on the weekend`() {
+    val today = LocalDate.of(2024, 3, 21)
+    val isWeekend = service.isWeekend(today)
+    assertFalse(isWeekend)
+  }
+
+  @Test
+  fun `is date a non working day`() {
+    val today = LocalDate.of(2024, 3, 23)
+    val isNonWorkingDay = service.isNonWorkingDay(someBankHolidays, today)
+    assertTrue(isNonWorkingDay)
+  }
+
+  @Test
+  fun `is date a working day`() {
+    val today = LocalDate.of(2024, 3, 21)
+    val isWorkingDay = service.isNonWorkingDay(someBankHolidays, today)
+    assertFalse(isWorkingDay)
+  }
+
+  @Test
+  fun `get next working day on a weekday`() {
+    val today = LocalDate.of(2024, 3, 21)
+    val nextWorkingDay = service.getNextWorkingDay(someBankHolidays, today)
+    assertEquals(nextWorkingDay, LocalDate.of(2024, 3, 22))
+  }
+
+  @Test
+  fun `get next working day on a Friday`() {
+    val today = LocalDate.of(2024, 3, 22)
+    val nextWorkingDay = service.getNextWorkingDay(someBankHolidays, today)
+    assertEquals(nextWorkingDay, LocalDate.of(2024, 3, 25))
+  }
+
+  @Test
+  fun `get next working day on a bank holiday`() {
+    val today = LocalDate.of(2024, 5, 3)
+    val nextWorkingDay = service.getNextWorkingDay(someBankHolidays, today)
+    assertEquals(nextWorkingDay, LocalDate.of(2024, 5, 7))
+  }
+
+  @Test
+  fun `get next working day on a multi day bank holiday`() {
+    val today = LocalDate.of(2024, 3, 28)
+    val nextWorkingDay = service.getNextWorkingDay(someBankHolidays, today)
+    assertEquals(nextWorkingDay, LocalDate.of(2024, 4, 2))
+  }
+
+  @Test
+  fun `is bank holiday a non working day`() {
+    val today = LocalDate.of(2024, 12, 25)
+    val isBankHoliday = service.isNonWorkingDay(someBankHolidays, today)
+    assertTrue(isBankHoliday)
+  }
+
+  @Test
+  fun `add working days`() {
+    val today = LocalDate.of(2024, 3, 20)
+    val date = service.addWorkingDays(today, 2)
+    assertEquals(date, LocalDate.of(2024, 3, 22))
+  }
+
+  @Test
+  fun `add working days on Friday`() {
+    val today = LocalDate.of(2024, 3, 22)
+    val date = service.addWorkingDays(today, 2)
+    assertEquals(date, LocalDate.of(2024, 3, 26))
+  }
+
+  @Test
+  fun `add working days on Easter bank holiday`() {
+    val today = LocalDate.of(2024, 3, 28)
+    val date = service.addWorkingDays(today, 2)
+    assertEquals(date, LocalDate.of(2024, 4, 3))
+  }
+
+  @Test
+  fun `add working days on multiple Christmas bank holidays`() {
+    val today = LocalDate.of(2024, 12, 20)
+    val date = service.addWorkingDays(today, 10)
+    assertEquals(date, LocalDate.of(2025, 1, 8))
+  }
+
+  private companion object {
+    val someBankHolidays = listOf(
+      LocalDate.parse("2024-03-29"),
+      LocalDate.parse("2024-04-01"),
+      LocalDate.parse("2024-05-06"),
+      LocalDate.parse("2024-08-26"),
+      LocalDate.parse("2024-12-25"),
+      LocalDate.parse("2024-12-26"),
+      LocalDate.parse("2025-01-01"),
+    )
+  }
+}


### PR DESCRIPTION
This PR is to add a WorkingDaysService in the backend to aid calculation of dates when we need to calculate using working days (as needed to change the logic in the `isInHardStopPeriod` in CVSL-1724)