### PR TITLE
CVSL-2151 Condition 4a refactor

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/policies/PolicyV3.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/policies/PolicyV3.kt
@@ -290,7 +290,7 @@ val POLICY_V3 = LicencePolicy(
       AdditionalConditionAp(
         category = "Participation in, or co-operation with, a programme or set of activities",
         categoryShort = "Programmes or activities",
-        code = "89e656ec-77e8-4832-acc4-6ec05d3e9a98",
+        code = "df3f08a8-4ae0-41fe-b3bc-d0be1fd2d8aa",
         inputs = listOf(
           Input(
             label = "Select all that apply",
@@ -1164,7 +1164,7 @@ val POLICY_V3 = LicencePolicy(
           ),
         ),
         requiresInput = true,
-        text = "Attend a location, as directed by your supervising officer, to address your dependency on, or propensity to misuse, [A  CONTROLLED DRUG / ALCOHOL / SOLVENTS].",
+        text = "Attend a location, as directed by your supervising officer, to address your dependency on, or propensity to misuse, [A CONTROLLED DRUG / ALCOHOL / SOLVENTS].",
         tpl = "Attend a location, as directed by your supervising officer, to address your dependency on, or propensity to misuse, {substanceTypes}.",
         type = "SubstanceMisuse",
       ),
@@ -1438,6 +1438,13 @@ val POLICY_V3 = LicencePolicy(
       previousCode = "bb401b88-2137-4154-be4a-5e05c168638a",
       replacements = emptyList(),
     ),
+    ChangeHint(
+      previousCode = "89e656ec-77e8-4832-acc4-6ec05d3e9a98",
+      replacements = listOf(
+        "df3f08a8-4ae0-41fe-b3bc-d0be1fd2d8aa",
+        "f1d2888b-be86-4732-8874-44cb867865c2"
+      ),
+    )
   ),
   standardConditions = StandardConditions(
     standardConditionsAp = listOf(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/policies/PolicyV3.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/policies/PolicyV3.kt
@@ -1442,9 +1442,9 @@ val POLICY_V3 = LicencePolicy(
       previousCode = "89e656ec-77e8-4832-acc4-6ec05d3e9a98",
       replacements = listOf(
         "df3f08a8-4ae0-41fe-b3bc-d0be1fd2d8aa",
-        "f1d2888b-be86-4732-8874-44cb867865c2"
+        "f1d2888b-be86-4732-8874-44cb867865c2",
       ),
-    )
+    ),
   ),
   standardConditions = StandardConditions(
     standardConditionsAp = listOf(


### PR DESCRIPTION
Condition 4a has essentially had both a text change, and a split between the existing condition and a new condition.
We don't currently have functionality to handle a text change and split, so we instead decided it would be better to model it as a condition deletion and replacement by two new conditions.
This was approved by the policy team.