### PR TITLE
CVSL-2647 Removing past PED check from new licence start date calculations

### DIFF
--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -2,8 +2,6 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
-    <ID>ComplexCondition:ReleaseDateService.kt$ReleaseDateService$ALT_OUTCOME_CODES.contains(it.legalStatus) || it.paroleEligibilityDate != null &amp;&amp; it.paroleEligibilityDate.isBefore(LocalDate.now()) || iS91BookingIds.contains(it.bookingId?.toLong())</ID>
-    <ID>ComplexCondition:ReleaseDateService.kt$ReleaseDateService$ALT_OUTCOME_CODES.contains(nomisRecord.legalStatus) || nomisRecord.paroleEligibilityDate != null &amp;&amp; nomisRecord.paroleEligibilityDate.isBefore(LocalDate.now()) || iS91DeterminationService.isIS91Case(nomisRecord)</ID>
     <ID>ForbiddenComment:HdcService.kt$HdcService.HdcStatuses$* For CA: * Always show started cases regardless of HDC status. * TODO: will need to fix when we start to show prospective HDC cases in caselist * If licence hasn't been started, only show !approved licences.</ID>
     <ID>ForbiddenComment:HdcService.kt$HdcService.HdcStatuses$* For COM: * If licence hasn't been started base on whether licence is approved. * TODO: will need to fix when we start to show prospective HDC cases in caselist * If licence has been started then show when (approved and HDC) or (!approved and !hdc)</ID>
     <ID>LargeClass:LicenceController.kt$LicenceController</ID>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ReleaseDateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ReleaseDateService.kt
