### PR TITLE
alee/CVSL-2266 fix errors when staff with teams search for offenders

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/ProbationSearchApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/ProbationSearchApiClient.kt
@@ -17,6 +17,7 @@ class ProbationSearchApiClient(@Qualifier("oauthProbationSearchApiClient") val p
     teamCodes: List<String>,
     sortBy: List<ProbationSearchSortByRequest> = emptyList(),
   ): List<CaseloadResult> {
+    if (teamCodes.isEmpty()) return emptyList()
     val sortOptions = sortBy.ifEmpty { listOf(ProbationSearchSortByRequest()) }
 
     val licenceCaseLoadRequestBody = LicenceCaseloadSearchRequest(
@@ -68,6 +69,7 @@ class ProbationSearchApiClient(@Qualifier("oauthProbationSearchApiClient") val p
   }
 
   fun getOffendersByCrn(crns: List<String?>): List<OffenderDetail> {
+    if (crns.isEmpty()) return emptyList()
     val response = probationSearchApiClient
       .post()
       .uri("/crns")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/ProbationSearchApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/probation/ProbationSearchApiClientTest.kt
@@ -1,0 +1,40 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.reset
+import org.mockito.kotlin.verifyNoInteractions
+import org.springframework.web.reactive.function.client.WebClient
+
+class ProbationSearchApiClientTest {
+
+  private val client = mock<WebClient>()
+  private val probationSearchApiClient = ProbationSearchApiClient(client)
+
+  @BeforeEach
+  fun reset() {
+    reset(client)
+  }
+
+  @Test
+  fun `search by teams endpoint not called if no teams`() {
+    probationSearchApiClient.searchLicenceCaseloadByTeam("query", emptyList())
+
+    verifyNoInteractions(client)
+  }
+
+  @Test
+  fun `search by noms number endpoint not called if no teams`() {
+    probationSearchApiClient.searchForPeopleByNomsNumber(emptyList())
+
+    verifyNoInteractions(client)
+  }
+
+  @Test
+  fun `get by CRN endpoint not called if no teams`() {
+    probationSearchApiClient.getOffendersByCrn(emptyList())
+
+    verifyNoInteractions(client)
+  }
+}


### PR DESCRIPTION
We could probably still do with some message to the user that they have no teams