### PR TITLE
CVSL-3137 Making NOT_STARTED hard stop cases redirect to PRISON_WILL_CREATE_THIS_LICENCE

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/caseload/ComCreateCaseloadService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/caseload/ComCreateCaseloadService.kt
@@ -158,7 +158,7 @@ class ComCreateCaseloadService(
   private fun findHardStopLicenceToDisplay(licences: List<CaseLoadLicenceSummary>): CaseLoadLicenceSummary {
     val hardStopLicence = licences.find { it.kind == LicenceKind.HARD_STOP }!!
 
-    if (hardStopLicence.licenceStatus == IN_PROGRESS) {
+    if (hardStopLicence.licenceId == null || hardStopLicence.licenceStatus == IN_PROGRESS) {
       return hardStopLicence.copy(
         licenceStatus = TIMED_OUT,
         licenceCreationType = LicenceCreationType.PRISON_WILL_CREATE_THIS_LICENCE,


### PR DESCRIPTION
licenceId is null when the case is `NOT_STARTED`, as the "licence" being referenced is a pre-creation placeholder.