### PR TITLE
CVSL-2329 return null rather than null fields if no recorded curfew times

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/hdc/HdcLicenceData.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/hdc/HdcLicenceData.kt
@@ -6,5 +6,5 @@ data class HdcLicenceData(
   val licenceId: Long? = null,
   val curfewAddress: CurfewAddress? = null,
   val firstNightCurfewHours: FirstNight? = null,
-  val curfewTimes: List<HdcCurfewTimes?> = emptyList(),
+  val curfewTimes: List<HdcCurfewTimes>? = null,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/HdcServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/HdcServiceTest.kt
@@ -97,18 +97,18 @@ class HdcServiceTest {
   }
 
   @Test
-  fun `getHdcLicenceData returns HDC licence data successfully when there are no curfew times`() {
+  fun `getHdcLicenceData returns HDC licence data successfully when no recorded curfew times`() {
     whenever(licenceRepository.findById(1L)).thenReturn(Optional.of(aLicenceEntity))
     whenever(hdcApiClient.getByBookingId(54321L)).thenReturn(
       someHdcLicenceData.copy(
-        curfewTimes = emptyList(),
+        curfewTimes = null,
       ),
     )
     val result = service.getHdcLicenceData(1)
     assertThat(result).isNotNull
     assertThat(result?.curfewAddress).isEqualTo(aCurfewAddress)
     assertThat(result?.firstNightCurfewHours).isEqualTo(aSetOfFirstNightCurfewHours)
-    assertThat(result?.curfewTimes).isEmpty()
+    assertThat(result?.curfewTimes).isNull()
     verify(hdcApiClient, times(1)).getByBookingId(54321L)
   }
 


### PR DESCRIPTION
This PR is to match the output of the HDC API now that we are returning null when curfew times are not recorded rather than a list of null fields. 