### PR TITLE
Update data extractor to latest

### DIFF
--- a/helm_deploy/create-and-vary-a-licence-api/templates/cronjob-data-extractor-analytics.yaml
+++ b/helm_deploy/create-and-vary-a-licence-api/templates/cronjob-data-extractor-analytics.yaml
@@ -12,7 +12,7 @@ spec:
           restartPolicy: "Never"
           containers:
             - name: data-extractor-analytics
-              image: ministryofjustice/data-engineering-data-extractor:v1
+              image: ministryofjustice/data-engineering-data-extractor:sha-b84888b
               imagePullPolicy: Always
               args: ["extract_table_names.py && mv ./export/metadata/database_name=meta/table_name=db_and_table_list/$(ls ./export/metadata/database_name=meta/table_name=db_and_table_list/)/db_and_table_list.yaml . && grep -v additional_condition_upload_detail db_and_table_list.yaml > temp.yaml && cp temp.yaml ./export/metadata/database_name=meta/table_name=db_and_table_list/$(ls ./export/metadata/database_name=meta/table_name=db_and_table_list/)/db_and_table_list.yaml && extract_psql_all_tables_to_csv.sh && transfer_local_to_s3.sh"]
               env:


### PR DESCRIPTION
We had a critical alert from dependabot in the data extractor repository which required us to bump a few dependencies and create a new release. This PR bumps the data extractor to the latest release. We've tested this with the calculate-release-dates service and it worked without issue. Hope this is ok - happy to discuss. Thanks!