### PR TITLE
CVSL-2399 enabling scheduled downtime

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -24,6 +24,9 @@ generic-service:
     SELF_API_LINK: "https://create-and-vary-a-licence-api-dev.hmpps.service.justice.gov.uk"
     HARDSTOP_ENABLED: false
 
+  scheduledDowntime:
+    enabled: true
+
 # CloudPlatform AlertManager receiver to route promethues alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:

--- a/helm_deploy/values-test1.yaml
+++ b/helm_deploy/values-test1.yaml
@@ -27,6 +27,9 @@ generic-service:
     HARDSTOP_ENABLED: true
     POLICYV3_ENABLED: true
 
+  scheduledDowntime:
+    enabled: true
+
 # CloudPlatform AlertManager receiver to route promethues alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:

--- a/helm_deploy/values-test2.yaml
+++ b/helm_deploy/values-test2.yaml
@@ -26,6 +26,9 @@ generic-service:
     SELF_API_LINK: "https://create-and-vary-a-licence-api-test2.hmpps.service.justice.gov.uk"
     POLICYV3_ENABLED: true
 
+  scheduledDowntime:
+    enabled: true
+
 # CloudPlatform AlertManager receiver to route promethues alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:


### PR DESCRIPTION
This will shut down pods between 10pm - 6:30am UTC on weekdays and all day on weekends. 
6:30am was chosen as the RDS startup happens between 6am and 6:30am.