### PR TITLE
CVSL-3971: Rename DateChangeLicenceDeactivationReason to LicenceDeact…

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/request/DeactivateLicenceAndVariationsRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/model/request/DeactivateLicenceAndVariationsRequest.kt
@@ -1,10 +1,10 @@
 package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.request
 
 import io.swagger.v3.oas.annotations.media.Schema
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.DateChangeLicenceDeactivationReason
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceDeactivationReason
 
 @Schema(description = "Request object for deactivating an active licence and its variations")
 data class DeactivateLicenceAndVariationsRequest(
   @field:Schema(description = "A key representing the reason for the variation", example = "RESENTENCED")
-  val reason: DateChangeLicenceDeactivationReason,
+  val reason: LicenceDeactivationReason,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/domainEvents/RecallInsertedHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/domainEvents/RecallInsertedHandler.kt
@@ -12,7 +12,7 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.LicenceR
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.LicenceService
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.prison.PrisonService
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.prison.RecallType
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.DateChangeLicenceDeactivationReason
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceDeactivationReason
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus.ACTIVE
 
 @Service
@@ -49,18 +49,17 @@ class RecallInsertedHandler(
       log.info("nomisId: $nomisId, has active licence: ${activeLicence.id}")
 
       val recallType = prisonService.getRecallType(bookingId = nomisRecord.bookingId?.toLong()!!)
-      log.info("nomisId: $nomisId, has recall type: $recallType, standard recalls enabled: $standardRecallsEnabled, ${recallType == RecallType.STANDARD}")
       if (recallType == RecallType.STANDARD && standardRecallsEnabled) {
-        log.info("deactivating licence: ${activeLicence.id} due to STANDARD recall, reason ${DateChangeLicenceDeactivationReason.STANDARD_RECALL.message}")
+        log.info("deactivating licence: ${activeLicence.id} due to STANDARD recall, reason ${LicenceDeactivationReason.STANDARD_RECALL.message}")
         licenceService.deactivateLicenceAndVariations(
           activeLicence.id,
-          DeactivateLicenceAndVariationsRequest(DateChangeLicenceDeactivationReason.STANDARD_RECALL),
+          DeactivateLicenceAndVariationsRequest(LicenceDeactivationReason.STANDARD_RECALL),
         )
       } else if (recallType == RecallType.FIXED_TERM) {
-        log.info("deactivating licence: ${activeLicence.id} due to FIXED_TERM recall, reason ${DateChangeLicenceDeactivationReason.RECALLED.message}")
+        log.info("deactivating licence: ${activeLicence.id} due to FIXED_TERM recall, reason ${LicenceDeactivationReason.FIXED_TERM.message}")
         licenceService.deactivateLicenceAndVariations(
           activeLicence.id,
-          DeactivateLicenceAndVariationsRequest(DateChangeLicenceDeactivationReason.RECALLED),
+          DeactivateLicenceAndVariationsRequest(LicenceDeactivationReason.FIXED_TERM),
         )
       }
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/prisonEvents/SentenceDatesChangedHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/prisonEvents/SentenceDatesChangedHandler.kt
@@ -12,7 +12,7 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.repository.LicenceR
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.LicenceService
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.UpdateSentenceDateService
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.prison.PrisonService
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.DateChangeLicenceDeactivationReason
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceDeactivationReason
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus.ACTIVE
 import java.time.LocalDate
@@ -63,7 +63,7 @@ class SentenceDatesChangedHandler(
 
     log.info("Checking if prisoner resentenced, ssd: {}, lsd: {}", ssd, lsd)
     if (ssd != null && lsd != null && ssd.isAfter(lsd)) {
-      deactivateLicenceAndVariations(licence.id, DateChangeLicenceDeactivationReason.RESENTENCED)
+      deactivateLicenceAndVariations(licence.id, LicenceDeactivationReason.RESENTENCED)
     }
   }
 
@@ -76,12 +76,12 @@ class SentenceDatesChangedHandler(
         return
       }
       if (prrd.isAfter(LocalDate.now())) {
-        deactivateLicenceAndVariations(licence.id, DateChangeLicenceDeactivationReason.RECALLED)
+        deactivateLicenceAndVariations(licence.id, LicenceDeactivationReason.RECALLED)
       }
     }
   }
 
