### PR TITLE
CVSL-2079 Changing indeterminate sentence eligibility criteria to match previous TypeScript equivalent to fix crash

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/EligibilityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/EligibilityService.kt
@@ -50,7 +50,9 @@ class EligibilityService(
 
   private fun isOnIndeterminateSentence(): EligibilityCheck = {
     val isIndeterminateSentence = it.indeterminateSentence ?: false
-    if(it.indeterminateSentence === null) { log.warn("${it.prisonerNumber} missing indeterminateSentence") }
+    if (it.indeterminateSentence === null) {
+      log.warn("${it.prisonerNumber} missing indeterminateSentence")
+    }
     isIndeterminateSentence
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/EligibilityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/EligibilityService.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service
 
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.prison.PrisonerSearchPrisoner
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.prison.getLicenceStartDate
@@ -48,7 +49,9 @@ class EligibilityService(
   private fun hasCorrectLegalStatus(): EligibilityCheck = { it.legalStatus != "DEAD" }
 
   private fun isOnIndeterminateSentence(): EligibilityCheck = {
-    it.indeterminateSentence ?: error("${it.prisonerNumber} missing indeterminateSentence")
+    val isIndeterminateSentence = it.indeterminateSentence ?: false
+    if(it.indeterminateSentence === null) { log.warn("${it.prisonerNumber} missing indeterminateSentence") }
+    isIndeterminateSentence
   }
 
   private fun hasConditionalReleaseDate(): EligibilityCheck = { it.conditionalReleaseDate != null }
@@ -103,5 +106,9 @@ class EligibilityService(
 
   private fun isBreachOfTopUpSupervision(): EligibilityCheck = early@{
     it.imprisonmentStatus == "BOTUS"
+  }
+
+  companion object {
+    private val log = LoggerFactory.getLogger(this::class.java)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/EligibilityServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/EligibilityServiceTest.kt
@@ -59,6 +59,17 @@ class EligibilityServiceTest {
   }
 
   @Test
+  fun `isIndeterminateSentence is null - eligible for CVL`() {
+    val reasons = service.getIneligibilityReasons(
+      aPrisonerSearchResult.copy(
+        indeterminateSentence = null,
+      ),
+    )
+
+    assertThat(reasons).isEmpty()
+  }
+
+  @Test
   fun `Person does not have a conditional release date - not eligible for CVL `() {
     val result = service.getIneligibilityReasons(
       aPrisonerSearchResult.copy(


### PR DESCRIPTION
TypeScript interprets `null` as `falsy`, so `!null` is `true`.
Our existing Kotlin code does not follow this same behaviour, which appears to be causing a crash for some PP caseloads.