### PR TITLE
CVLS-3022: Unschedule document migration job

### DIFF
--- a/helm_deploy/create-and-vary-a-licence-api/values.yaml
+++ b/helm_deploy/create-and-vary-a-licence-api/values.yaml
@@ -130,9 +130,3 @@ jobs:
     path: /notify-probation-of-unapproved-licences
     cron: "0 2 * * *" # 2am every day
     allowRetry: false
-
-  - name: documents-migration-job
-    enabled: true
-    path: /migrate-exclusion-zone-maps?batchSize=25
-    cron: "*/1 * * * *" # every 1 minute
-    allowRetry: false


### PR DESCRIPTION
The migration has finished on both pre-prod and prod so the job just runs, finds nothing and ends.
This removes the job from cron as it doesn't need to run on a schedule anymore.