### PR TITLE
CVSL-2596 change model to include county and adjust names of variables

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/hdc/CurfewAddress.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/hdc/CurfewAddress.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.hdc
 data class CurfewAddress(
   val addressLine1: String,
   val addressLine2: String? = null,
-  val addressTown: String,
-  val postCode: String,
+  val townOrCity: String,
+  val county: String? = null,
+  val postcode: String,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/HdcIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/HdcIntegrationTest.kt
@@ -48,6 +48,7 @@ class HdcIntegrationTest : IntegrationTestBase() {
           "123 Test Street",
           null,
           "Test Area",
+          null,
           "AB1 2CD",
         ),
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/wiremock/HdcApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/wiremock/HdcApiMockServer.kt
@@ -15,8 +15,9 @@ class HdcApiMockServer : WireMockServer(8100) {
             "curfewAddress": {
               "addressLine1": "123 Test Street",
               "addressLine2": null,
-              "addressTown": "Test Area",
-              "postCode": "AB1 2CD"
+              "townOrCity": "Test Area",
+              "county": null,
+              "postcode": "AB1 2CD"
             },
             "firstNightCurfewHours": {
               "firstNightFrom": "15:00",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/HdcServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/HdcServiceTest.kt
@@ -302,6 +302,7 @@ class HdcServiceTest {
       "1 Test Street",
       "Test Area",
       "Test Town",
+      null,
       "AB1 2CD",
     )
 


### PR DESCRIPTION
This PR is to adjust the model which returns a curfew address from the HDC API. This is to match what will be from the HDC API for curfew addresses.