### PR TITLE
CVSL-2329 replace LocalTime schema with string

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/config/OpenApiConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/config/OpenApiConfiguration.kt
@@ -3,10 +3,13 @@ package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.config
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.info.Contact
 import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.media.Schema
 import org.springdoc.core.models.GroupedOpenApi
+import org.springdoc.core.utils.SpringDocUtils
 import org.springframework.boot.info.BuildProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import java.time.LocalTime
 
 @Configuration
 class OpenApiConfiguration(buildProperties: BuildProperties) {
@@ -39,8 +42,7 @@ class OpenApiConfiguration(buildProperties: BuildProperties) {
   @Bean
   fun publicGroupedConfig(): GroupedOpenApi = GroupedOpenApi.builder()
     .group("public")
-    .addOpenApiCustomizer {
-        a ->
+    .addOpenApiCustomizer { a ->
       a.info(
         Info()
           .title("Create and Vary a Licence Public API")
@@ -57,8 +59,10 @@ class OpenApiConfiguration(buildProperties: BuildProperties) {
     .build()
 
   @Bean
-  fun customOpenAPI(): OpenAPI? = OpenAPI()
-    .info(
+  fun customOpenAPI(): OpenAPI {
+    SpringDocUtils.getConfig()
+      .replaceWithSchema(LocalTime::class.java, Schema<LocalTime>().type("string").format("HH:mm").example("00:00"))
+    return OpenAPI().info(
       Info()
         .title("Create and Vary a Licence API")
         .version(version)
@@ -69,4 +73,5 @@ class OpenApiConfiguration(buildProperties: BuildProperties) {
             .email("feedback@digital.justice.gov.uk"),
         ),
     )
+  }
 }


### PR DESCRIPTION
This PR is to fix a LocalTime issue where it was being unmarshalled as a string but as an object:

```
{
    "hour": 0,
    "minute": 0,
    "nano": 0,
    "second": 0
}
```
 The fix includes creating a new `Schema<LocalTime>` object, setting its type to "string", its format to "HH:mm", and providing an example value. Then I have replaced the default schema for `LocalTime` with this custom schema.
 
 Before:
 
![Screenshot 2024-12-18 at 09 57 18](https://github.com/user-attachments/assets/ea521370-361f-43a4-9cb8-4fd865b1f38a)

 After:

![Screenshot 2024-12-18 at 09 55 09](https://github.com/user-attachments/assets/8272423a-2cc9-44d5-b9ae-8b3e544226b8)

 