### PR TITLE
CVSL-3215 Extend DB refresh timeout

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -33,6 +33,7 @@ generic-service:
 
   postgresDatabaseRestore:
     enabled: true
+    timeout: 5400 # 1 hour 30 min
     namespace_secrets:
       rds-instance-output:
         DB_NAME: "database_name"

--- a/src/main/resources/migration/adhoc/image_size_migration.sql
+++ b/src/main/resources/migration/adhoc/image_size_migration.sql
@@ -1,0 +1,13 @@
+UPDATE additional_condition_upload_summary AS acus
+SET image_size = octet_length(full_size_image)
+    FROM additional_condition_upload_detail AS acud
+where
+    acus.upload_detail_id = acud.id
+  and
+    acus.id in (
+    SELECT id
+    FROM   additional_condition_upload_summary
+    WHERE  image_size is null
+    LIMIT  1
+    );
+


### PR DESCRIPTION
This should only be required temporarily whilst we have a load of PDFs in the DB. Once they are removed we should be able to reduce this