### PR TITLE
CVSL-1910 Adding new paginated endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/config/ResourceServerConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/config/ResourceServerConfiguration.kt
@@ -5,6 +5,8 @@ import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.EnableCaching
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.data.web.config.EnableSpringDataWebSupport
+import org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
@@ -18,6 +20,7 @@ import org.springframework.security.web.SecurityFilterChain
 @EnableWebSecurity
 @EnableMethodSecurity(prePostEnabled = true)
 @EnableCaching
+@EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO)
 class ResourceServerConfiguration {
 
   @Bean

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/privateApi/CaseloadController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/privateApi/CaseloadController.kt
@@ -10,6 +10,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
+import org.springframework.data.domain.Page
+import org.springframework.data.web.PagedModel
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
@@ -17,6 +19,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.CaseloadItem
@@ -172,8 +175,57 @@ class CaseloadController(val caseloadService: CaseloadService) {
       ),
     ],
   )
-  fun findByNumber(
+  @Deprecated("use paginated version")
+  fun findByReleaseDate(
     @Parameter(required = true) @Valid @RequestBody criteria: ReleaseDateSearch,
   ) =
-    caseloadService.getPrisonersByReleaseDate(criteria.earliestReleaseDate!!, criteria.latestReleaseDate!!, criteria.prisonIds!!)
+    caseloadService.getPrisonersByReleaseDate(criteria.earliestReleaseDate!!, criteria.latestReleaseDate!!, criteria.prisonIds!!, page = 0).content
+
+  @PostMapping("/release-date-by-prison")
+  @PreAuthorize("hasAnyRole('SYSTEM_USER', 'CVL_ADMIN')")
+  @Operation(
+    summary = "Returns prisoners by release date and prison id",
+    description = "Match prisoners in a subset of prisons with a release date within a given range",
+    security = [SecurityRequirement(name = "ROLE_SYSTEM_USER"), SecurityRequirement(name = "ROLE_CVL_ADMIN")],
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Returning A page of search results",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = SearchResultsPage::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorised, requires a valid Oauth2 token",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires an appropriate role",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+    ],
+  )
+  fun findByReleaseDatePaginated(
+    @Parameter(required = true) @Valid @RequestBody criteria: ReleaseDateSearch,
+    @Parameter(description = "page of results to return (0 indexed), defaults to first page", required = false) @Valid @RequestParam(value = "page") page: Int = 0,
+  ) = caseloadService.getPrisonersByReleaseDate(criteria.earliestReleaseDate!!, criteria.latestReleaseDate!!, criteria.prisonIds!!, page)
 }
