### PR TITLE
A error started happening in test, it was not happening earlier in mo…

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/OffenderIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/OffenderIntegrationTest.kt
@@ -1,12 +1,15 @@
 package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.integration
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.test.context.jdbc.Sql
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.config.ErrorResponse
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.integration.wiremock.GovUkMockServer
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.UpdateComRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.request.UpdateProbationTeamRequest
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.LicenceRepository
@@ -54,6 +57,7 @@ class OffenderIntegrationTest : IntegrationTestBase() {
     "classpath:test_data/seed-licence-id-1.sql",
   )
   fun `Update an offender's inflight licences with new COM details`() {
+    // Given
     val requestBody = UpdateComRequest(
       staffIdentifier = 2000,
       staffUsername = "test-client",
@@ -61,14 +65,18 @@ class OffenderIntegrationTest : IntegrationTestBase() {
       firstName = "Joseph",
       lastName = "Bloggs",
     )
+    govUkApiMockServer.stubGetBankHolidaysForEnglandAndWales()
 
-    webTestClient.put()
+    // When
+    val result = webTestClient.put()
       .uri("/offender/crn/CRN1/responsible-com")
       .bodyValue(requestBody)
       .accept(MediaType.APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf("ROLE_CVL_ADMIN")))
       .exchange()
-      .expectStatus().isOk
+
+    // Then
+    result.expectStatus().isOk
 
     val licence = licenceRepository.findById(1L).orElseThrow()
     assertThat(licence.responsibleCom)
@@ -101,5 +109,21 @@ class OffenderIntegrationTest : IntegrationTestBase() {
     assertThat(licence.probationPduCode).isEqualTo("PDU2")
     assertThat(licence.probationLauCode).isEqualTo("LAU2")
     assertThat(licence.probationTeamCode).isEqualTo("TEAM2")
+  }
+
+  private companion object {
+    val govUkApiMockServer = GovUkMockServer()
+
+    @JvmStatic
+    @BeforeAll
+    fun startMocks() {
+      govUkApiMockServer.start()
+    }
+
+    @JvmStatic
+    @AfterAll
+    fun stopMocks() {
+      govUkApiMockServer.stop()
+    }
   }
 }


### PR DESCRIPTION
A error started happening in a test locally, it was not happening earlier in morning, I took the code back a week it is still happening. The test should never have worked. Because the licence start date was based on `current_date` from postgres `see seed-licence-id-1.sql`.
```
      val releaseDate = inProgressLicence.licenceStartDate
      if (releaseDateService.isLateAllocationWarningRequired(releaseDate)) {  
```
wonder if this is a DB thing and `current_date` is behaving differently locally.

These tests pass on CI 
