### PR TITLE
CVSL-2483 change the licence activation job to allow HDC licences

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/jobs/LicenceActivationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/jobs/LicenceActivationService.kt
@@ -34,10 +34,7 @@ class LicenceActivationService(
     }
     val matchedLicences = prisonerSearchApiClient.searchPrisonersByBookingIds(potentialLicences.keys)
       .map { LicenceWithPrisoner(potentialLicences[it.bookingId?.toLong()]!!, it) }
-    println(matchedLicences)
     val (eligibleLicences, ineligibleLicences) = determineLicenceEligibility(matchedLicences)
-    println("Eligible licences: ${eligibleLicences.size}")
-    println("Ineligible licences: ${ineligibleLicences.size}")
     val (iS91licencesToActivate, standardLicencesToActivate) = determineEligibleLicencesToActivate(eligibleLicences)
 
     licenceService.activateLicences(iS91licencesToActivate, IS91_LICENCE_ACTIVATION)
@@ -47,10 +44,7 @@ class LicenceActivationService(
 
   private fun determineLicenceEligibility(matchedLicences: List<LicenceWithPrisoner>): Pair<List<LicenceWithPrisoner>, List<Licence>> {
     val approvedHdcBookingIds = findBookingsWithHdc(matchedLicences)
-    println("Approved HDC booking IDs: ${approvedHdcBookingIds.size}")
     val (ineligibleLicences, eligibleLicences) = matchedLicences.partition {
-      println(it.licence.kind)
-      println(approvedHdcBookingIds.contains(it.bookingId))
       if (approvedHdcBookingIds.contains(it.bookingId) && it.licence.kind === LicenceKind.HDC) {
         false
       } else {
@@ -65,9 +59,7 @@ class LicenceActivationService(
     val bookingsWithHdc = matchedLicences
       .filter { it.homeDetentionCurfewEligibilityDate != null }
       .map { it.bookingId }
-    println("Bookings with HDC: ${bookingsWithHdc.size}")
     val hdcStatuses = prisonApiClient.getHdcStatuses(bookingsWithHdc)
-    println(hdcStatuses.size)
     return hdcStatuses.filter { it.approvalStatus == "APPROVED" }.mapNotNull { it.bookingId }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/jobs/LicenceActivationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/jobs/LicenceActivationService.kt
@@ -34,8 +34,10 @@ class LicenceActivationService(
     }
     val matchedLicences = prisonerSearchApiClient.searchPrisonersByBookingIds(potentialLicences.keys)
       .map { LicenceWithPrisoner(potentialLicences[it.bookingId?.toLong()]!!, it) }
-
+    println(matchedLicences)
     val (eligibleLicences, ineligibleLicences) = determineLicenceEligibility(matchedLicences)
+    println("Eligible licences: ${eligibleLicences.size}")
+    println("Ineligible licences: ${ineligibleLicences.size}")
     val (iS91licencesToActivate, standardLicencesToActivate) = determineEligibleLicencesToActivate(eligibleLicences)
 
     licenceService.activateLicences(iS91licencesToActivate, IS91_LICENCE_ACTIVATION)
@@ -45,7 +47,10 @@ class LicenceActivationService(
 
   private fun determineLicenceEligibility(matchedLicences: List<LicenceWithPrisoner>): Pair<List<LicenceWithPrisoner>, List<Licence>> {
     val approvedHdcBookingIds = findBookingsWithHdc(matchedLicences)
+    println("Approved HDC booking IDs: ${approvedHdcBookingIds.size}")
     val (ineligibleLicences, eligibleLicences) = matchedLicences.partition {
+      println(it.licence.kind)
+      println(approvedHdcBookingIds.contains(it.bookingId))
       if (approvedHdcBookingIds.contains(it.bookingId) && it.licence.kind === LicenceKind.HDC) {
         false
       } else {
@@ -60,8 +65,9 @@ class LicenceActivationService(
     val bookingsWithHdc = matchedLicences
       .filter { it.homeDetentionCurfewEligibilityDate != null }
       .map { it.bookingId }
-
+    println("Bookings with HDC: ${bookingsWithHdc.size}")
     val hdcStatuses = prisonApiClient.getHdcStatuses(bookingsWithHdc)
+    println(hdcStatuses.size)
     return hdcStatuses.filter { it.approvalStatus == "APPROVED" }.mapNotNull { it.bookingId }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/jobs/LicenceActivationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/jobs/LicenceActivationService.kt
@@ -44,11 +44,18 @@ class LicenceActivationService(
 
   private fun determineLicenceEligibility(matchedLicences: List<LicenceWithPrisoner>): Pair<List<LicenceWithPrisoner>, List<Licence>> {
     val approvedHdcBookingIds = findBookingsWithHdc(matchedLicences)
-    val (ineligibleLicences, eligibleLicences) = matchedLicences.partition {
+
+    // Filter out HDC licences that have not been approved for HDC as we don't want to deactivate them for MVP1
+    val filteredLicences =
+      matchedLicences.filterNot {
+        it.licence.kind === LicenceKind.HDC && !approvedHdcBookingIds.contains(it.bookingId)
+      }
+
+    val (eligibleLicences, ineligibleLicences) = filteredLicences.partition {
       if (approvedHdcBookingIds.contains(it.bookingId) && it.licence.kind === LicenceKind.HDC) {
-        false
+        true
       } else {
-        approvedHdcBookingIds.contains(it.bookingId)
+        !approvedHdcBookingIds.contains(it.bookingId)
       }
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/jobs/LicenceActivationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/jobs/LicenceActivationService.kt
@@ -9,7 +9,7 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.LicenceServ
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.prison.PrisonApiClient
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.prison.PrisonerSearchApiClient
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.prison.PrisonerSearchPrisoner
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceKind
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceKind.HDC
 import java.time.LocalDate
 
 data class LicenceWithPrisoner(val licence: Licence, val prisoner: PrisonerSearchPrisoner) {
@@ -48,15 +48,12 @@ class LicenceActivationService(
     // Filter out HDC licences that have not been approved for HDC as we don't want to deactivate them for MVP1
     val filteredLicences =
       matchedLicences.filterNot {
-        it.licence.kind === LicenceKind.HDC && !approvedHdcBookingIds.contains(it.bookingId)
+        it.licence.kind == HDC && !approvedHdcBookingIds.contains(it.bookingId)
       }
 
     val (eligibleLicences, ineligibleLicences) = filteredLicences.partition {
-      if (approvedHdcBookingIds.contains(it.bookingId) && it.licence.kind === LicenceKind.HDC) {
-        true
-      } else {
-        !approvedHdcBookingIds.contains(it.bookingId)
-      }
+      val approvedForHdc = approvedHdcBookingIds.contains(it.bookingId)
+      (it.licence.kind == HDC && approvedForHdc) || !approvedForHdc
     }
 
     return Pair(eligibleLicences, ineligibleLicences.map { it.licence })

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/LicenceActivationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/LicenceActivationIntegrationTest.kt
@@ -45,7 +45,7 @@ class LicenceActivationIntegrationTest : IntegrationTestBase() {
       .expectStatus().isOk
 
     argumentCaptor<HMPPSDomainEvent>().apply {
-      verify(eventsPublisher, times(7)).publishDomainEvent(capture())
+      verify(eventsPublisher, times(8)).publishDomainEvent(capture())
 
       assertThat(allValues).extracting<Tuple> { tuple(it.eventType, it.additionalInformation?.licenceId) }
         .containsExactly(
@@ -53,6 +53,7 @@ class LicenceActivationIntegrationTest : IntegrationTestBase() {
           tuple(LICENCE_ACTIVATED.value, "2"),
           tuple(LICENCE_ACTIVATED.value, "3"),
           tuple(LICENCE_ACTIVATED.value, "7"),
+          tuple(LICENCE_ACTIVATED.value, "8"),
           tuple(LICENCE_INACTIVATED.value, "4"),
           tuple(LICENCE_INACTIVATED.value, "5"),
           tuple(LICENCE_INACTIVATED.value, "6"),
@@ -68,7 +69,7 @@ class LicenceActivationIntegrationTest : IntegrationTestBase() {
       .expectBodyList(LicenceSummary::class.java)
       .returnResult().responseBody
 
-    assertThat(activatedLicences?.size).isEqualTo(4)
+    assertThat(activatedLicences?.size).isEqualTo(5)
     assertThat(activatedLicences)
       .extracting<Tuple> {
         tuple(it.licenceId, it.licenceStatus)
@@ -78,6 +79,7 @@ class LicenceActivationIntegrationTest : IntegrationTestBase() {
         tuple(2L, LicenceStatus.ACTIVE),
         tuple(3L, LicenceStatus.ACTIVE),
         tuple(7L, LicenceStatus.ACTIVE),
+        tuple(8L, LicenceStatus.ACTIVE),
       )
 
     val deactivatedLicences = webTestClient.post()
@@ -114,6 +116,7 @@ class LicenceActivationIntegrationTest : IntegrationTestBase() {
       govUkMockServer.start()
       prisonerSearchMockServer.stubSearchPrisonersByBookingIds()
       prisonApiMockServer.stubGetCourtOutcomes()
+      prisonApiMockServer.getHdcStatuses()
       govUkMockServer.stubGetBankHolidaysForEnglandAndWales()
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/wiremock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/wiremock/PrisonApiMockServer.kt
@@ -68,6 +68,11 @@ class PrisonApiMockServer : WireMockServer(8091) {
                {
                   "bookingId": "789",
                   "passed": true
+               },
+               {
+                  "bookingId": "123",
+                  "approvalStatus": "APPROVED",
+                  "passed": false
                }
               ]
             """.trimIndent(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/wiremock/PrisonerSearchMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/wiremock/PrisonerSearchMockServer.kt
@@ -69,7 +69,21 @@ class PrisonerSearchMockServer : WireMockServer(8099) {
                   "firstName": "Test4",
                   "lastName": "Person4",
                   "dateOfBirth": "1987-01-01"
-               }
+               },
+               {
+                  "prisonerNumber": "G1234BB",
+                  "bookingId": "123",
+                  "status": "INACTIVE",
+                  "legalStatus": "SENTENCED",
+                  "indeterminateSentence": false,
+                  "recall": false,
+                  "prisonId": "GHI",
+                  "bookNumber": "54321D",
+                  "firstName": "Test5",
+                  "lastName": "Person5",
+                  "dateOfBirth": "1988-01-01",
+                  "homeDetentionCurfewEligibilityDate": "${LocalDate.now().plusDays(1)}"
+              }
               ]
             """.trimIndent(),
           ).withStatus(200),
@@ -79,8 +93,7 @@ class PrisonerSearchMockServer : WireMockServer(8099) {
 
   fun nextWorkingDate() = nextWorkingDates().first()
 
-  private fun nextWorkingDates(): Sequence<LocalDate> =
-    generateSequence(LocalDate.now()) { it.plusDays(1) }.filterNot { setOf(SATURDAY, SUNDAY).contains(it.dayOfWeek) }
+  private fun nextWorkingDates(): Sequence<LocalDate> = generateSequence(LocalDate.now()) { it.plusDays(1) }.filterNot { setOf(SATURDAY, SUNDAY).contains(it.dayOfWeek) }
 
   fun stubSearchPrisonersByNomisIds(prisonerSearchResponse: String? = null) {
     val json = prisonerSearchResponse ?: """[

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/jobs/LicenceActivationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/jobs/LicenceActivationServiceTest.kt
@@ -160,7 +160,7 @@ class LicenceActivationServiceTest {
   }
 
   @Test
-  fun `licence activation job calls for non-IS91 non licences with HDC (not approved) to be activated on their LSD if the offender has been released`() {
+  fun `licence activation job calls for non-IS91 licences with HDC (not approved) to be activated on their LSD if the offender has been released`() {
     whenever(licenceRepository.getApprovedLicencesOnOrPassedReleaseDate()).thenReturn(listOf(aLicenceEntity))
 
     whenever(prisonerSearchApiClient.searchPrisonersByBookingIds(setOf(aLicenceEntity.bookingId!!)))

--- a/src/test/resources/test_data/seed-licences-for-activation.sql
+++ b/src/test/resources/test_data/seed-licences-for-activation.sql
@@ -16,5 +16,6 @@ values (1, 'CRD', '1.0', 1, 1, 'AP', 'G7285UT', 'APPROVED', 456, current_date, '
        (4, 'CRD', '1.0', 1, 1, 'AP', 'G7285UT', 'IN_PROGRESS', 456, current_date, '1.1', 1),
        (5, 'CRD', '1.0', 1, 1, 'AP', 'G4169UO', 'SUBMITTED', 432, current_date, '1.1', 3),
        (6, 'CRD', '1.0', 1, 1, 'AP', 'G7285AA', 'TIMED_OUT', 521, current_date, '1.0', null),
-       (7, 'HARD_STOP', '1.0', 1, 1, 'AP', 'G7285AA', 'APPROVED', 521, current_date, '1.0', null)
+       (7, 'HARD_STOP', '1.0', 1, 1, 'AP', 'G7285AA', 'APPROVED', 521, current_date, '1.0', null),
+       (8, 'HDC', '1.0', 1, 1, 'AP', 'G1234BB', 'APPROVED', 123, current_date, '1.0', null)
 ;


### PR DESCRIPTION
This PR is to change the logic in the `LicenceActivationService` to activate HDC licences when they are approved and to not deactivate HDC licences at CRD.  @SebNegahbanMoJ's work around the LSD means that for HDC licences, the LSD will be the HDCAD so now at LSD:
- The job will check the HDC status in NOMIS (as before)
- If HDC is approved and the licence being potentially activated is a HDC licence, we activate as normal (new logic)
- If HDC is approved and there is any other kind of licence, they are not made active. (as before)
- The HDC licence will not be deactivated at LSD if the HDC approval status has changed in HDC. (new logic)