@@ -103,8 +103,6 @@ class ReleaseDateService(
     nomisRecord.homeDetentionCurfewActualDate
   } else if (
     ALT_OUTCOME_CODES.contains(nomisRecord.legalStatus) ||
-    nomisRecord.paroleEligibilityDate != null &&
-    nomisRecord.paroleEligibilityDate.isBefore(LocalDate.now()) ||
     iS91DeterminationService.isIS91Case(nomisRecord)
   ) {
     nomisRecord.determineAltLicenceStartDate()
@@ -118,8 +116,6 @@ class ReleaseDateService(
     return prisoners.associate {
       it.prisonerNumber to if (
         ALT_OUTCOME_CODES.contains(it.legalStatus) ||
-        it.paroleEligibilityDate != null &&
-        it.paroleEligibilityDate.isBefore(LocalDate.now()) ||
         iS91BookingIds.contains(it.bookingId?.toLong())
       ) {
         it.determineAltLicenceStartDate()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ReleaseDateServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/ReleaseDateServiceTest.kt
@@ -922,17 +922,6 @@ class ReleaseDateServiceTest {
       }
 
       @Test
-      fun `returns null if there is no CRD when PED is in the past`() {
-        val nomisRecord = prisonerSearchResult().copy(
-          paroleEligibilityDate = LocalDate.of(2020, 1, 1),
-          conditionalReleaseDate = null,
-          confirmedReleaseDate = LocalDate.of(2021, 10, 21),
-        )
-
-        assertThat(service.getLicenceStartDate(nomisRecord)).isNull()
-      }
-
-      @Test
       fun `returns null if there is no CRD when it is an IS91 case`() {
         val nomisRecord = prisonerSearchResult().copy(
           conditionalReleaseDate = null,
@@ -949,17 +938,6 @@ class ReleaseDateServiceTest {
       fun `returns the CRD if the ARD is null when the legal status is one of note`(legalStatus: String) {
         val nomisRecord = prisonerSearchResult().copy(
           legalStatus = legalStatus,
-          conditionalReleaseDate = LocalDate.of(2021, 10, 22),
-          confirmedReleaseDate = null,
-        )
-
-        assertThat(service.getLicenceStartDate(nomisRecord)).isEqualTo(LocalDate.of(2021, 10, 22))
-      }
-
-      @Test
-      fun `returns the CRD if the ARD is null when PED is in the past`() {
-        val nomisRecord = prisonerSearchResult().copy(
-          paroleEligibilityDate = LocalDate.of(2020, 1, 1),
           conditionalReleaseDate = LocalDate.of(2021, 10, 22),
           confirmedReleaseDate = null,
         )
@@ -992,17 +970,6 @@ class ReleaseDateServiceTest {
       }
 
       @Test
-      fun `returns the CRD if the ARD is before the CRD when PED is in the past`() {
-        val nomisRecord = prisonerSearchResult().copy(
-          paroleEligibilityDate = LocalDate.of(2020, 1, 1),
-          conditionalReleaseDate = LocalDate.of(2021, 10, 22),
-          confirmedReleaseDate = LocalDate.of(2021, 10, 21),
-        )
-
-        assertThat(service.getLicenceStartDate(nomisRecord)).isEqualTo(LocalDate.of(2021, 10, 22))
-      }
-
-      @Test
       fun `returns the CRD if the ARD is before the CRD when it is an IS91 case`() {
         val nomisRecord = prisonerSearchResult().copy(
           conditionalReleaseDate = LocalDate.of(2021, 10, 22),
@@ -1019,17 +986,6 @@ class ReleaseDateServiceTest {
       fun `returns the CRD if the ARD is after the CRD when the legal status is one of note`(legalStatus: String) {
         val nomisRecord = prisonerSearchResult().copy(
           legalStatus = legalStatus,
-          conditionalReleaseDate = LocalDate.of(2021, 10, 22),
-          confirmedReleaseDate = LocalDate.of(2021, 10, 23),
-        )
-
-        assertThat(service.getLicenceStartDate(nomisRecord)).isEqualTo(LocalDate.of(2021, 10, 22))
-      }
-
-      @Test
-      fun `returns the CRD if the ARD is after the CRD when PED is in the past`() {
-        val nomisRecord = prisonerSearchResult().copy(
-          paroleEligibilityDate = LocalDate.of(2020, 1, 1),
           conditionalReleaseDate = LocalDate.of(2021, 10, 22),
           confirmedReleaseDate = LocalDate.of(2021, 10, 23),
         )
@@ -1064,17 +1020,6 @@ class ReleaseDateServiceTest {
       }
 
       @Test
-      fun `returns last working day before CRD if CRD is a bank holiday or weekend when PED is in the past`() {
-        val nomisRecord = prisonerSearchResult().copy(
-          paroleEligibilityDate = LocalDate.of(2020, 1, 1),
-          conditionalReleaseDate = LocalDate.of(2018, 12, 4),
-          confirmedReleaseDate = null,
-        )
-
-        assertThat(service.getLicenceStartDate(nomisRecord)).isEqualTo(LocalDate.of(2018, 11, 30))
-      }
-
-      @Test
       fun `returns last working day before CRD if CRD is a bank holiday or weekend when it is an IS91 case`() {
         val nomisRecord = prisonerSearchResult().copy(
           conditionalReleaseDate = LocalDate.of(2018, 12, 4),
@@ -1093,17 +1038,6 @@ class ReleaseDateServiceTest {
       ) {
         val nomisRecord = prisonerSearchResult().copy(
           legalStatus = legalStatus,
-          conditionalReleaseDate = LocalDate.of(2018, 12, 4),
-          confirmedReleaseDate = LocalDate.of(2018, 11, 29),
-        )
-
-        assertThat(service.getLicenceStartDate(nomisRecord)).isEqualTo(LocalDate.of(2018, 11, 30))
-      }
-
-      @Test
-      fun `returns last working day before CRD if CRD is a bank holiday or weekend and the ARD is too early when PED is in the past`() {
-        val nomisRecord = prisonerSearchResult().copy(
-          paroleEligibilityDate = LocalDate.of(2020, 1, 1),
           conditionalReleaseDate = LocalDate.of(2018, 12, 4),
           confirmedReleaseDate = LocalDate.of(2018, 11, 29),
         )
@@ -1138,17 +1072,6 @@ class ReleaseDateServiceTest {
       }
 
       @Test
-      fun `returns ARD when the CRD and ARD are the same non-working day and PED is in the past`() {
-        val nomisRecord = prisonerSearchResult().copy(
-          paroleEligibilityDate = LocalDate.of(2020, 1, 1),
-          conditionalReleaseDate = LocalDate.of(2021, 12, 4),
-          confirmedReleaseDate = LocalDate.of(2021, 12, 4),
-        )
-
-        assertThat(service.getLicenceStartDate(nomisRecord)).isEqualTo(LocalDate.of(2021, 12, 4))
-      }
-
-      @Test
       fun `returns ARD when the CRD and ARD are the same non-working day and it is an IS91 case`() {
         val nomisRecord = prisonerSearchResult().copy(
           conditionalReleaseDate = LocalDate.of(2021, 12, 4),
@@ -1167,17 +1090,6 @@ class ReleaseDateServiceTest {
       ) {
         val nomisRecord = prisonerSearchResult().copy(
           legalStatus = legalStatus,
-          conditionalReleaseDate = LocalDate.of(2021, 12, 4),
-          confirmedReleaseDate = LocalDate.of(2021, 12, 3),
-        )
-
-        assertThat(service.getLicenceStartDate(nomisRecord)).isEqualTo(LocalDate.of(2021, 12, 3))
-      }
-
-      @Test
-      fun `returns ARD when the CRD is a non-working day and the ARD is an earlier non-working day and PED is in the past`() {
-        val nomisRecord = prisonerSearchResult().copy(
-          paroleEligibilityDate = LocalDate.of(2020, 1, 1),
           conditionalReleaseDate = LocalDate.of(2021, 12, 4),
           confirmedReleaseDate = LocalDate.of(2021, 12, 3),
         )


### PR DESCRIPTION
The past PED check has resulted in several support issues reporting that the LSD has been calculated incorrectly.

From discussing with Laura, we believe that any cases intended to be caught by this check would also have an APD, which would make them ineligible for CVL. As such, this check is redundant and is causing issues for users, so is being removed.