### PR TITLE
CVSL-2269 Reverting changes affecting IS91 activation until after data fix

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/jobs/LicenceActivationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/jobs/LicenceActivationService.kt
@@ -59,7 +59,7 @@ class LicenceActivationService(
 
   private fun determineEligibleLicencesToActivate(licences: List<LicenceWithPrisoner>): Pair<List<Licence>, List<Licence>> {
     val (iS91Licences, standardLicences) = filterLicencesIntoTypes(licences)
-    val iS91LicencesToActivate = iS91Licences.filter { it.licence.licenceStartDate != null && it.licence.licenceStartDate!! <= LocalDate.now() }
+    val iS91LicencesToActivate = iS91Licences.filter { it.licence.isPassedIS91ReleaseDate() }
     val standardLicencesToActivate = standardLicences.filter { it.isStandardLicenceForActivation() }
     return Pair(iS91LicencesToActivate.map { it.licence }, standardLicencesToActivate.map { it.licence })
   }
@@ -69,6 +69,23 @@ class LicenceActivationService(
     val iS91RelatedIds = iS91DeterminationService.getIS91AndExtraditionBookingIds(prisoners)
     val (iS91AndExtraditionLicences, standardLicences) = licences.partition { iS91RelatedIds.contains(it.bookingId) }
     return Pair(iS91AndExtraditionLicences, standardLicences)
+  }
+
+  private fun Licence.isPassedIS91ReleaseDate(): Boolean {
+    val actualReleaseDate = this.actualReleaseDate
+    val conditionalReleaseDate = this.conditionalReleaseDate ?: return false
+
+    // If ARD within CRD minus 4 days and CRD (inclusive), use ARD
+    val releaseDate = if (actualReleaseDate != null &&
+      !actualReleaseDate.isBefore(conditionalReleaseDate.minusDays(4)) &&
+      !actualReleaseDate.isAfter(conditionalReleaseDate)
+    ) {
+      actualReleaseDate
+    } else {
+      conditionalReleaseDate
+    }
+
+    return releaseDate <= LocalDate.now()
   }
 
   private fun LicenceWithPrisoner.isStandardLicenceForActivation(): Boolean {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/jobs/LicenceActivationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/jobs/LicenceActivationServiceTest.kt
@@ -103,8 +103,15 @@ class LicenceActivationServiceTest {
   }
 
   @Test
-  fun `licence activation job calls for non-HDC, IS91 licences to be activated on LSD`() {
-    whenever(licenceRepository.getApprovedLicencesOnOrPassedReleaseDate()).thenReturn(listOf(aLicenceEntity))
+  fun `licence activation job calls for non-HDC, IS91 licences to be activated on CRD`() {
+    whenever(licenceRepository.getApprovedLicencesOnOrPassedReleaseDate()).thenReturn(
+      listOf(
+        aLicenceEntity.copy(
+          conditionalReleaseDate = LocalDate.now(),
+          actualReleaseDate = LocalDate.now().plusDays(10),
+        ),
+      ),
+    )
     whenever(prisonerSearchApiClient.searchPrisonersByBookingIds(setOf(aLicenceEntity.bookingId!!)))
       .thenReturn(listOf(aPrisonerSearchPrisoner))
     whenever(iS91DeterminationService.getIS91AndExtraditionBookingIds(listOf(aPrisonerSearchPrisoner)))


### PR DESCRIPTION
Realised that these changes would work for newly created IS91 licences, but would potentially break existing IS91 licences.
As such the logic is being reverted (it will continue to work for new IS91 licences), and can be reimplemented after the data-fix to recalculate LSDs has been performed.