-  private fun deactivateLicenceAndVariations(licenceId: Long, reason: DateChangeLicenceDeactivationReason) {
+  private fun deactivateLicenceAndVariations(licenceId: Long, reason: LicenceDeactivationReason) {
     licenceService.deactivateLicenceAndVariations(
       licenceId,
       DeactivateLicenceAndVariationsRequest(reason),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/util/LicenceDeactivationReason.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/util/LicenceDeactivationReason.kt
@@ -1,7 +1,8 @@
 package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util
 
-enum class DateChangeLicenceDeactivationReason(val message: String) {
+enum class LicenceDeactivationReason(val message: String) {
   RECALLED("Licence inactivated due to being recalled"),
+  FIXED_TERM("Licence inactivated due to the offender returning to custody on a fixed term recall"),
   STANDARD_RECALL("Licence inactivated due to the offender returning to custody on a standard recall"),
   RESENTENCED("Licence inactivated due to being resentenced"),
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/privateApi/LicenceControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/resource/privateApi/LicenceControllerTest.kt
@@ -52,7 +52,7 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.LicenceServ
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.TestData.aLicenceSummary
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.UpdateSentenceDateService
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.dates.SentenceDates
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.DateChangeLicenceDeactivationReason
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceDeactivationReason
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceType
 import java.time.LocalDate
@@ -457,7 +457,7 @@ class LicenceControllerTest {
 
   @Test
   fun `deactivate a licence and variations`() {
-    val request = DeactivateLicenceAndVariationsRequest(DateChangeLicenceDeactivationReason.RECALLED)
+    val request = DeactivateLicenceAndVariationsRequest(LicenceDeactivationReason.RECALLED)
     mvc.perform(
       post("/licence/id/4/deactivate-licence-and-variations")
         .accept(APPLICATION_JSON)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceServiceTest.kt
@@ -84,8 +84,8 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.prison.Pris
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.probation.DeliusApiClient
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.AuditEventType.SYSTEM_EVENT
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.AuditEventType.USER_EVENT
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.DateChangeLicenceDeactivationReason
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.EligibleKind
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceDeactivationReason
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceEventType
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceKind
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus
@@ -2908,7 +2908,7 @@ class LicenceServiceTest {
 
     service.deactivateLicenceAndVariations(
       aLicenceEntity.id,
-      DeactivateLicenceAndVariationsRequest(DateChangeLicenceDeactivationReason.RESENTENCED),
+      DeactivateLicenceAndVariationsRequest(LicenceDeactivationReason.RESENTENCED),
     )
     verify(
       licenceRepository,
@@ -2938,7 +2938,7 @@ class LicenceServiceTest {
 
     service.deactivateLicenceAndVariations(
       activeLicence.id,
-      DeactivateLicenceAndVariationsRequest(DateChangeLicenceDeactivationReason.RESENTENCED),
+      DeactivateLicenceAndVariationsRequest(LicenceDeactivationReason.RESENTENCED),
     )
 
     verify(
@@ -2991,7 +2991,7 @@ class LicenceServiceTest {
 
     service.deactivateLicenceAndVariations(
       activeLicence.id,
-      DeactivateLicenceAndVariationsRequest(DateChangeLicenceDeactivationReason.RECALLED),
+      DeactivateLicenceAndVariationsRequest(LicenceDeactivationReason.RECALLED),
     )
 
     verify(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/domainEvents/RecallInsertedHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/domainEvents/RecallInsertedHandlerTest.kt
@@ -18,7 +18,7 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.prison.Pris
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.prison.RecallType
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.prison.SentenceAndRecallType
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.prison.SentenceRecallType
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.DateChangeLicenceDeactivationReason
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceDeactivationReason
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus.ACTIVE
 
 class RecallInsertedHandlerTest {
@@ -60,7 +60,7 @@ class RecallInsertedHandlerTest {
       licenceService,
     ).deactivateLicenceAndVariations(
       licence.id,
-      DeactivateLicenceAndVariationsRequest(DateChangeLicenceDeactivationReason.RECALLED),
+      DeactivateLicenceAndVariationsRequest(LicenceDeactivationReason.FIXED_TERM),
     )
   }
 
@@ -85,7 +85,7 @@ class RecallInsertedHandlerTest {
       licenceService,
     ).deactivateLicenceAndVariations(
       licence.id,
-      DeactivateLicenceAndVariationsRequest(DateChangeLicenceDeactivationReason.STANDARD_RECALL),
+      DeactivateLicenceAndVariationsRequest(LicenceDeactivationReason.STANDARD_RECALL),
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/prisonEvents/SentenceDatesChangedHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/prisonEvents/SentenceDatesChangedHandlerTest.kt
@@ -17,7 +17,7 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.TestData.cr
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.TestData.prisonerSearchResult
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.UpdateSentenceDateService
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.prison.PrisonService
-import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.DateChangeLicenceDeactivationReason
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceDeactivationReason
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.LicenceStatus.ACTIVE
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.util.createTestMapper
@@ -81,11 +81,11 @@ class SentenceDatesChangedHandlerTest {
 
     verify(licenceService).deactivateLicenceAndVariations(
       activeLicence.id,
-      DeactivateLicenceAndVariationsRequest(reason = DateChangeLicenceDeactivationReason.RESENTENCED),
+      DeactivateLicenceAndVariationsRequest(reason = LicenceDeactivationReason.RESENTENCED),
     )
     verify(licenceService, never()).deactivateLicenceAndVariations(
       activeLicence.id,
-      DeactivateLicenceAndVariationsRequest(reason = DateChangeLicenceDeactivationReason.RECALLED),
+      DeactivateLicenceAndVariationsRequest(reason = LicenceDeactivationReason.RECALLED),
     )
   }
 
@@ -112,7 +112,7 @@ class SentenceDatesChangedHandlerTest {
 
     verify(licenceService).deactivateLicenceAndVariations(
       activeLicence.id,
-      DeactivateLicenceAndVariationsRequest(reason = DateChangeLicenceDeactivationReason.RECALLED),
+      DeactivateLicenceAndVariationsRequest(reason = LicenceDeactivationReason.RECALLED),
     )
   }
 


### PR DESCRIPTION
…ivationReason as no longer only used for date change events.CVSL-3971: Rename DateChangeLicenceDeactivationReason to LicenceDeactivationReason as no longer only used for date change events.