### PR TITLE
CVSL-2079 Changing recall flag handling to match previous TS caseload builder

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/EligibilityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/EligibilityService.kt
@@ -49,11 +49,10 @@ class EligibilityService(
   private fun hasCorrectLegalStatus(): EligibilityCheck = { it.legalStatus != "DEAD" }
 
   private fun isOnIndeterminateSentence(): EligibilityCheck = {
-    val isIndeterminateSentence = it.indeterminateSentence ?: false
-    if (it.indeterminateSentence === null) {
+    if (it.indeterminateSentence == null) {
       log.warn("${it.prisonerNumber} missing indeterminateSentence")
     }
-    isIndeterminateSentence
+    it.indeterminateSentence ?: false
   }
 
   private fun hasConditionalReleaseDate(): EligibilityCheck = { it.conditionalReleaseDate != null }
@@ -103,7 +102,10 @@ class EligibilityService(
     }
 
     // Trust the Nomis recall flag as a fallback position - the above rules should always override
-    return@early it.recall ?: error("${it.prisonerNumber} missing recall flag")
+    if (it.recall == null) {
+      log.warn("${it.prisonerNumber} missing recall flag")
+    }
+    return@early it.recall ?: false
   }
 
   private fun isBreachOfTopUpSupervision(): EligibilityCheck = early@{

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/EligibilityServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/EligibilityServiceTest.kt
@@ -206,6 +206,17 @@ class EligibilityServiceTest {
   }
 
   @Test
+  fun `Recall flag is null in NOMIS - not ineligibile due to recall`() {
+    val result = service.getIneligibilityReasons(
+      aPrisonerSearchResult.copy(
+        conditionalReleaseDate = null,
+        recall = null,
+      ),
+    )
+    assertThat(result).containsExactly("has no conditional release date")
+  }
+
+  @Test
   fun `Person has no ARD and a CRD in the past - not eligible for CVL `() {
     val result = service.getIneligibilityReasons(
       aPrisonerSearchResult.copy(


### PR DESCRIPTION
Has the same intention as https://github.com/ministryofjustice/create-and-vary-a-licence-api/pull/576
The same bug was seen with the `recall` flag, so implementing the same solution.