### PR TITLE
CVSL-1828 add extra check to check that licence is in progress before timing out

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/UpdateSentenceDateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/UpdateSentenceDateService.kt
@@ -61,8 +61,11 @@ class UpdateSentenceDateService(
     if (hardStopEnabled) {
       val licencePreviouslyInHardStopPeriod = releaseDateService.isInHardStopPeriod(licenceEntity)
       val licenceCurrentlyInHardStopPeriod = releaseDateService.isInHardStopPeriod(updatedLicenceEntity)
+      val isLicenceStatusInProgress = updatedLicenceEntity.statusCode == LicenceStatus.IN_PROGRESS
+      val isTimedOut =
+        !licencePreviouslyInHardStopPeriod && licenceCurrentlyInHardStopPeriod && isLicenceStatusInProgress
 
-      if (!licencePreviouslyInHardStopPeriod && licenceCurrentlyInHardStopPeriod && updatedLicenceEntity is CrdLicence) {
+      if (isTimedOut && updatedLicenceEntity is CrdLicence) {
         licenceService.timeout(updatedLicenceEntity, reason = "due to sentence dates update")
       } else {
         licenceRepository.saveAndFlush(updatedLicenceEntity)


### PR DESCRIPTION
This PR is to address a bug found in testing where incorrect licences were being timed out upon date change. An additional check to check for in progress licences has been added which mirrors how the time out job operates.