### PR TITLE
CVSL-2033 add missing HDC kind to prison approver service

### DIFF
--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -71,6 +71,7 @@
     <ID>ReturnCount:CaCaseloadService.kt$CaCaseloadService$fun findLatestLicenceSummary(licences: List&lt;LicenceSummary&gt;): LicenceSummary?</ID>
     <ID>ReturnCount:ComCaseloadService.kt$ComCaseloadService$private fun findLicenceToDisplay(case: ManagedCase): CaseLoadLicenceSummary</ID>
     <ID>ReturnCount:ExclusionZoneService.kt$ExclusionZoneService$fun createThumbnailImageJpeg(fullSizeImage: ByteArray?, width: Int = 150, height: Int = 200): ByteArray?</ID>
+    <ID>ReturnCount:PrisonApproverService.kt$PrisonApproverService$private fun findOriginalLicenceForVariation(variationLicence: VariationLicence): Licence</ID>
     <ID>ReturnCount:StaffService.kt$StaffService$@Transactional fun updateComDetails(comDetails: UpdateComRequest): CommunityOffenderManager</ID>
     <ID>SpreadOperator:CreateAndVaryALicenceApi.kt$(*args)</ID>
     <ID>TooManyFunctions:AuditService.kt$AuditService</ID>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/PrisonApproverService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/PrisonApproverService.kt
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.CrdLicence
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.HardStopLicence
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.HdcLicence
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.Licence
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.VariationLicence
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.LicenceSummaryApproverView
@@ -65,6 +66,7 @@ class PrisonApproverService(
         is CrdLicence -> return licence
         is HardStopLicence -> return licence
         is VariationLicence -> originalLicence = licence
+        is HdcLicence -> return licence
         else -> error("Unknown licence type in hierarchy: ${licence.javaClass}")
       }
     }


### PR DESCRIPTION
Pr to address a bug we found during testing where the "Recently Approved" tab was not working as expected as forgot to add the HDC licence kind to logic when finding the original licence for variation.