### PR TITLE
CVSL-3195 Hibernate update - pre cursor change for conditions variati…

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/entity/AdditionalCondition.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/entity/AdditionalCondition.kt
@@ -53,7 +53,7 @@ data class AdditionalCondition(
   )
   @Fetch(FetchMode.SUBSELECT)
   @OrderBy("id")
-  val additionalConditionUploadSummary: List<AdditionalConditionUploadSummary> = emptyList(),
+  val additionalConditionUploadSummary: MutableList<AdditionalConditionUploadSummary> = mutableListOf(),
 ) {
 
   override fun toString(): String = "AdditionalCondition(" +

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/entity/AdditionalConditionUploadSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/entity/AdditionalConditionUploadSummary.kt
@@ -22,7 +22,7 @@ data class AdditionalConditionUploadSummary(
 
   @ManyToOne
   @JoinColumn(name = "additional_condition_id", nullable = false)
-  val additionalCondition: AdditionalCondition,
+  var additionalCondition: AdditionalCondition,
 
   val filename: String? = null,
 
@@ -44,7 +44,7 @@ data class AdditionalConditionUploadSummary(
   val thumbnailImageDsUuid: String? = null,
 
   @param:NotNull
-  val uploadDetailId: Long,
+  var uploadDetailId: Long,
 ) {
 
   @Transient

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceService.kt
@@ -916,7 +916,7 @@ class LicenceService(
           conditionSummary.copy(
             id = null,
           )
-        },
+        }.toMutableList(),
       )
     }
 
