### PR TITLE
CVSL-1829 Adding isEligibleForEarlyRelease to caseload item

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/CaseloadItem.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/CaseloadItem.kt
@@ -24,6 +24,9 @@ data class CvlFields(
   @Schema(description = "Is the licence in the hard stop period? (Within two working days of release)")
   val isInHardStopPeriod: Boolean = false,
 
+  @Schema(description = "If ARD||CRD falls on Friday/Bank holiday/Weekend then it is eligible for early release)")
+  val isEligibleForEarlyRelease: Boolean = false,
+
   @Schema(description = "Is the prisoner due for early release")
   val isDueForEarlyRelease: Boolean = false,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/CaseloadService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/CaseloadService.kt
@@ -34,6 +34,7 @@ class CaseloadService(
         hardStopDate = releaseDateService.getHardStopDate(sentenceDateHolder),
         hardStopWarningDate = releaseDateService.getHardStopWarningDate(sentenceDateHolder),
         isInHardStopPeriod = releaseDateService.isInHardStopPeriod(sentenceDateHolder),
+        isEligibleForEarlyRelease = releaseDateService.isEligibleForEarlyRelease(sentenceDateHolder),
         isDueForEarlyRelease = releaseDateService.isDueForEarlyRelease(sentenceDateHolder),
         isDueToBeReleasedInTheNextTwoWorkingDays = releaseDateService.isDueToBeReleasedInTheNextTwoWorkingDays(sentenceDateHolder),
       ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceService.kt
@@ -86,14 +86,8 @@ class LicenceService(
       .findById(licenceId)
       .orElseThrow { EntityNotFoundException("$licenceId") }
 
-    val releaseDate = entityLicence.actualReleaseDate ?: entityLicence.conditionalReleaseDate
-    val isEligibleForEarlyRelease =
-      releaseDate !== null && releaseDateService.isEligibleForEarlyRelease(releaseDate)
-
-    val earliestReleaseDate = when {
-      isEligibleForEarlyRelease -> releaseDateService.getEarliestReleaseDate(releaseDate!!)
-      else -> releaseDate
-    }
+    val isEligibleForEarlyRelease = releaseDateService.isEligibleForEarlyRelease(entityLicence)
+    val earliestReleaseDate = releaseDateService.getEarliestReleaseDate(entityLicence)
 
     val conditionsSubmissionStatus =
       isLicenceReadyToSubmit(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ReleaseDateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ReleaseDateService.kt
@@ -49,8 +49,12 @@ class ReleaseDateService(
     return LocalDate.now(clock) >= 2.workingDaysBefore(earliestReleaseDate) && LocalDate.now(clock) <= earliestReleaseDate
   }
 
-  fun getEarliestReleaseDate(releaseDate: LocalDate): LocalDate {
-    return getEarliestDateBefore(maxNumberOfWorkingDaysAllowedForEarlyRelease, releaseDate)
+  fun getEarliestReleaseDate(sentenceDateHolder: SentenceDateHolder): LocalDate? {
+    val releaseDate = sentenceDateHolder.actualReleaseDate ?: sentenceDateHolder.conditionalReleaseDate ?: return null
+    return when {
+      isEligibleForEarlyRelease(sentenceDateHolder) -> getEarliestDateBefore(maxNumberOfWorkingDaysAllowedForEarlyRelease, releaseDate)
+      else -> releaseDate
+    }
   }
 
   fun isLateAllocationWarningRequired(releaseDate: LocalDate?): Boolean {
@@ -60,6 +64,11 @@ class ReleaseDateService(
       releaseDate,
     )
     return LocalDate.now(clock) >= warningThreshold
+  }
+
+  fun isEligibleForEarlyRelease(sentenceDateHolder: SentenceDateHolder): Boolean {
+    val releaseDate = sentenceDateHolder.actualReleaseDate ?: sentenceDateHolder.conditionalReleaseDate
+    return releaseDate != null && isEligibleForEarlyRelease(releaseDate)
   }
 
   /** Friday is also considered as weekend */

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/CaseloadServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/CaseloadServiceTest.kt
@@ -11,6 +11,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.reset
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.SentenceDateHolder
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.CaseloadItem
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.CvlFields
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.Prisoner
@@ -34,6 +35,7 @@ class CaseloadServiceTest {
     whenever(releaseDateService.getHardStopWarningDate(any())).thenReturn(LocalDate.of(2023, 10, 11))
     whenever(releaseDateService.isInHardStopPeriod(any(), anyOrNull())).thenReturn(true)
     whenever(releaseDateService.isDueForEarlyRelease(any())).thenReturn(true)
+    whenever(releaseDateService.isEligibleForEarlyRelease(any<SentenceDateHolder>())).thenReturn(true)
     whenever(releaseDateService.isDueToBeReleasedInTheNextTwoWorkingDays(any())).thenReturn(true)
   }
 
@@ -48,6 +50,7 @@ class CaseloadServiceTest {
           hardStopDate = LocalDate.of(2023, 10, 12),
           hardStopWarningDate = LocalDate.of(2023, 10, 11),
           isInHardStopPeriod = true,
+          isEligibleForEarlyRelease = true,
           isDueForEarlyRelease = true,
           isDueToBeReleasedInTheNextTwoWorkingDays = true,
         ),
@@ -104,6 +107,7 @@ class CaseloadServiceTest {
           hardStopWarningDate = LocalDate.of(2023, 10, 11),
           isInHardStopPeriod = true,
           isDueForEarlyRelease = true,
+          isEligibleForEarlyRelease = true,
           isDueToBeReleasedInTheNextTwoWorkingDays = true,
         ),
         prisoner = Prisoner(
@@ -166,6 +170,7 @@ class CaseloadServiceTest {
           hardStopWarningDate = LocalDate.of(2023, 10, 11),
           isInHardStopPeriod = true,
           isDueForEarlyRelease = true,
+          isEligibleForEarlyRelease = true,
           isDueToBeReleasedInTheNextTwoWorkingDays = true,
         ),
         prisoner = Prisoner(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/NotifyServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/NotifyServiceTest.kt
@@ -45,7 +45,7 @@ class NotifyServiceTest {
 
   @Test
   fun `send licence initial licence create email`() {
-    whenever(releaseDateService.isEligibleForEarlyRelease(any())).thenReturn(true)
+    whenever(releaseDateService.isEligibleForEarlyRelease(any<LocalDate>())).thenReturn(true)
 
     val comToEmail = PromptLicenceCreationRequest(
       email = EMAIL_ADDRESS,
@@ -67,7 +67,7 @@ class NotifyServiceTest {
 
   @Test
   fun `send licence urgent licence create email`() {
-    whenever(releaseDateService.isEligibleForEarlyRelease(any())).thenReturn(true)
+    whenever(releaseDateService.isEligibleForEarlyRelease(any<LocalDate>())).thenReturn(true)
 
     val comToEmail = PromptLicenceCreationRequest(
       email = EMAIL_ADDRESS,
@@ -89,7 +89,7 @@ class NotifyServiceTest {
 
   @Test
   fun `send licence initial licence create email with multiple cases among which one prisoner is eligible for early release`() {
-    whenever(releaseDateService.isEligibleForEarlyRelease(any())).thenReturn(true)
+    whenever(releaseDateService.isEligibleForEarlyRelease(any<LocalDate>())).thenReturn(true)
 
     val comToEmail = PromptLicenceCreationRequest(
       email = EMAIL_ADDRESS,
@@ -143,7 +143,7 @@ class NotifyServiceTest {
 
   @Test
   fun `send licence urgent licence create email with multiple cases among which one prisoner is eligible for early release`() {
-    whenever(releaseDateService.isEligibleForEarlyRelease(any())).thenReturn(true)
+    whenever(releaseDateService.isEligibleForEarlyRelease(any<LocalDate>())).thenReturn(true)
 
     val comToEmail = PromptLicenceCreationRequest(
       email = EMAIL_ADDRESS,
@@ -171,7 +171,7 @@ class NotifyServiceTest {
 
   @Test
   fun `send licence urgent licence create email with multiple cases among which none are eligible for early release`() {
-    whenever(releaseDateService.isEligibleForEarlyRelease(any())).thenReturn(false)
+    whenever(releaseDateService.isEligibleForEarlyRelease(any<LocalDate>())).thenReturn(false)
 
     val comToEmail = PromptLicenceCreationRequest(
       email = EMAIL_ADDRESS,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ReleaseDateServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ReleaseDateServiceTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.reset
 import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.SentenceDateHolder
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.TestData.createCrdLicence
 import java.time.Clock
 import java.time.Instant
@@ -31,8 +32,14 @@ class ReleaseDateServiceTest {
     whenever(bankHolidayService.getBankHolidaysForEnglandAndWales()).thenReturn(bankHolidays)
   }
 
-  private fun getEarliestDate(actualReleaseDate: LocalDate): LocalDate {
-    return service.getEarliestReleaseDate(actualReleaseDate)
+  private fun getEarliestDate(actualReleaseDate: LocalDate): LocalDate? {
+    return service.getEarliestReleaseDate(
+      object : SentenceDateHolder {
+        override val licenceStartDate: LocalDate? = null
+        override val conditionalReleaseDate: LocalDate? = null
+        override val actualReleaseDate: LocalDate? = actualReleaseDate
+      },
+    )
   }
 
   @Nested


### PR DESCRIPTION
This is being recalculated on the frontend when there is no licence - this means we can remove that bit of logic