### PR TITLE
CVSL-1738 add inactivate recall job to backend

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/repository/LicenceRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/repository/LicenceRepository.kt
@@ -175,6 +175,22 @@ interface LicenceRepository : JpaRepository<Licence, Long>, JpaSpecificationExec
     nativeQuery = true,
   )
   fun getHardStopLicencesNeedingReview(): List<HardStopLicence>
+
+  @Query(
+    """
+      SELECT l
+      FROM Licence l
+      WHERE l.postRecallReleaseDate >= CURRENT_DATE 
+      AND l.statusCode IN (
+        uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus.ACTIVE,
+        uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus.VARIATION_IN_PROGRESS,
+        uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus.VARIATION_SUBMITTED,
+        uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus.VARIATION_REJECTED,
+        uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus.VARIATION_APPROVED
+      )
+    """,
+  )
+  fun getActiveAndVariedLicencesWhichAreNowRecalls(): List<Licence>
 }
 
 @Schema(description = "Describes a prisoner's first and last name, their CRN if present and a COM's contact details for use in an email to COM")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/privateApi/jobs/InactivateRecallLicencesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/privateApi/jobs/InactivateRecallLicencesController.kt
@@ -26,7 +26,7 @@ class InactivateRecallLicencesController(
   @PreAuthorize("hasAnyRole('CVL_ADMIN')")
   @Operation(
     summary = "Triggers the inactivate recall licences job.",
-    description = "Triggers a job that inactivates licences where there is an active or varied licence with a PRRD of today or in the future. Requires ROLE_CVL_ADMIN.",
+    description = "Triggers a job that inactivates licences where there is an active licence or an in flight variation of a licence with a PRRD of today or in the future. Requires ROLE_CVL_ADMIN.",
     security = [SecurityRequirement(name = "ROLE_CVL_ADMIN")],
   )
   @ApiResponses(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/privateApi/jobs/InactivateRecallLicencesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/privateApi/jobs/InactivateRecallLicencesController.kt
@@ -1,0 +1,53 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.privateApi.jobs
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.MediaType
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.config.ErrorResponse
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.Tags
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.jobs.InactivateRecallLicencesService
+
+@Tag(name = Tags.JOBS)
+@RestController
+@RequestMapping("", produces = [MediaType.APPLICATION_JSON_VALUE])
+class InactivateRecallLicencesController(
+  private val inactivateRecallLicencesService: InactivateRecallLicencesService,
+) {
+  @PostMapping(value = ["/run-inactivate-recall-licences-job"])
+  @PreAuthorize("hasAnyRole('CVL_ADMIN')")
+  @Operation(
+    summary = "Triggers the inactivate recall licences job.",
+    description = "Triggers a job that inactivates licences where there is an active or varied licence with a PRRD of today or in the future. Requires ROLE_CVL_ADMIN.",
+    security = [SecurityRequirement(name = "ROLE_CVL_ADMIN")],
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Inactive recall licences job executed.",
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorised, requires a valid Oauth2 token",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires an appropriate role",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  fun runInactivateRecallLicencesJob() {
+    return inactivateRecallLicencesService.inactivateLicences()
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/jobs/InactivateRecallLicencesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/jobs/InactivateRecallLicencesService.kt
@@ -1,0 +1,33 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.jobs
+
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.LicenceRepository
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.LicenceService
+
+@Service
+class InactivateRecallLicencesService(
+  private val licenceRepository: LicenceRepository,
+  private val licenceService: LicenceService,
+) {
+
+  companion object {
+    private val log = LoggerFactory.getLogger(this::class.java)
+  }
+
+  @Transactional
+  fun inactivateLicences() {
+    log.info("Starting runInactivateRecallLicencesJob")
+    val licences = licenceRepository.getActiveAndVariedLicencesWhichAreNowRecalls()
+    if (licences.isEmpty()) {
+      log.info("No matching licences to inactivate were found")
+      return
+    }
+    licenceService.inactivateLicences(
+      licences,
+      "Licence automatically inactivated as licence has a PRRD and is now a recall",
+    )
+    log.info("${licences.size} licences were automatically inactivated")
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/InactivateRecallLicencesIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/InactivateRecallLicencesIntegrationTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.integration
 
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.groups.Tuple
+import org.assertj.core.groups.Tuple.tuple
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
@@ -54,16 +55,16 @@ class InactivateRecallLicencesIntegrationTest : IntegrationTestBase() {
 
     assertThat(inactiveLicences)
       .extracting<Tuple> {
-        Tuple.tuple(it.licenceId, it.licenceStatus)
+        tuple(it.licenceId, it.licenceStatus)
       }
       .containsExactlyElementsOf(
         listOf(
-          Tuple.tuple(1L, LicenceStatus.INACTIVE),
-          Tuple.tuple(2L, LicenceStatus.INACTIVE),
-          Tuple.tuple(4L, LicenceStatus.INACTIVE),
-          Tuple.tuple(5L, LicenceStatus.INACTIVE),
-          Tuple.tuple(6L, LicenceStatus.INACTIVE),
-          Tuple.tuple(7L, LicenceStatus.INACTIVE),
+          tuple(1L, LicenceStatus.INACTIVE),
+          tuple(2L, LicenceStatus.INACTIVE),
+          tuple(4L, LicenceStatus.INACTIVE),
+          tuple(5L, LicenceStatus.INACTIVE),
+          tuple(6L, LicenceStatus.INACTIVE),
+          tuple(7L, LicenceStatus.INACTIVE),
         ),
       )
 
@@ -72,15 +73,15 @@ class InactivateRecallLicencesIntegrationTest : IntegrationTestBase() {
 
       assertThat(allValues)
         .extracting<Tuple> {
-          Tuple.tuple(it.eventType, it.additionalInformation?.licenceId)
+          tuple(it.eventType, it.additionalInformation?.licenceId)
         }
         .containsExactly(
-          Tuple.tuple(LicenceDomainEventType.LICENCE_INACTIVATED.value, "1"),
-          Tuple.tuple(LicenceDomainEventType.LICENCE_INACTIVATED.value, "2"),
-          Tuple.tuple(LicenceDomainEventType.LICENCE_INACTIVATED.value, "4"),
-          Tuple.tuple(LicenceDomainEventType.LICENCE_INACTIVATED.value, "6"),
-          Tuple.tuple(LicenceDomainEventType.LICENCE_VARIATION_INACTIVATED.value, "7"),
-          Tuple.tuple(LicenceDomainEventType.LICENCE_VARIATION_INACTIVATED.value, "5"),
+          tuple(LicenceDomainEventType.LICENCE_INACTIVATED.value, "1"),
+          tuple(LicenceDomainEventType.LICENCE_INACTIVATED.value, "2"),
+          tuple(LicenceDomainEventType.LICENCE_INACTIVATED.value, "4"),
+          tuple(LicenceDomainEventType.LICENCE_INACTIVATED.value, "6"),
+          tuple(LicenceDomainEventType.LICENCE_VARIATION_INACTIVATED.value, "7"),
+          tuple(LicenceDomainEventType.LICENCE_VARIATION_INACTIVATED.value, "5"),
         )
     }
 
@@ -97,12 +98,12 @@ class InactivateRecallLicencesIntegrationTest : IntegrationTestBase() {
 
     assertThat(remainingLicences)
       .extracting<Tuple> {
-        Tuple.tuple(it.licenceId, it.licenceStatus)
+        tuple(it.licenceId, it.licenceStatus)
       }
       .containsExactlyElementsOf(
         listOf(
-          Tuple.tuple(3L, LicenceStatus.ACTIVE),
-          Tuple.tuple(8L, LicenceStatus.IN_PROGRESS),
+          tuple(3L, LicenceStatus.ACTIVE),
+          tuple(8L, LicenceStatus.IN_PROGRESS),
         ),
       )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/InactivateRecallLicencesIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/InactivateRecallLicencesIntegrationTest.kt
@@ -1,0 +1,126 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.groups.Tuple
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
+import org.springframework.test.context.jdbc.Sql
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.integration.wiremock.GovUkMockServer
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.LicenceSummary
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.request.MatchLicencesRequest
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.LicenceRepository
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.domainEvents.DomainEventsService.HMPPSDomainEvent
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.domainEvents.DomainEventsService.LicenceDomainEventType
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.domainEvents.OutboundEventsPublisher
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus
+
+class InactivateRecallLicencesIntegrationTest : IntegrationTestBase() {
+
+  @MockBean
+  private lateinit var eventsPublisher: OutboundEventsPublisher
+
+  @Autowired
+  lateinit var licenceRepository: LicenceRepository
+
+  @Test
+  @Sql(
+    "classpath:test_data/seed-licences-for-inactivate-recall-licences.sql",
+  )
+  fun `Run inactivate recall licences job`() {
+    webTestClient.post()
+      .uri("/run-inactivate-recall-licences-job")
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_CVL_ADMIN")))
+      .exchange()
+      .expectStatus().isOk
+
+    val inactiveLicences = webTestClient.post()
+      .uri("/licence/match")
+      .bodyValue(MatchLicencesRequest(status = listOf(LicenceStatus.INACTIVE)))
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_CVL_ADMIN")))
+      .exchange()
+      .expectBodyList(LicenceSummary::class.java)
+      .returnResult().responseBody
+
+    assertThat(inactiveLicences?.size).isEqualTo(6)
+
+    assertThat(inactiveLicences)
+      .extracting<Tuple> {
+        Tuple.tuple(it.licenceId, it.licenceStatus)
+      }
+      .containsExactlyElementsOf(
+        listOf(
+          Tuple.tuple(1L, LicenceStatus.INACTIVE),
+          Tuple.tuple(2L, LicenceStatus.INACTIVE),
+          Tuple.tuple(4L, LicenceStatus.INACTIVE),
+          Tuple.tuple(5L, LicenceStatus.INACTIVE),
+          Tuple.tuple(6L, LicenceStatus.INACTIVE),
+          Tuple.tuple(7L, LicenceStatus.INACTIVE),
+        ),
+      )
+
+    argumentCaptor<HMPPSDomainEvent>().apply {
+      verify(eventsPublisher, times(6)).publishDomainEvent(capture())
+
+      assertThat(allValues)
+        .extracting<Tuple> {
+          Tuple.tuple(it.eventType, it.additionalInformation?.licenceId)
+        }
+        .containsExactly(
+          Tuple.tuple(LicenceDomainEventType.LICENCE_INACTIVATED.value, "1"),
+          Tuple.tuple(LicenceDomainEventType.LICENCE_INACTIVATED.value, "2"),
+          Tuple.tuple(LicenceDomainEventType.LICENCE_INACTIVATED.value, "4"),
+          Tuple.tuple(LicenceDomainEventType.LICENCE_INACTIVATED.value, "6"),
+          Tuple.tuple(LicenceDomainEventType.LICENCE_VARIATION_INACTIVATED.value, "7"),
+          Tuple.tuple(LicenceDomainEventType.LICENCE_VARIATION_INACTIVATED.value, "5"),
+        )
+    }
+
+    val remainingLicences = webTestClient.post()
+      .uri("/licence/match")
+      .bodyValue(MatchLicencesRequest(status = LicenceStatus.IN_FLIGHT_LICENCES))
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf("ROLE_CVL_ADMIN")))
+      .exchange()
+      .expectBodyList(LicenceSummary::class.java)
+      .returnResult().responseBody
+
+    assertThat(remainingLicences?.size).isEqualTo(2)
+
+    assertThat(remainingLicences)
+      .extracting<Tuple> {
+        Tuple.tuple(it.licenceId, it.licenceStatus)
+      }
+      .containsExactlyElementsOf(
+        listOf(
+          Tuple.tuple(3L, LicenceStatus.ACTIVE),
+          Tuple.tuple(8L, LicenceStatus.IN_PROGRESS),
+        ),
+      )
+  }
+
+  private companion object {
+    val govUkApiMockServer = GovUkMockServer()
+
+    @JvmStatic
+    @BeforeAll
+    fun startMocks() {
+      govUkApiMockServer.start()
+      govUkApiMockServer.stubGetBankHolidaysForEnglandAndWales()
+    }
+
+    @JvmStatic
+    @AfterAll
+    fun stopMocks() {
+      govUkApiMockServer.stop()
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/privateApi/jobs/InactivateRecallLicencesControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/privateApi/jobs/InactivateRecallLicencesControllerTest.kt
@@ -1,0 +1,57 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.privateApi.jobs
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.springframework.test.context.web.WebAppConfiguration
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.config.ControllerAdvice
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.jobs.InactivateRecallLicencesService
+
+@ExtendWith(SpringExtension::class)
+@ActiveProfiles("test")
+@WebMvcTest(controllers = [InactivateRecallLicencesController::class])
+@AutoConfigureMockMvc(addFilters = false)
+@ContextConfiguration(classes = [InactivateRecallLicencesController::class])
+@WebAppConfiguration
+class InactivateRecallLicencesControllerTest {
+  @MockBean
+  private lateinit var inactivateRecallLicencesService: InactivateRecallLicencesService
+
+  @Autowired
+  private lateinit var mvc: MockMvc
+
+  @BeforeEach
+  fun reset() {
+    org.mockito.kotlin.reset(inactivateRecallLicencesService)
+
+    mvc = MockMvcBuilders
+      .standaloneSetup(InactivateRecallLicencesController(inactivateRecallLicencesService))
+      .setControllerAdvice(ControllerAdvice())
+      .build()
+  }
+
+  @Test
+  fun `inactivate licences`() {
+    mvc.perform(
+      MockMvcRequestBuilders.post("/run-inactivate-recall-licences-job")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON),
+    )
+      .andExpect(MockMvcResultMatchers.status().isOk)
+    verify(inactivateRecallLicencesService, times(1)).inactivateLicences()
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/privateApi/jobs/InactivateRecallLicencesControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/privateApi/jobs/InactivateRecallLicencesControllerTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.privateAp
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.kotlin.reset
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.springframework.beans.factory.annotation.Autowired
@@ -36,7 +37,7 @@ class InactivateRecallLicencesControllerTest {
 
   @BeforeEach
   fun reset() {
-    org.mockito.kotlin.reset(inactivateRecallLicencesService)
+    reset(inactivateRecallLicencesService)
 
     mvc = MockMvcBuilders
       .standaloneSetup(InactivateRecallLicencesController(inactivateRecallLicencesService))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/jobs/InactivateRecallLicencesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/jobs/InactivateRecallLicencesServiceTest.kt
@@ -40,7 +40,7 @@ class InactivateRecallLicencesServiceTest {
   }
 
   @Test
-  fun `should inactivate active licence with a PRRD of today`() {
+  fun `should inactivate active licence`() {
     val licences = listOf(
       aLicence.copy(
         statusCode = LicenceStatus.ACTIVE,
@@ -56,71 +56,7 @@ class InactivateRecallLicencesServiceTest {
     verify(licenceRepository, times(1)).getActiveAndVariedLicencesWhichAreNowRecalls()
   }
 
-  @Test
-  fun `should inactivate active licence with a PRRD of tomorrow`() {
-    val licences = listOf(
-      aLicence.copy(
-        statusCode = LicenceStatus.ACTIVE,
-        postRecallReleaseDate = LocalDate.now().plusDays(1),
-      ),
-    )
-    whenever(licenceRepository.getActiveAndVariedLicencesWhichAreNowRecalls()).thenReturn(
-      licences,
-    )
-
-    service.inactivateLicences()
-
-    verify(licenceRepository, times(1)).getActiveAndVariedLicencesWhichAreNowRecalls()
-  }
-
-  @Test
-  fun `should inactivate active and variation licence with a PRRD of today`() {
-    val licences = listOf(
-      aLicence.copy(
-        id = 1L,
-        statusCode = LicenceStatus.ACTIVE,
-        postRecallReleaseDate = LocalDate.now().plusDays(1),
-      ),
-      aVariationLicence.copy(
-        variationOfId = 1L,
-        statusCode = LicenceStatus.VARIATION_IN_PROGRESS,
-        postRecallReleaseDate = LocalDate.now().plusDays(1),
-      ),
-    )
-    whenever(licenceRepository.getActiveAndVariedLicencesWhichAreNowRecalls()).thenReturn(
-      licences,
-    )
-
-    service.inactivateLicences()
-
-    verify(licenceRepository, times(1)).getActiveAndVariedLicencesWhichAreNowRecalls()
-  }
-
-  @Test
-  fun `should inactivate active and variation licence with a PRRD of tomorrow`() {
-    val licences = listOf(
-      aLicence.copy(
-        id = 1L,
-        statusCode = LicenceStatus.ACTIVE,
-        postRecallReleaseDate = LocalDate.now().plusDays(1),
-      ),
-      aVariationLicence.copy(
-        variationOfId = 1L,
-        statusCode = LicenceStatus.VARIATION_APPROVED,
-        postRecallReleaseDate = LocalDate.now().plusDays(1),
-      ),
-    )
-    whenever(licenceRepository.getActiveAndVariedLicencesWhichAreNowRecalls()).thenReturn(
-      licences,
-    )
-
-    service.inactivateLicences()
-
-    verify(licenceRepository, times(1)).getActiveAndVariedLicencesWhichAreNowRecalls()
-  }
-
   private companion object {
     val aLicence = TestData.createCrdLicence().copy()
-    val aVariationLicence = TestData.createVariationLicence().copy()
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/jobs/InactivateRecallLicencesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/jobs/InactivateRecallLicencesServiceTest.kt
@@ -1,0 +1,126 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.jobs
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.context.SecurityContext
+import org.springframework.security.core.context.SecurityContextHolder
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.LicenceRepository
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.LicenceService
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.TestData
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus
+import java.time.LocalDate
+
+class InactivateRecallLicencesServiceTest {
+  private val licenceRepository = mock<LicenceRepository>()
+  private val licenceService = mock<LicenceService>()
+
+  private val service = InactivateRecallLicencesService(
+    licenceRepository,
+    licenceService,
+  )
+
+  @BeforeEach
+  fun reset() {
+    val authentication = mock<Authentication>()
+    val securityContext = mock<SecurityContext>()
+
+    whenever(authentication.name).thenReturn("smills")
+    whenever(securityContext.authentication).thenReturn(authentication)
+    SecurityContextHolder.setContext(securityContext)
+
+    org.mockito.kotlin.reset(
+      licenceRepository,
+      licenceService,
+    )
+  }
+
+  @Test
+  fun `should inactivate active licence with a PRRD of today`() {
+    val licences = listOf(
+      aLicence.copy(
+        statusCode = LicenceStatus.ACTIVE,
+        postRecallReleaseDate = LocalDate.now(),
+      ),
+    )
+    whenever(licenceRepository.getActiveAndVariedLicencesWhichAreNowRecalls()).thenReturn(
+      licences,
+    )
+
+    service.inactivateLicences()
+
+    verify(licenceRepository, times(1)).getActiveAndVariedLicencesWhichAreNowRecalls()
+  }
+
+  @Test
+  fun `should inactivate active licence with a PRRD of tomorrow`() {
+    val licences = listOf(
+      aLicence.copy(
+        statusCode = LicenceStatus.ACTIVE,
+        postRecallReleaseDate = LocalDate.now().plusDays(1),
+      ),
+    )
+    whenever(licenceRepository.getActiveAndVariedLicencesWhichAreNowRecalls()).thenReturn(
+      licences,
+    )
+
+    service.inactivateLicences()
+
+    verify(licenceRepository, times(1)).getActiveAndVariedLicencesWhichAreNowRecalls()
+  }
+
+  @Test
+  fun `should inactivate active and variation licence with a PRRD of today`() {
+    val licences = listOf(
+      aLicence.copy(
+        id = 1L,
+        statusCode = LicenceStatus.ACTIVE,
+        postRecallReleaseDate = LocalDate.now().plusDays(1),
+      ),
+      aVariationLicence.copy(
+        variationOfId = 1L,
+        statusCode = LicenceStatus.VARIATION_IN_PROGRESS,
+        postRecallReleaseDate = LocalDate.now().plusDays(1),
+      ),
+    )
+    whenever(licenceRepository.getActiveAndVariedLicencesWhichAreNowRecalls()).thenReturn(
+      licences,
+    )
+
+    service.inactivateLicences()
+
+    verify(licenceRepository, times(1)).getActiveAndVariedLicencesWhichAreNowRecalls()
+  }
+
+  @Test
+  fun `should inactivate active and variation licence with a PRRD of tomorrow`() {
+    val licences = listOf(
+      aLicence.copy(
+        id = 1L,
+        statusCode = LicenceStatus.ACTIVE,
+        postRecallReleaseDate = LocalDate.now().plusDays(1),
+      ),
+      aVariationLicence.copy(
+        variationOfId = 1L,
+        statusCode = LicenceStatus.VARIATION_APPROVED,
+        postRecallReleaseDate = LocalDate.now().plusDays(1),
+      ),
+    )
+    whenever(licenceRepository.getActiveAndVariedLicencesWhichAreNowRecalls()).thenReturn(
+      licences,
+    )
+
+    service.inactivateLicences()
+
+    verify(licenceRepository, times(1)).getActiveAndVariedLicencesWhichAreNowRecalls()
+  }
+
+  private companion object {
+    val aLicence = TestData.createCrdLicence().copy()
+    val aVariationLicence = TestData.createVariationLicence().copy()
+  }
+}

--- a/src/test/resources/test_data/seed-licences-for-inactivate-recall-licences.sql
+++ b/src/test/resources/test_data/seed-licences-for-inactivate-recall-licences.sql
@@ -1,0 +1,22 @@
+insert into licence (id,
+                     forename,
+                     surname,
+                     kind,
+                     version,
+                     responsible_com_id,
+                     created_by_com_id,
+                     type_code,
+                     noms_id,
+                     crn,
+                     status_code,
+                     post_recall_release_date,
+                     variation_of_id)
+values (1, 'Test Forename 1', 'Test Surname 1', 'CRD', '1.0', 1, 1, 'AP', 'G7285UT', 'A123456', 'ACTIVE', current_date, null),
+       (2, 'Test Forename 2', 'Test Surname 2', 'CRD', '1.0', 1, 1, 'AP', 'G5613GT', 'B123456', 'ACTIVE', DATEADD(day, 1, current_date), null),
+       (3, 'Test Forename 3', 'Test Surname 3', 'CRD', '1.0', 1, 1, 'AP', 'G4169UO', 'C123456', 'ACTIVE', DATEADD(day, -1, current_date), null),
+       (4, 'Test Forename 4', 'Test Surname 4', 'CRD', '1.0', 1, 1, 'AP', 'G7285UT', 'D123456', 'ACTIVE', current_date, null),
+       (5, 'Test Forename 4', 'Test Surname 4', 'VARIATION', '1.0', 1, 1, 'AP', 'G7285UT', 'D123456', 'VARIATION_IN_PROGRESS', current_date, 4),
+       (6, 'Test Forename 5', 'Test Surname 5', 'CRD', '1.0', 1, 1, 'AP', 'A1234BC', 'E123456', 'ACTIVE', DATEADD(day, 1, current_date), null),
+       (7, 'Test Forename 5', 'Test Surname 5', 'VARIATION', '1.0', 1, 1, 'AP', 'A1234BC', 'E123456', 'VARIATION_APPROVED', DATEADD(day, 1, current_date), 6),
+       (8, 'Test Forename 6', 'Test Surname 6', 'CRD', '1.0', 1, 1, 'AP', 'B1234BC', 'F123456', 'IN_PROGRESS', current_date, null);
+


### PR DESCRIPTION
This PR is to add the job to inactivate active licences and their variations where a PRRD has been entered, meaning the person has been recalled.