### PR TITLE
CVSL-3048 Improved integration db connection times

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/config/PostgresContainer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/config/PostgresContainer.kt
@@ -34,6 +34,14 @@ object PostgresContainer {
       withUsername(DB_USERNAME)
       withPassword(DB_PASSWORD)
       setWaitStrategy(Wait.forListeningPort())
+      // Postgres tuning for faster startup & better test concurrency
+      withCommand(
+        "postgres",
+        "-c", "max_connections=20",
+        "-c", "fsync=off",
+        "-c", "synchronous_commit=off",
+        "-c", "full_page_writes=off",
+      )
       withReuse(true)
       withTmpFs(mapOf("/var/lib/postgresql/data" to "rw"))
       start()

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -14,8 +14,8 @@ spring:
   datasource:
     hikari:
       pool-name: CVL-CP
-      maximum-pool-size: 4
-      minimum-idle: 0
+      maximum-pool-size: 10
+      minimum-idle: 2
       idle-timeout: 10000           # 10 seconds
       max-lifetime: 30000           # 30 seconds
       connection-timeout: 2000      # 2 seconds


### PR DESCRIPTION
Old time:
`SUCCESS: Executed 225 tests in 3m 4s (1 skipped)`
New Time:
`SUCCESS: Executed 225 tests in 2m 22s (1 skipped)`
