### PR TITLE
CVSL-353 Postcode Lookup | Process appointment address as individual …

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/publicApi/SubjectAccessRequestResponseBuilder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/publicApi/SubjectAccessRequestResponseBuilder.kt
@@ -42,7 +42,7 @@ class SubjectAccessRequestResponseBuilder(val baseUrl: String) {
         appointmentPerson = licence.appointmentPerson,
         appointmentTime = licence.appointmentTime,
         appointmentTimeType = SarAppointmentTimeType.from(licence.appointmentTimeType),
-        appointmentAddress = licence.licenceAppointmentAddress?.toString() ?: licence.appointmentAddress,
+        appointmentAddress = licence.appointmentAddress,
         appointmentContact = licence.appointmentContact,
         approvedDate = licence.approvedDate,
         approvedByUsername = licence.approvedByUsername,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/publicApi/SubjectAccessRequestResponseBuilderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/publicApi/SubjectAccessRequestResponseBuilderTest.kt
@@ -185,6 +185,7 @@ class SubjectAccessRequestResponseBuilderTest {
         version = "2.1",
         typeCode = AP,
         appointmentTimeType = AppointmentTimeType.SPECIFIC_DATE_TIME,
+        appointmentAddress = "Test Address String",
       ),
       earliestReleaseDate = LocalDate.of(2024, 1, 3),
       isEligibleForEarlyRelease = true,


### PR DESCRIPTION
Defect with SAR data return object value rather than address string. This is just quick fix, when we finally remove the address text we can refactor this.