### PR TITLE
CVSL-1832 add updatedByFullName to licence summary

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/LicenceSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/LicenceSummary.kt
@@ -176,4 +176,7 @@ data class LicenceSummary(
 
   @Schema(description = "Is a review of this licence is required", example = "true")
   val isReviewNeeded: Boolean,
+
+  @Schema(description = "The full name of the person who last updated this licence", example = "Jane Jones")
+  val updatedByFullName: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ToModelTransformers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ToModelTransformers.kt
@@ -91,6 +91,7 @@ fun transformToLicenceSummary(
     isInHardStopPeriod = isInHardStopPeriod,
     isDueForEarlyRelease = isDueForEarlyRelease,
     isDueToBeReleasedInTheNextTwoWorkingDays = isDueToBeReleasedInTheNextTwoWorkingDays,
+    updatedByFullName = licence.getUpdatedByFullName(),
   )
 }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/privateApi/LicenceControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/privateApi/LicenceControllerTest.kt
@@ -681,6 +681,7 @@ class LicenceControllerTest {
       approvedDate = LocalDateTime.of(2023, 9, 19, 16, 38, 42),
       licenceVersion = "1.0",
       isReviewNeeded = false,
+      updatedByFullName = "X Y",
     )
 
     val aStatusUpdateRequest =

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceServiceTest.kt
@@ -339,6 +339,34 @@ class LicenceServiceTest {
   }
 
   @Test
+  fun `find licences matching criteria - updated by full name populated`() {
+    val licenceQueryObject = LicenceQueryObject(
+      prisonCodes = listOf("MDI"),
+      statusCodes = listOf(LicenceStatus.APPROVED),
+      staffIds = listOf(1, 2, 3),
+      nomsIds = listOf("A1234AA"),
+    )
+    whenever(licenceRepository.findAll(any<Specification<EntityLicence>>(), any<Sort>())).thenReturn(
+      listOf(
+        aLicenceEntity.copy(
+          updatedBy = aCom,
+        ),
+      ),
+    )
+
+    val licenceSummaries = service.findLicencesMatchingCriteria(licenceQueryObject)
+
+    assertThat(licenceSummaries).isEqualTo(
+      listOf(
+        aLicenceSummary.copy(
+          updatedByFullName = "X Y",
+        ),
+      ),
+    )
+    verify(licenceRepository, times(1)).findAll(any<Specification<EntityLicence>>(), eq(Sort.unsorted()))
+  }
+
+  @Test
   fun `find recently approved licences matching criteria - returns recently approved licences`() {
     whenever(licenceRepository.getRecentlyApprovedLicences(any(), any())).thenReturn(
       listOf(


### PR DESCRIPTION
This PR is to address a bug where Last Worked On By was not populated in the frontend in the CA view. 