### PR TITLE
CVSL-2269 Adding new LSD logic to COM caseload

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/caseload/ComCaseloadService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/caseload/ComCaseloadService.kt
@@ -127,9 +127,9 @@ class ComCaseloadService(
 
   fun mapOffendersToLicences(cases: List<ManagedCase>): List<ManagedCase> {
     val nomisIdList = cases.mapNotNull { offender -> offender.nomisRecord?.prisonerNumber }
-    val existingLicences: List<LicenceSummary> = findExistingLicences(nomisIdList)
+    val existingLicences = findExistingLicences(nomisIdList).groupBy { it.nomisId }
     val casesToLicences = cases.filter { it.nomisRecord != null }.associateWith {
-      existingLicences.filter { licence -> it.nomisRecord!!.prisonerNumber == licence.nomisId }
+      existingLicences[it.nomisRecord!!.prisonerNumber] ?: emptyList()
     }
     val licenceStartDates = getLicenceStartDates(casesToLicences)
 


### PR DESCRIPTION
Ensures that the release date is correctly calculated for NOT_STARTED cases.

Also changed logic to filter out cases without NOMIS records as they wouldn't be eligible for CVL anyway, and even if one did sneak through somehow, it would blow up on `LicenceType.getLicenceType(case.nomisRecord!!)`
This could _potentially_ impact post-release cases if something happened to the PoP's NOMIS record, but that would be an error case that arguably we shouldn't account for anyway.