### PR TITLE
CVSL-3022: Perform document migration as cron job

### DIFF
--- a/helm_deploy/create-and-vary-a-licence-api/values.yaml
+++ b/helm_deploy/create-and-vary-a-licence-api/values.yaml
@@ -130,3 +130,9 @@ jobs:
     path: /notify-probation-of-unapproved-licences
     cron: "0 2 * * *" # 2am every day
     allowRetry: false
+
+  - name: documents-migration-job
+    enabled: true
+    path: /migrate-exclusion-zone-maps?batchSize=25
+    cron: "*/1 * * * *" # every 1 minute
+    allowRetry: false


### PR DESCRIPTION
It is proving impractical to manually run the document migration job myself, so the plan is to have cron schedule the job for me every minute. Running in batches of 25 (25 per record type, 50 total per batch) which is the number I have landed on through testing in preprod. Any larger and the request times out or fails. Also it provides a natural pause in the requests to not DDoS the document service.

AdditionalConditionUploadSummary has a total of 44617 docs to migrate, which is 1785 batches of 25 run every minute, so will therefore take 1 Day, 5 Hours and 45 Minutes to migrate

AdditionalConditionUploadDetail has a total of 49405 docs to migrate, which is 1977 batches of 25 run every minute, so will therefore take 1 Day, 8 Hours and 57 Minutes to migrate

No better time to start than to start now!!

Job enabled in preprod and prod (there are no docs to migrate in dev)

When the logs say that there are 0 docs being migrated then we can delete this job