+
+class SearchResultsPage : PagedModel<CaseloadItem>(Page.empty())

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/CaseloadService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/CaseloadService.kt
@@ -19,8 +19,8 @@ class CaseloadService(
   fun getPrisonersByNumber(nomisIds: List<String>) =
     prisonerSearchApiClient.searchPrisonersByNomisIds(nomisIds).map { it.toCaseloadItem() }
 
-  fun getPrisonersByReleaseDate(earliestReleaseDate: LocalDate, latestReleaseDate: LocalDate, prisonIds: Set<String>) =
-    prisonerSearchApiClient.searchPrisonersByReleaseDate(earliestReleaseDate, latestReleaseDate, prisonIds).map { it.toCaseloadItem() }
+  fun getPrisonersByReleaseDate(earliestReleaseDate: LocalDate, latestReleaseDate: LocalDate, prisonIds: Set<String>, page: Int = 0) =
+    prisonerSearchApiClient.searchPrisonersByReleaseDate(earliestReleaseDate, latestReleaseDate, prisonIds, page).map { it.toCaseloadItem() }
 
   fun getPrisoner(nomisId: String) =
     getPrisonersByNumber(listOf(nomisId)).firstOrNull() ?: throw EntityNotFoundException(nomisId)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/prison/PageResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/prison/PageResponse.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.prison
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+
+data class PageResponse<T>(val content: List<T>, val number: Int, val size: Int, val totalElements: Long) {
+  fun toPage(): Page<T> {
+    return PageImpl(content, PageRequest.of(number, size), totalElements)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/prison/PrisonerSearchApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/prison/PrisonerSearchApiClient.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.prison
 
 import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.data.domain.Page
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
@@ -37,15 +38,15 @@ class PrisonerSearchApiClient(@Qualifier("oauthPrisonerSearchClient") val prison
       .block() ?: emptyList()
   }
 
-  fun searchPrisonersByReleaseDate(earliestReleaseDate: LocalDate, latestReleaseDate: LocalDate, prisonIds: Set<String>): List<PrisonerSearchPrisoner> {
-    if (prisonIds.isEmpty()) return emptyList()
+  fun searchPrisonersByReleaseDate(earliestReleaseDate: LocalDate, latestReleaseDate: LocalDate, prisonIds: Set<String>, page: Int = 0): Page<PrisonerSearchPrisoner> {
+    if (prisonIds.isEmpty()) return Page.empty()
     return prisonerSearchApiWebClient
       .post()
-      .uri("/prisoner-search/release-date-by-prison?size=2000")
+      .uri("/prisoner-search/release-date-by-prison?size=2000&page=$page")
       .accept(MediaType.APPLICATION_JSON)
       .bodyValue(ReleaseDateSearch(earliestReleaseDate = earliestReleaseDate, latestReleaseDate = latestReleaseDate, prisonIds = prisonIds))
       .retrieve()
-      .bodyToMono(typeReference<SearchPaginationResponse>())
-      .block()?.content ?: emptyList()
+      .bodyToMono(typeReference<PageResponse<PrisonerSearchPrisoner>>())
+      .block()?.toPage() ?: Page.empty()
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/IntegrationTestBase.kt
@@ -60,7 +60,10 @@ abstract class IntegrationTestBase {
   protected val domainEventsTopicSnsClient by lazy { domainEventsTopic.snsClient }
   protected val domainEventsTopicArn by lazy { domainEventsTopic.arn }
 
-  protected val domainEventsQueue by lazy { hmppsQueueService.findByQueueId("domaineventsqueue") ?: throw MissingQueueException("HmppsQueue domaineventsqueue not found") }
+  protected val domainEventsQueue by lazy {
+    hmppsQueueService.findByQueueId("domaineventsqueue")
+      ?: throw MissingQueueException("HmppsQueue domaineventsqueue not found")
+  }
 
   protected val domainEventsSqsClient by lazy { domainEventsQueue.sqsClient }
   protected val domainEventsQueueUrl by lazy { domainEventsQueue.queueUrl }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/wiremock/PrisonerSearchMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/wiremock/PrisonerSearchMockServer.kt
@@ -225,9 +225,9 @@ class PrisonerSearchMockServer : WireMockServer(8099) {
     )
   }
 
-  fun stubSearchPrisonersByReleaseDate() {
+  fun stubSearchPrisonersByReleaseDate(page: Int) {
     stubFor(
-      post(urlEqualTo("/api/prisoner-search/release-date-by-prison?size=2000"))
+      post(urlEqualTo("/api/prisoner-search/release-date-by-prison?size=2000&page=$page"))
         .willReturn(
           aResponse().withHeader(
             "Content-Type",
@@ -349,7 +349,33 @@ class PrisonerSearchMockServer : WireMockServer(8099) {
                   "lastName": "Person3",
                   "dateOfBirth": "1987-01-01"
                }
-              ]}
+              ],
+              "pageable": {
+                  "pageSize": 100,
+                  "offset": 0,
+                  "sort": {
+                      "empty": false,
+                      "unsorted": false,
+                      "sorted": true
+                  },
+                  "pageNumber": 0,
+                  "paged": true,
+                  "unpaged": false
+              },
+              "totalElements": 5,
+              "totalPages": 1,
+              "last": true,
+              "size": 2000,
+              "number": 0,
+              "sort": {
+                  "empty": false,
+                  "unsorted": false,
+                  "sorted": true
+              },
+              "first": true,
+              "numberOfElements": 5,
+              "empty": false
+            }
             """.trimIndent(),
           ).withStatus(200),
         ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/CaseloadServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/CaseloadServiceTest.kt
@@ -11,6 +11,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.reset
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.springframework.data.domain.PageImpl
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.SentenceDateHolder
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.CaseloadItem
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.CvlFields
@@ -28,9 +29,9 @@ class CaseloadServiceTest {
 
   @BeforeEach
   fun reset() {
-    reset(prisonerSearchApiClient)
+    reset(prisonerSearchApiClient, releaseDateService)
     whenever(prisonerSearchApiClient.searchPrisonersByNomisIds(any())).thenReturn(listOf(prisonerSearchResult()))
-    whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any())).thenReturn(listOf(prisonerSearchResult()))
+    whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull())).thenReturn(PageImpl(listOf(prisonerSearchResult())))
     whenever(releaseDateService.getHardStopDate(any())).thenReturn(LocalDate.of(2023, 10, 12))
     whenever(releaseDateService.getHardStopWarningDate(any())).thenReturn(LocalDate.of(2023, 10, 11))
     whenever(releaseDateService.isInHardStopPeriod(any(), anyOrNull())).thenReturn(true)


### PR DESCRIPTION
Prompt job is currently restricted as it tries to load upcoming releases across all prisons and is capped by max limit of 2000 cases. 
This will allow us to iterate across pages and gather info for everyone