@@ -933,7 +933,7 @@ class LicenceService(
           uploadDetail.copy(id = null, licenceId = newLicence.id, additionalConditionId = condition.id!!)
         uploadDetail = additionalConditionUploadDetailRepository.save(uploadDetail)
         it.copy(additionalCondition = condition, uploadDetailId = uploadDetail.id!!)
-      }
+      }.toMutableList()
 
       condition.copy(
         additionalConditionData = updatedAdditionalConditionData.toMutableList(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/conditions/ExclusionZoneService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/conditions/ExclusionZoneService.kt
@@ -81,7 +81,7 @@ class ExclusionZoneService(
       uploadDetailId = savedDetail.id!!,
     )
 
-    val updatedAdditionalCondition = additionalCondition.copy(additionalConditionUploadSummary = listOf(uploadSummary))
+    val updatedAdditionalCondition = additionalCondition.copy(additionalConditionUploadSummary = mutableListOf(uploadSummary))
 
     additionalConditionRepository.saveAndFlush(updatedAdditionalCondition)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/LicenceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/LicenceIntegrationTest.kt
@@ -364,7 +364,7 @@ class LicenceIntegrationTest : IntegrationTestBase() {
   @Sql(
     "classpath:test_data/seed-variation-licence-id-1-inPssPeriod.sql",
   )
-  fun `Create licence variation when in pss period excludes bespoke conditions`() {
+  fun `Create licence variation when in pss period then exclude bespoke conditions`() {
     // Given
     val uri = "/licence/id/1/create-variation"
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/LicenceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/LicenceIntegrationTest.kt
@@ -334,11 +334,11 @@ class LicenceIntegrationTest : IntegrationTestBase() {
     assertThat(licenceRepository.count()).isEqualTo(2)
 
     val newLicence = licenceRepository.findById(licenceSummary.licenceId).getOrNull()
-    assertThat(newLicence!!).isNotNull
+    assertThat(newLicence).isNotNull
     val oldLicence = licenceRepository.findById(licenceSummary.licenceId - 1).getOrNull()
-    assertThat(oldLicence!!).isNotNull
+    assertThat(oldLicence).isNotNull
 
-    assertThat(newLicence.licenceVersion).isEqualTo("2.0")
+    assertThat(newLicence!!.licenceVersion).isEqualTo("2.0")
     assertThat(newLicence.appointmentAddress).isEqualTo("123 Test Street,Apt 4B,Testville,Testshire,TE5 7AA")
 
     assertThat(newLicence).isInstanceOf(EntityVariationLicence::class.java)
@@ -347,7 +347,7 @@ class LicenceIntegrationTest : IntegrationTestBase() {
     assertThat(newLicence.variationOfId).isEqualTo(1)
     assertThat(newLicence.licenceVersion).isEqualTo("2.0")
 
-    assertThat(newLicence.standardConditions.size).isEqualTo(oldLicence.standardConditions.size)
+    assertThat(newLicence.standardConditions.size).isEqualTo(oldLicence!!.standardConditions.size)
     assertThat(newLicence.additionalConditions.size).isEqualTo(oldLicence.additionalConditions.size)
     assertThat(newLicence.bespokeConditions.size).isEqualTo(oldLicence.bespokeConditions.size)
 
@@ -358,6 +358,28 @@ class LicenceIntegrationTest : IntegrationTestBase() {
     assertListsEqual(newLicence.standardConditions, oldLicence.standardConditions)
     assertListsEqual(newLicence.additionalConditions, oldLicence.additionalConditions)
     assertListsEqual(newLicence.bespokeConditions, oldLicence.bespokeConditions)
+  }
+
+  @Test
+  @Sql(
+    "classpath:test_data/seed-variation-licence-id-1-inPssPeriod.sql",
+  )
+  fun `Create licence variation when in pss period excludes bespoke conditions`() {
+    // Given
+    val uri = "/licence/id/1/create-variation"
+
+    // When
+    val result = postRequest(uri)
+
+    // Then
+    result.expectStatus().isOk
+
+    val licenceSummary = result.expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(LicenceSummary::class.java)
+      .returnResult().responseBody
+
+    val newLicence = licenceRepository.findById(licenceSummary!!.licenceId).getOrNull()
+    assertThat(newLicence!!.bespokeConditions.size).isEqualTo(0)
   }
 
   private fun <T> assertNoOverlap(newList: List<T>, oldList: List<T>, selectorCallBack: (T) -> Any?) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/AdditionalConditionWithConfigTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/AdditionalConditionWithConfigTest.kt
@@ -275,7 +275,7 @@ class AdditionalConditionWithConfigTest {
       conditionSequence = 4,
       conditionText = "text",
       additionalConditionData = mutableListOf(someAdditionalConditionData),
-      additionalConditionUploadSummary = emptyList(),
+      additionalConditionUploadSummary = mutableListOf(),
       conditionType = "AP",
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/AuditServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/AuditServiceTest.kt
@@ -922,7 +922,7 @@ class AuditServiceTest {
       conditionSequence = 4,
       conditionText = "text",
       additionalConditionData = someAdditionalConditionData,
-      additionalConditionUploadSummary = emptyList(),
+      additionalConditionUploadSummary = mutableListOf(),
       conditionType = "AP",
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/TestData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/TestData.kt
@@ -99,7 +99,7 @@ object TestData {
     expandedConditionText = HARD_STOP_CONDITION.text,
     conditionVersion = licence.version!!,
     additionalConditionData = mutableListOf(),
-    additionalConditionUploadSummary = emptyList(),
+    additionalConditionUploadSummary = mutableListOf(),
     conditionCategory = HARD_STOP_CONDITION.categoryShort!!,
   )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/conditions/ConditionFormatterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/conditions/ConditionFormatterTest.kt
@@ -1018,7 +1018,7 @@ class ConditionFormatterTest {
     conditionSequence = 0,
     conditionText = "You must reside within the [INSERT REGION] while of no fixed abode, unless otherwise approved by your supervising officer.",
     additionalConditionData = mutableListOf(),
-    additionalConditionUploadSummary = emptyList(),
+    additionalConditionUploadSummary = mutableListOf(),
     conditionVersion = "1.0",
     conditionType = "AP",
     licence = licence,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/conditions/ExclusionZoneServiceGetFullImageTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/conditions/ExclusionZoneServiceGetFullImageTest.kt
@@ -78,7 +78,7 @@ class ExclusionZoneServiceGetFullImageTest {
     id = additionalConditionId,
     licence = mock(),
     additionalConditionData = mock(),
-    additionalConditionUploadSummary = listOf(additionalConditionUploadSummary()),
+    additionalConditionUploadSummary = mutableListOf(additionalConditionUploadSummary()),
     conditionVersion = "",
     conditionCode = "",
     conditionCategory = "",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/conditions/ExclusionZoneServicePreloadLicenceThumbnailsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/conditions/ExclusionZoneServicePreloadLicenceThumbnailsTest.kt
@@ -53,7 +53,7 @@ class ExclusionZoneServicePreloadLicenceThumbnailsTest {
     conditionText = "",
     conditionType = "",
     additionalConditionData = mutableListOf(),
-    additionalConditionUploadSummary = listOf(
+    additionalConditionUploadSummary = mutableListOf(
       AdditionalConditionUploadSummary(
         id = 2L,
         additionalCondition = mock(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/conditions/ExclusionZoneServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/conditions/ExclusionZoneServiceTest.kt
@@ -121,7 +121,7 @@ class ExclusionZoneServiceTest {
       conditionText = "text",
       conditionType = "AP",
       additionalConditionData = someAdditionalConditionData,
-      additionalConditionUploadSummary = emptyList(),
+      additionalConditionUploadSummary = mutableListOf(),
     )
 
     val someUploadSummaryData = AdditionalConditionUploadSummary(
@@ -145,7 +145,7 @@ class ExclusionZoneServiceTest {
       conditionText = "text",
       conditionType = "AP",
       additionalConditionData = someAdditionalConditionData,
-      additionalConditionUploadSummary = listOf(someUploadSummaryData),
+      additionalConditionUploadSummary = mutableListOf(someUploadSummaryData),
     )
 
     val anAdditionalConditionUploadDetailEntity = AdditionalConditionUploadDetail(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/conditions/LicenceConditionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/conditions/LicenceConditionServiceTest.kt
@@ -780,7 +780,7 @@ class LicenceConditionServiceTest {
       conditionSequence = 4,
       conditionText = "text",
       additionalConditionData = someAdditionalConditionData,
-      additionalConditionUploadSummary = emptyList(),
+      additionalConditionUploadSummary = mutableListOf(),
       conditionType = "AP",
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/publicApi/PublicLicenceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/publicApi/PublicLicenceServiceTest.kt
@@ -673,7 +673,7 @@ class PublicLicenceServiceTest {
       conditionText = "text",
       conditionType = "AP",
       additionalConditionData = someAdditionalConditionData,
-      additionalConditionUploadSummary = listOf(someUploadSummaryData),
+      additionalConditionUploadSummary = mutableListOf(someUploadSummaryData),
     )
 
     val anAdditionalConditionUploadDetailEntity = AdditionalConditionUploadDetail(
@@ -694,7 +694,7 @@ class PublicLicenceServiceTest {
       conditionText = "text",
       conditionType = "AP",
       additionalConditionData = someAdditionalConditionData,
-      additionalConditionUploadSummary = emptyList(),
+      additionalConditionUploadSummary = mutableListOf(),
     )
 
     val publicLicenseConditions = Conditions(

--- a/src/test/resources/test_data/seed-licence-id-1-with-address.sql
+++ b/src/test/resources/test_data/seed-licence-id-1-with-address.sql
@@ -71,8 +71,19 @@ values (1, 'notBreakLaw', 2, 'Do not break the law', 'AP');
 insert into standard_condition (licence_id, condition_code, condition_sequence, condition_text, condition_type)
 values (1, 'attendMeetings', 3, 'Attend meetings', 'PSS');
 
+insert into bespoke_condition (licence_id, condition_sequence, condition_text)
+values ( 1, 4, 'bespoke condition 1');
+
 insert into electronic_monitoring_provider (licence_id, is_to_be_tagged_for_programme, programme_name)
 VALUES (1, true, 'Test Programme');
+
+-- Create the exclusion zone additional condition
+insert into additional_condition (licence_id, condition_version, condition_category, condition_code, condition_sequence, condition_text, condition_type)
+values (1, '1.0', 'Freedom of movement', '9ae2a336-3491-4667-aaed-dd852b09b4b9', 5, 'Not to enter exclusion zone [EXCLUSION ZONE DESCRIPTION]', 'AP');
+
+-- Create the data for the exclusion zone condition
+insert into additional_condition_data (additional_condition_id, data_sequence, data_field, data_value)
+values ((select max(id) from additional_condition), 1, 'outOfBoundArea', 'Town centre');
 
 INSERT INTO address (reference, first_line, second_line, town_or_city, county, postcode, source)
 VALUES ('550e8400-e29b-41d4-a716-446655440000', '123 Test Street', 'Apt 4B', 'Testville', 'Testshire', 'TE5 7AA','MANUAL');

--- a/src/test/resources/test_data/seed-licence-id-2.sql
+++ b/src/test/resources/test_data/seed-licence-id-2.sql
@@ -74,7 +74,7 @@ values ( 2, '1.0', 'Freedom of movement', '9ae2a336-3491-4667-aaed-dd852b09b4b9'
 
 -- Create the data for the exclusion zone condition
 insert into additional_condition_data (additional_condition_id, data_sequence, data_field, data_value)
-values ( 1, 1, 'outOfBoundArea', 'Town centre');
+values ( (select max(id) from additional_condition), 1, 'outOfBoundArea', 'Town centre');
 
 insert into additional_condition_data (additional_condition_id, data_sequence, data_field, data_value)
-values (1, 2, 'outOfBoundFile', 'Test_map_2021-12-06_112550.pdf');
+values ((select max(id) from additional_condition), 2, 'outOfBoundFile', 'Test_map_2021-12-06_112550.pdf');

--- a/src/test/resources/test_data/seed-variation-licence-id-1-inPssPeriod.sql
+++ b/src/test/resources/test_data/seed-variation-licence-id-1-inPssPeriod.sql
@@ -1,0 +1,87 @@
+insert into licence (kind,
+                     type_code,
+                     version,
+                     status_code,
+                     noms_id,
+                     booking_no,
+                     booking_id,
+                     crn,
+                     pnc,
+                     cro,
+                     prison_code,
+                     prison_description,
+                     forename,
+                     surname,
+                     date_of_birth,
+                     conditional_release_date,
+                     actual_release_date,
+                     sentence_start_date,
+                     sentence_end_date,
+                     topup_supervision_start_date,
+                     topup_supervision_expiry_date,
+                     licence_start_date,
+                     licence_expiry_date,
+                     probation_area_code,
+                     probation_pdu_code,
+                     probation_lau_code,
+                     probation_team_code,
+                     responsible_com_id,
+                     created_by_com_id,
+                     licence_version,
+					 appointment_address)
+values (
+        'VARIATION',
+        'AP_PSS',
+        '1.0',
+        'IN_PROGRESS',
+        'A1234AA',
+        'BOOKNO',
+        12345,
+        'CRN1',
+        '2015/1234',
+        'CRO1',
+        'MDI',
+        'Moorland (HMP)',
+        'Person',
+        'One',
+        '2020-10-25',
+        '2022-02-12',
+        '2022-02-25',
+        '2020-10-11',
+        '2022-02-25',
+        '2022-02-25',
+        '20252-08-01',
+        '2025-08-01',
+        '2023-02-25',
+        'N01',
+        'PDU1',
+        'LAU1',
+        'TEAM1',
+        1,
+        1,
+        '1.0',
+        '123 Test Street,Apt 4B,Testville,Testshire,TE5 7AA');
+
+insert into standard_condition (licence_id, condition_code, condition_sequence, condition_text, condition_type)
+values (1, 'goodBehaviour', 1, 'Be of generally good behaviour', 'AP');
+
+insert into standard_condition (licence_id, condition_code, condition_sequence, condition_text, condition_type)
+values (1, 'notBreakLaw', 2, 'Do not break the law', 'AP');
+
+insert into standard_condition (licence_id, condition_code, condition_sequence, condition_text, condition_type)
+values (1, 'attendMeetings', 3, 'Attend meetings', 'PSS');
+
+insert into bespoke_condition (licence_id, condition_sequence, condition_text)
+values ( 1, 4, 'bespoke condition 1');
+
+insert into electronic_monitoring_provider (licence_id, is_to_be_tagged_for_programme, programme_name)
+VALUES (1, true, 'Test Programme');
+
+-- Create the exclusion zone additional condition
+insert into additional_condition (licence_id, condition_version, condition_category, condition_code, condition_sequence, condition_text, condition_type)
+values (1, '1.0', 'Freedom of movement', '9ae2a336-3491-4667-aaed-dd852b09b4b9', 5, 'Not to enter exclusion zone [EXCLUSION ZONE DESCRIPTION]', 'AP');
+
+-- Create the data for the exclusion zone condition
+insert into additional_condition_data (additional_condition_id, data_sequence, data_field, data_value)
+values ((select max(id) from additional_condition), 1, 'outOfBoundArea', 'Town centre');
+


### PR DESCRIPTION
Pre cursor change for conditions variation copy improve test so we know if we break anything later.
Basically the tests were not covering the code, so if I made changes to populateCopyAndAudit there was no decent code coverage for regression.