### PR TITLE
CVSL-3991 amend calls to by-release-date to include flag

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/caseload/ca/prison/NotStartedCaseloadService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/caseload/ca/prison/NotStartedCaseloadService.kt
@@ -59,22 +59,13 @@ class NotStartedCaseloadService(
     val now = overrideClock ?: clock
     val today = LocalDate.now(now)
     val todayPlusFourWeeks = LocalDate.now(now).plusWeeks(FOUR_WEEKS)
-    return if (restrictedPatientsEnabled) {
-      prisonerSearchApiClient.searchPrisonersByReleaseDate(
-        today.minusDays(maxNumberOfDaysBeforeTodayForCrdTimeserved - 1),
-        todayPlusFourWeeks,
-        prisonCaseload,
-        page = 0,
-        includeRestrictedPatients = restrictedPatientsEnabled,
-      ).toList()
-    } else {
-      prisonerSearchApiClient.searchPrisonersByReleaseDate(
-        today.minusDays(maxNumberOfDaysBeforeTodayForCrdTimeserved - 1),
-        todayPlusFourWeeks,
-        prisonCaseload,
-        page = 0,
-      ).toList()
-    }
+    return prisonerSearchApiClient.searchPrisonersByReleaseDate(
+      today.minusDays(maxNumberOfDaysBeforeTodayForCrdTimeserved - 1),
+      todayPlusFourWeeks,
+      prisonCaseload,
+      page = 0,
+      includeRestrictedPatients = restrictedPatientsEnabled,
+    ).toList()
   }
 
   private fun buildManagedCaseDto(prisoners: List<PrisonerSearchPrisoner>): List<ManagedCaseDto> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/caseload/ca/prison/NotStartedCaseloadService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/caseload/ca/prison/NotStartedCaseloadService.kt
@@ -33,6 +33,7 @@ class NotStartedCaseloadService(
   private val cvlRecordService: CvlRecordService,
   private val licenceRepository: TimeServedExternalRecordsRepository,
   @param:Value("\${timeserved.max.days.crd.before.today:28}") private val maxNumberOfDaysBeforeTodayForCrdTimeserved: Long = 28,
+  @param:Value("\${feature.toggle.restrictedPatients.enabled:false}") private val restrictedPatientsEnabled: Boolean = false,
 ) {
   fun findNotStartedCases(
     licences: List<LicenceCaCase>,
@@ -58,12 +59,22 @@ class NotStartedCaseloadService(
     val now = overrideClock ?: clock
     val today = LocalDate.now(now)
     val todayPlusFourWeeks = LocalDate.now(now).plusWeeks(FOUR_WEEKS)
-    return prisonerSearchApiClient.searchPrisonersByReleaseDate(
-      today.minusDays(maxNumberOfDaysBeforeTodayForCrdTimeserved - 1),
-      todayPlusFourWeeks,
-      prisonCaseload,
-      page = 0,
-    ).toList()
+    return if (restrictedPatientsEnabled) {
+      prisonerSearchApiClient.searchPrisonersByReleaseDate(
+        today.minusDays(maxNumberOfDaysBeforeTodayForCrdTimeserved - 1),
+        todayPlusFourWeeks,
+        prisonCaseload,
+        page = 0,
+        includeRestrictedPatients = true,
+      ).toList()
+    } else {
+      prisonerSearchApiClient.searchPrisonersByReleaseDate(
+        today.minusDays(maxNumberOfDaysBeforeTodayForCrdTimeserved - 1),
+        todayPlusFourWeeks,
+        prisonCaseload,
+        page = 0,
+      ).toList()
+    }
   }
 
   private fun buildManagedCaseDto(prisoners: List<PrisonerSearchPrisoner>): List<ManagedCaseDto> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/caseload/ca/prison/NotStartedCaseloadService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/caseload/ca/prison/NotStartedCaseloadService.kt
@@ -65,7 +65,7 @@ class NotStartedCaseloadService(
         todayPlusFourWeeks,
         prisonCaseload,
         page = 0,
-        includeRestrictedPatients = true,
+        includeRestrictedPatients = restrictedPatientsEnabled,
       ).toList()
     } else {
       prisonerSearchApiClient.searchPrisonersByReleaseDate(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/caseload/timeServed/TimeServedCaseloadService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/caseload/timeServed/TimeServedCaseloadService.kt
@@ -16,15 +16,26 @@ class TimeServedCaseloadService(
   private val releaseDateService: ReleaseDateService,
   private val clock: Clock,
   @param:Value("\${timeserved.max.days.crd.before.today:28}") private val maxNumberOfDaysBeforeTodayForCrdTimeserved: Long = 28,
+  @param:Value("\${feature.toggle.restrictedPatients.enabled:false}") private val restrictedPatientsEnabled: Boolean = false,
+
 ) {
   fun getCases(prisonCode: String): TimeServedCaseload {
     val today = LocalDate.now(clock)
 
-    val cases = prisonerSearchApiClient.searchPrisonersByReleaseDate(
-      today.minusDays(maxNumberOfDaysBeforeTodayForCrdTimeserved - 1),
-      today.plusDays(CASELOAD_WINDOW),
-      setOf(prisonCode),
-    )
+    val cases = if (restrictedPatientsEnabled) {
+      prisonerSearchApiClient.searchPrisonersByReleaseDate(
+        today.minusDays(maxNumberOfDaysBeforeTodayForCrdTimeserved - 1),
+        today.plusDays(CASELOAD_WINDOW),
+        setOf(prisonCode),
+        includeRestrictedPatients = true,
+      )
+    } else {
+      prisonerSearchApiClient.searchPrisonersByReleaseDate(
+        today.minusDays(maxNumberOfDaysBeforeTodayForCrdTimeserved - 1),
+        today.plusDays(CASELOAD_WINDOW),
+        setOf(prisonCode),
+      )
+    }
 
     val (timeServedCases, nonTimeServedCases) = cases.map {
       TimeServedCase(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/caseload/timeServed/TimeServedCaseloadService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/caseload/timeServed/TimeServedCaseloadService.kt
@@ -22,20 +22,12 @@ class TimeServedCaseloadService(
   fun getCases(prisonCode: String): TimeServedCaseload {
     val today = LocalDate.now(clock)
 
-    val cases = if (restrictedPatientsEnabled) {
-      prisonerSearchApiClient.searchPrisonersByReleaseDate(
-        today.minusDays(maxNumberOfDaysBeforeTodayForCrdTimeserved - 1),
-        today.plusDays(CASELOAD_WINDOW),
-        setOf(prisonCode),
-        includeRestrictedPatients = restrictedPatientsEnabled,
-      )
-    } else {
-      prisonerSearchApiClient.searchPrisonersByReleaseDate(
-        today.minusDays(maxNumberOfDaysBeforeTodayForCrdTimeserved - 1),
-        today.plusDays(CASELOAD_WINDOW),
-        setOf(prisonCode),
-      )
-    }
+    val cases = prisonerSearchApiClient.searchPrisonersByReleaseDate(
+      today.minusDays(maxNumberOfDaysBeforeTodayForCrdTimeserved - 1),
+      today.plusDays(CASELOAD_WINDOW),
+      setOf(prisonCode),
+      includeRestrictedPatients = restrictedPatientsEnabled,
+    )
 
     val (timeServedCases, nonTimeServedCases) = cases.map {
       TimeServedCase(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/caseload/timeServed/TimeServedCaseloadService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/caseload/timeServed/TimeServedCaseloadService.kt
@@ -27,7 +27,7 @@ class TimeServedCaseloadService(
         today.minusDays(maxNumberOfDaysBeforeTodayForCrdTimeserved - 1),
         today.plusDays(CASELOAD_WINDOW),
         setOf(prisonCode),
-        includeRestrictedPatients = true,
+        includeRestrictedPatients = restrictedPatientsEnabled,
       )
     } else {
       prisonerSearchApiClient.searchPrisonersByReleaseDate(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/jobs/promptingCom/PromptComService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/jobs/promptingCom/PromptComService.kt
@@ -40,7 +40,7 @@ class PromptComService(
     log.info("Gathering prisoners with release dates between {} and {}", earliestReleaseDate, latestReleaseDate)
 
     val candidates = if (restrictedPatientsEnabled) {
-      prisonerSearchApiClient.getAllByReleaseDate(earliestReleaseDate, latestReleaseDate, includeRestrictedPatients = true)
+      prisonerSearchApiClient.getAllByReleaseDate(earliestReleaseDate, latestReleaseDate, includeRestrictedPatients = restrictedPatientsEnabled)
     } else {
       prisonerSearchApiClient.getAllByReleaseDate(earliestReleaseDate, latestReleaseDate)
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/jobs/promptingCom/PromptComService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/jobs/promptingCom/PromptComService.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.jobs.promptingCom
 
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.CvlRecordService
@@ -19,6 +20,7 @@ class PromptComService(
   private val notifyService: NotifyService,
   private val cvlRecordService: CvlRecordService,
   private val telemetryService: TelemetryService,
+  @param:Value("\${feature.toggle.restrictedPatients.enabled:false}") private val restrictedPatientsEnabled: Boolean = false,
 ) {
 
   @Async
@@ -37,7 +39,11 @@ class PromptComService(
     val (earliestReleaseDate, latestReleaseDate) = fromNowToTheNext4Weeks(clock)
     log.info("Gathering prisoners with release dates between {} and {}", earliestReleaseDate, latestReleaseDate)
 
-    val candidates = prisonerSearchApiClient.getAllByReleaseDate(earliestReleaseDate, latestReleaseDate)
+    val candidates = if (restrictedPatientsEnabled) {
+      prisonerSearchApiClient.getAllByReleaseDate(earliestReleaseDate, latestReleaseDate, includeRestrictedPatients = true)
+    } else {
+      prisonerSearchApiClient.getAllByReleaseDate(earliestReleaseDate, latestReleaseDate)
+    }
 
     log.info("Found {} prisoners with release dates within the next 4 weeks ", candidates.size)
     return promptComListBuilder.gatherEmails(candidates, earliestReleaseDate, latestReleaseDate)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/jobs/promptingCom/PromptComService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/jobs/promptingCom/PromptComService.kt
@@ -39,11 +39,7 @@ class PromptComService(
     val (earliestReleaseDate, latestReleaseDate) = fromNowToTheNext4Weeks(clock)
     log.info("Gathering prisoners with release dates between {} and {}", earliestReleaseDate, latestReleaseDate)
 
-    val candidates = if (restrictedPatientsEnabled) {
-      prisonerSearchApiClient.getAllByReleaseDate(earliestReleaseDate, latestReleaseDate, includeRestrictedPatients = restrictedPatientsEnabled)
-    } else {
-      prisonerSearchApiClient.getAllByReleaseDate(earliestReleaseDate, latestReleaseDate)
-    }
+    val candidates = prisonerSearchApiClient.getAllByReleaseDate(earliestReleaseDate, latestReleaseDate, includeRestrictedPatients = restrictedPatientsEnabled)
 
     log.info("Found {} prisoners with release dates within the next 4 weeks ", candidates.size)
     return promptComListBuilder.gatherEmails(candidates, earliestReleaseDate, latestReleaseDate)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/prison/PrisonerSearchApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/prison/PrisonerSearchApiClient.kt
@@ -48,7 +48,7 @@ class PrisonerSearchApiClient(@param:Qualifier("oauthPrisonerSearchClient") val 
     latestReleaseDate: LocalDate,
     prisonIds: Set<String>,
     page: Int = 0,
-    includeRestrictedPatients: Boolean = false,
+    includeRestrictedPatients: Boolean,
   ): Page<PrisonerSearchPrisoner> {
     if (prisonIds.isEmpty()) return Page.empty()
     return searchForPrisoners(earliestReleaseDate, latestReleaseDate, prisonIds, PAGE_SIZE, page, includeRestrictedPatients)
@@ -59,7 +59,7 @@ class PrisonerSearchApiClient(@param:Qualifier("oauthPrisonerSearchClient") val 
     to: LocalDate,
     prisonIds: Set<String> = emptySet(),
     pageSize: Int = PAGE_SIZE,
-    includeRestrictedPatients: Boolean = false,
+    includeRestrictedPatients: Boolean,
   ): List<PrisonerSearchPrisoner> {
     val result = mutableListOf<PrisonerSearchPrisoner>()
     var pageNumber = 0

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/prison/PrisonerSearchApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/prison/PrisonerSearchApiClient.kt
@@ -48,9 +48,10 @@ class PrisonerSearchApiClient(@param:Qualifier("oauthPrisonerSearchClient") val 
     latestReleaseDate: LocalDate,
     prisonIds: Set<String>,
     page: Int = 0,
+    includeRestrictedPatients: Boolean = false,
   ): Page<PrisonerSearchPrisoner> {
     if (prisonIds.isEmpty()) return Page.empty()
-    return searchForPrisoners(earliestReleaseDate, latestReleaseDate, prisonIds, PAGE_SIZE, page)
+    return searchForPrisoners(earliestReleaseDate, latestReleaseDate, prisonIds, PAGE_SIZE, page, includeRestrictedPatients)
   }
 
   fun getAllByReleaseDate(
@@ -58,11 +59,12 @@ class PrisonerSearchApiClient(@param:Qualifier("oauthPrisonerSearchClient") val 
     to: LocalDate,
     prisonIds: Set<String> = emptySet(),
     pageSize: Int = PAGE_SIZE,
+    includeRestrictedPatients: Boolean = false,
   ): List<PrisonerSearchPrisoner> {
     val result = mutableListOf<PrisonerSearchPrisoner>()
     var pageNumber = 0
     while (pageNumber >= 0) {
-      val page = searchForPrisoners(from, to, prisonIds, pageSize, pageNumber)
+      val page = searchForPrisoners(from, to, prisonIds, pageSize, pageNumber, includeRestrictedPatients)
       pageNumber = if (pageNumber < page.totalPages - 1) pageNumber + 1 else -1
       result.addAll(page.content)
     }
@@ -75,10 +77,11 @@ class PrisonerSearchApiClient(@param:Qualifier("oauthPrisonerSearchClient") val 
     prisonIds: Set<String>,
     pageSize: Int,
     pageNumber: Int,
+    includeRestrictedPatients: Boolean = false,
   ): Page<PrisonerSearchPrisoner> {
     val page = prisonerSearchApiWebClient
       .post()
-      .uri("/prisoner-search/release-date-by-prison?size=$pageSize&page=$pageNumber")
+      .uri("/prisoner-search/release-date-by-prison?size=$pageSize&page=$pageNumber&includeSupportedByPrisons=$includeRestrictedPatients")
       .accept(MediaType.APPLICATION_JSON)
       .bodyValue(
         ReleaseDateSearch(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/prison/PrisonerSearchApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/prison/PrisonerSearchApiClient.kt
@@ -77,7 +77,7 @@ class PrisonerSearchApiClient(@param:Qualifier("oauthPrisonerSearchClient") val 
     prisonIds: Set<String>,
     pageSize: Int,
     pageNumber: Int,
-    includeRestrictedPatients: Boolean = false,
+    includeRestrictedPatients: Boolean,
   ): Page<PrisonerSearchPrisoner> {
     val page = prisonerSearchApiWebClient
       .post()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/prison/PrisonerSearchPrisoner.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/prison/PrisonerSearchPrisoner.kt
@@ -87,7 +87,12 @@ data class PrisonerSearchPrisoner(
 
   val croNumber: String? = null,
 
+  val supportingPrisonId: String? = null,
+
+  val restrictedPatient: Boolean? = null,
+
 ) {
 
   fun fullName() = listOfNotNull(firstName, middleNames, lastName).filter { it.isNotBlank() }.joinToString(" ")
+  fun isRestrictedPatient() = supportingPrisonId != null && restrictedPatient == true
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/reports/LastMinuteHandoverCaseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/reports/LastMinuteHandoverCaseService.kt
@@ -21,6 +21,7 @@ class LastMinuteHandoverCaseService(
   private val lastMinutePrisonCodes: Set<String>,
   private val cvlRecordService: CvlRecordService,
   private val clock: Clock,
+  @param:Value("\${feature.toggle.restrictedPatients.enabled:false}") private val restrictedPatientsEnabled: Boolean = false,
 ) {
   private val log = LoggerFactory.getLogger(this::class.java)
 
@@ -48,7 +49,11 @@ class LastMinuteHandoverCaseService(
     log.info("Getting prisoner data for $lastMinutePrisonCodes")
     val today = LocalDate.now(clock)
     val nextWeek = today.plusWeeks(1)
-    val prisoners = prisonerSearchApiClient.getAllByReleaseDate(today, nextWeek, lastMinutePrisonCodes)
+    val prisoners = if (restrictedPatientsEnabled) {
+      prisonerSearchApiClient.getAllByReleaseDate(today, nextWeek, lastMinutePrisonCodes, includeRestrictedPatients = true)
+    } else {
+      prisonerSearchApiClient.getAllByReleaseDate(today, nextWeek)
+    }
     log.info("Found ${prisoners.size} prisoners")
     return prisoners.associateBy { it.prisonerNumber }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/reports/LastMinuteHandoverCaseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/reports/LastMinuteHandoverCaseService.kt
@@ -49,11 +49,7 @@ class LastMinuteHandoverCaseService(
     log.info("Getting prisoner data for $lastMinutePrisonCodes")
     val today = LocalDate.now(clock)
     val nextWeek = today.plusWeeks(1)
-    val prisoners = if (restrictedPatientsEnabled) {
-      prisonerSearchApiClient.getAllByReleaseDate(today, nextWeek, lastMinutePrisonCodes, includeRestrictedPatients = restrictedPatientsEnabled)
-    } else {
-      prisonerSearchApiClient.getAllByReleaseDate(today, nextWeek)
-    }
+    val prisoners = prisonerSearchApiClient.getAllByReleaseDate(today, nextWeek, lastMinutePrisonCodes, includeRestrictedPatients = restrictedPatientsEnabled)
     log.info("Found ${prisoners.size} prisoners")
     return prisoners.associateBy { it.prisonerNumber }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/reports/LastMinuteHandoverCaseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/reports/LastMinuteHandoverCaseService.kt
@@ -50,7 +50,7 @@ class LastMinuteHandoverCaseService(
     val today = LocalDate.now(clock)
     val nextWeek = today.plusWeeks(1)
     val prisoners = if (restrictedPatientsEnabled) {
-      prisonerSearchApiClient.getAllByReleaseDate(today, nextWeek, lastMinutePrisonCodes, includeRestrictedPatients = true)
+      prisonerSearchApiClient.getAllByReleaseDate(today, nextWeek, lastMinutePrisonCodes, includeRestrictedPatients = restrictedPatientsEnabled)
     } else {
       prisonerSearchApiClient.getAllByReleaseDate(today, nextWeek)
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/reports/LicenceStatusReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/reports/LicenceStatusReportService.kt
@@ -74,7 +74,7 @@ class LicenceStatusReportService(
   }
 
   private fun getPrisonerData(fromDate: LocalDate, toDate: LocalDate): List<PrisonerSearchPrisoner> = if (restrictedPatientsEnabled) {
-    prisonerSearchApiClient.getAllByReleaseDate(fromDate, toDate, emptySet(), LICENCE_STATUS_REPORT_PAGE_SIZE, includeRestrictedPatients = true)
+    prisonerSearchApiClient.getAllByReleaseDate(fromDate, toDate, emptySet(), LICENCE_STATUS_REPORT_PAGE_SIZE, includeRestrictedPatients = restrictedPatientsEnabled)
   } else {
     prisonerSearchApiClient.getAllByReleaseDate(fromDate, toDate, emptySet(), LICENCE_STATUS_REPORT_PAGE_SIZE)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/reports/LicenceStatusReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/reports/LicenceStatusReportService.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.service.reports
 
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.Licence
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.model.response.LicenceStatusResponse
@@ -22,6 +23,7 @@ class LicenceStatusReportService(
   private val cvlRecordService: CvlRecordService,
   private val clock: Clock,
   private val licenceRepository: LicenceRepository,
+  @param:Value("\${feature.toggle.restrictedPatients.enabled:false}") private val restrictedPatientsEnabled: Boolean = false,
 ) {
 
   fun getCases(): List<LicenceStatusResponse> {
@@ -71,7 +73,11 @@ class LicenceStatusReportService(
     return notStartedCases + casesWithLicence
   }
 
-  private fun getPrisonerData(fromDate: LocalDate, toDate: LocalDate): List<PrisonerSearchPrisoner> = prisonerSearchApiClient.getAllByReleaseDate(fromDate, toDate, emptySet(), LICENCE_STATUS_REPORT_PAGE_SIZE)
+  private fun getPrisonerData(fromDate: LocalDate, toDate: LocalDate): List<PrisonerSearchPrisoner> = if (restrictedPatientsEnabled) {
+    prisonerSearchApiClient.getAllByReleaseDate(fromDate, toDate, emptySet(), LICENCE_STATUS_REPORT_PAGE_SIZE, includeRestrictedPatients = true)
+  } else {
+    prisonerSearchApiClient.getAllByReleaseDate(fromDate, toDate, emptySet(), LICENCE_STATUS_REPORT_PAGE_SIZE)
+  }
 
   private fun enrichWithDeliusData(candidates: List<PrisonerSearchPrisoner>): Map<PrisonerSearchPrisoner, CommunityManager> {
     val coms = deliusApiClient.getOffenderManagers(candidates.map { it.prisonerNumber }).filter { it.case.nomisId != null }.associateBy { it.case.nomisId!! }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/reports/LicenceStatusReportService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/reports/LicenceStatusReportService.kt
@@ -73,11 +73,7 @@ class LicenceStatusReportService(
     return notStartedCases + casesWithLicence
   }
 
-  private fun getPrisonerData(fromDate: LocalDate, toDate: LocalDate): List<PrisonerSearchPrisoner> = if (restrictedPatientsEnabled) {
-    prisonerSearchApiClient.getAllByReleaseDate(fromDate, toDate, emptySet(), LICENCE_STATUS_REPORT_PAGE_SIZE, includeRestrictedPatients = restrictedPatientsEnabled)
-  } else {
-    prisonerSearchApiClient.getAllByReleaseDate(fromDate, toDate, emptySet(), LICENCE_STATUS_REPORT_PAGE_SIZE)
-  }
+  private fun getPrisonerData(fromDate: LocalDate, toDate: LocalDate): List<PrisonerSearchPrisoner> = prisonerSearchApiClient.getAllByReleaseDate(fromDate, toDate, emptySet(), LICENCE_STATUS_REPORT_PAGE_SIZE, includeRestrictedPatients = restrictedPatientsEnabled)
 
   private fun enrichWithDeliusData(candidates: List<PrisonerSearchPrisoner>): Map<PrisonerSearchPrisoner, CommunityManager> {
     val coms = deliusApiClient.getOffenderManagers(candidates.map { it.prisonerNumber }).filter { it.case.nomisId != null }.associateBy { it.case.nomisId!! }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/PromptComIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/PromptComIntegrationTest.kt
@@ -91,7 +91,7 @@ class PromptComIntegrationTest : IntegrationTestBase() {
       govUkApiMockServer.start()
       govUkApiMockServer.stubGetBankHolidaysForEnglandAndWales()
       prisonSearchServer.start()
-      prisonSearchServer.stubSearchPrisonersByReleaseDate(0, inHardStop = false, includeRecall = true)
+      prisonSearchServer.stubSearchPrisonersByReleaseDate(0, inHardStop = false, includeRecall = true, includeRestrictedPatients = false)
       deliusMockServer.start()
       deliusMockServer.stubGetManagersForPromptComJob()
       prisonMockServer.start()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/wiremock/PrisonerSearchMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/integration/wiremock/PrisonerSearchMockServer.kt
@@ -390,7 +390,7 @@ class PrisonerSearchMockServer : WireMockServer(8099) {
     )
   }
 
-  fun stubSearchPrisonersByReleaseDate(page: Int, inHardStop: Boolean = true, includeRecall: Boolean = false) {
+  fun stubSearchPrisonersByReleaseDate(page: Int, inHardStop: Boolean = true, includeRecall: Boolean = false, includeRestrictedPatients: Boolean = false) {
     val releaseDate = if (inHardStop) LocalDate.now().plusDays(1) else nextWorkingDates().drop(4).first()
     var jsonBody = """{ "content": [
                 {
@@ -589,7 +589,7 @@ class PrisonerSearchMockServer : WireMockServer(8099) {
               "empty": false
             }
     """.trimIndent()
-    stubSearchPrisonersByReleaseDate(jsonBody, page)
+    stubSearchPrisonersByReleaseDate(jsonBody, page, includeRestrictedPatients)
   }
 
   fun stubSearchPrisonersByReleaseDate(prisoners: List<PrisonerSearchPrisoner>) {
@@ -598,9 +598,9 @@ class PrisonerSearchMockServer : WireMockServer(8099) {
     stubSearchPrisonersByReleaseDate(mapper.writeValueAsString(prisonerPage), 0)
   }
 
-  fun stubSearchPrisonersByReleaseDate(jsonBody: String, page: Int) {
+  fun stubSearchPrisonersByReleaseDate(jsonBody: String, page: Int, includeRestrictedPatients: Boolean = false) {
     stubFor(
-      post(urlEqualTo("/api/prisoner-search/release-date-by-prison?size=2000&page=$page"))
+      post(urlEqualTo("/api/prisoner-search/release-date-by-prison?size=2000&page=$page&includeSupportedByPrisons=$includeRestrictedPatients"))
         .willReturn(
           aResponse().withHeader(
             "Content-Type",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/CaseServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/CaseServiceTest.kt
@@ -46,6 +46,7 @@ class CaseServiceTest {
         any(),
         any(),
         anyOrNull(),
+        anyOrNull(),
       ),
     ).thenReturn(PageImpl(listOf(prisonerSearchResult())))
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/CaseServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/CaseServiceTest.kt
@@ -46,7 +46,7 @@ class CaseServiceTest {
         any(),
         any(),
         anyOrNull(),
-        anyOrNull(),
+        any(),
       ),
     ).thenReturn(PageImpl(listOf(prisonerSearchResult())))
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/caseload/ca/CaCaseloadServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/caseload/ca/CaCaseloadServiceTest.kt
@@ -186,7 +186,7 @@ class CaCaseloadServiceTest {
       ),
     )
 
-    whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull())).thenReturn(
+    whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull())).thenReturn(
       PageImpl(
         listOf(
           aPrisonerSearchPrisoner,
@@ -263,7 +263,7 @@ class CaCaseloadServiceTest {
           ),
         )
 
-        whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull())).thenReturn(
+        whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull())).thenReturn(
           PageImpl(
             listOf(
               aPrisonerSearchPrisoner.copy(
@@ -293,7 +293,7 @@ class CaCaseloadServiceTest {
           PrisonQuery.prisonCodes,
         )
         verify(prisonerSearchApiClient, times(0)).searchPrisonersByNomisIds(listOf(licenceCase.prisonNumber))
-        verify(prisonerSearchApiClient, times(1)).searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull())
+        verify(prisonerSearchApiClient, times(1)).searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull())
       }
     }
 
@@ -360,7 +360,7 @@ class CaCaseloadServiceTest {
           listOf(licenceCase1, licenceCase2),
         )
 
-        whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull())).thenReturn(
+        whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull())).thenReturn(
           PageImpl(emptyList()),
         )
 
@@ -425,7 +425,7 @@ class CaCaseloadServiceTest {
         ),
       )
 
-      whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull())).thenReturn(
+      whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull())).thenReturn(
         PageImpl(
           listOf(
             aPrisonerSearchPrisoner.copy(
@@ -495,7 +495,7 @@ class CaCaseloadServiceTest {
         ),
       )
 
-      whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull())).thenReturn(
+      whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull())).thenReturn(
         PageImpl(
           listOf(
             aPrisonerSearchPrisoner.copy(
@@ -641,7 +641,7 @@ class CaCaseloadServiceTest {
           PrisonQuery.prisonCodes,
         ),
       ).thenReturn(listOf(licenceCase))
-      whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull())).thenReturn(
+      whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull())).thenReturn(
         PageImpl(
           listOf(prisonerSearchResult()),
         ),
@@ -682,7 +682,7 @@ class CaCaseloadServiceTest {
         ),
       ).thenReturn(listOf(licenceCase))
 
-      whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull())).thenReturn(
+      whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull())).thenReturn(
         PageImpl(
           listOf(prisonerSearchResult()),
         ),
@@ -725,7 +725,7 @@ class CaCaseloadServiceTest {
           ),
         )
 
-        whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull())).thenReturn(
+        whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull())).thenReturn(
           PageImpl(
             listOf(
               aPrisonerSearchPrisoner.copy(
@@ -750,7 +750,7 @@ class CaCaseloadServiceTest {
 
       @Test
       fun `Should filter out cases with a legal status of DEAD`() {
-        whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull())).thenReturn(
+        whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull())).thenReturn(
           PageImpl(
             emptyList(),
           ),
@@ -791,7 +791,7 @@ class CaCaseloadServiceTest {
 
       @Test
       fun `should filter out ineligible cases`() {
-        whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull())).thenReturn(
+        whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull())).thenReturn(
           PageImpl(listOf(aPrisonerSearchPrisoner.copy(conditionalReleaseDate = null))),
         )
 
@@ -833,7 +833,7 @@ class CaCaseloadServiceTest {
           bookingId = "1234",
         )
 
-        whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull())).thenReturn(
+        whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull())).thenReturn(
           PageImpl(listOf(prisoner)),
         )
 
@@ -889,7 +889,7 @@ class CaCaseloadServiceTest {
           ),
         )
 
-        whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull())).thenReturn(
+        whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull())).thenReturn(
           PageImpl(
             listOf(
               aPrisonerSearchPrisoner.copy(
@@ -956,7 +956,7 @@ class CaCaseloadServiceTest {
           ),
         )
 
-        whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull())).thenReturn(
+        whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull())).thenReturn(
           PageImpl(
             listOf(
               aPrisonerSearchPrisoner.copy(
@@ -1022,7 +1022,7 @@ class CaCaseloadServiceTest {
           ),
         )
 
-        whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull())).thenReturn(
+        whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull())).thenReturn(
           PageImpl(
             listOf(
               aPrisonerSearchPrisoner.copy(
@@ -1090,7 +1090,7 @@ class CaCaseloadServiceTest {
           ),
         )
 
-        whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull())).thenReturn(
+        whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull())).thenReturn(
           PageImpl(
             listOf(
               aPrisonerSearchPrisoner.copy(
@@ -1431,7 +1431,7 @@ class CaCaseloadServiceTest {
       }
 
       whenever(prisonerSearchApiClient.searchPrisonersByNomisIds(any())).thenReturn(prisoners)
-      whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull())).thenReturn(
+      whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull())).thenReturn(
         PageImpl(emptyList()),
       )
 
@@ -1648,7 +1648,7 @@ class CaCaseloadServiceTest {
 
     @Test
     fun `should successfully search by probation practitioner name for offender on probation`() {
-      whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull())).thenReturn(
+      whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull())).thenReturn(
         PageImpl(emptyList()),
       )
       whenever(licenceCaseRepository.findLicenceCases(PrisonQuery.statusCodes, ProbationQuery.prisonCodes)).thenReturn(
@@ -2036,7 +2036,7 @@ class CaCaseloadServiceTest {
       }
 
       whenever(prisonerSearchApiClient.searchPrisonersByNomisIds(any())).thenReturn(prisoners)
-      whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull())).thenReturn(
+      whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull())).thenReturn(
         PageImpl(emptyList()),
       )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/caseload/ca/CaCaseloadServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/caseload/ca/CaCaseloadServiceTest.kt
@@ -186,7 +186,7 @@ class CaCaseloadServiceTest {
       ),
     )
 
-    whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull())).thenReturn(
+    whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), any())).thenReturn(
       PageImpl(
         listOf(
           aPrisonerSearchPrisoner,
@@ -263,7 +263,7 @@ class CaCaseloadServiceTest {
           ),
         )
 
-        whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull())).thenReturn(
+        whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), any())).thenReturn(
           PageImpl(
             listOf(
               aPrisonerSearchPrisoner.copy(
@@ -360,7 +360,7 @@ class CaCaseloadServiceTest {
           listOf(licenceCase1, licenceCase2),
         )
 
-        whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull())).thenReturn(
+        whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), any())).thenReturn(
           PageImpl(emptyList()),
         )
 
@@ -425,7 +425,7 @@ class CaCaseloadServiceTest {
         ),
       )
 
-      whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull())).thenReturn(
+      whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), any())).thenReturn(
         PageImpl(
           listOf(
             aPrisonerSearchPrisoner.copy(
@@ -454,6 +454,7 @@ class CaCaseloadServiceTest {
         LocalDate.now(clock).plusWeeks(4),
         setOf("BAI"),
         0,
+        includeRestrictedPatients = false,
       )
     }
 
@@ -495,7 +496,7 @@ class CaCaseloadServiceTest {
         ),
       )
 
-      whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull())).thenReturn(
+      whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), any())).thenReturn(
         PageImpl(
           listOf(
             aPrisonerSearchPrisoner.copy(
@@ -641,7 +642,7 @@ class CaCaseloadServiceTest {
           PrisonQuery.prisonCodes,
         ),
       ).thenReturn(listOf(licenceCase))
-      whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull())).thenReturn(
+      whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), any())).thenReturn(
         PageImpl(
           listOf(prisonerSearchResult()),
         ),
@@ -682,7 +683,7 @@ class CaCaseloadServiceTest {
         ),
       ).thenReturn(listOf(licenceCase))
 
-      whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull())).thenReturn(
+      whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), any())).thenReturn(
         PageImpl(
           listOf(prisonerSearchResult()),
         ),
@@ -725,7 +726,7 @@ class CaCaseloadServiceTest {
           ),
         )
 
-        whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull())).thenReturn(
+        whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), any())).thenReturn(
           PageImpl(
             listOf(
               aPrisonerSearchPrisoner.copy(
@@ -750,7 +751,7 @@ class CaCaseloadServiceTest {
 
       @Test
       fun `Should filter out cases with a legal status of DEAD`() {
-        whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull())).thenReturn(
+        whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), any())).thenReturn(
           PageImpl(
             emptyList(),
           ),
@@ -791,7 +792,7 @@ class CaCaseloadServiceTest {
 
       @Test
       fun `should filter out ineligible cases`() {
-        whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull())).thenReturn(
+        whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), any())).thenReturn(
           PageImpl(listOf(aPrisonerSearchPrisoner.copy(conditionalReleaseDate = null))),
         )
 
@@ -833,7 +834,7 @@ class CaCaseloadServiceTest {
           bookingId = "1234",
         )
 
-        whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull())).thenReturn(
+        whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), any())).thenReturn(
           PageImpl(listOf(prisoner)),
         )
 
@@ -889,7 +890,7 @@ class CaCaseloadServiceTest {
           ),
         )
 
-        whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull())).thenReturn(
+        whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), any())).thenReturn(
           PageImpl(
             listOf(
               aPrisonerSearchPrisoner.copy(
@@ -956,7 +957,7 @@ class CaCaseloadServiceTest {
           ),
         )
 
-        whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull())).thenReturn(
+        whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), any())).thenReturn(
           PageImpl(
             listOf(
               aPrisonerSearchPrisoner.copy(
@@ -1022,7 +1023,7 @@ class CaCaseloadServiceTest {
           ),
         )
 
-        whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull())).thenReturn(
+        whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), any())).thenReturn(
           PageImpl(
             listOf(
               aPrisonerSearchPrisoner.copy(
@@ -1090,7 +1091,7 @@ class CaCaseloadServiceTest {
           ),
         )
 
-        whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull())).thenReturn(
+        whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), any())).thenReturn(
           PageImpl(
             listOf(
               aPrisonerSearchPrisoner.copy(
@@ -1431,7 +1432,7 @@ class CaCaseloadServiceTest {
       }
 
       whenever(prisonerSearchApiClient.searchPrisonersByNomisIds(any())).thenReturn(prisoners)
-      whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull())).thenReturn(
+      whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), any())).thenReturn(
         PageImpl(emptyList()),
       )
 
@@ -1648,7 +1649,7 @@ class CaCaseloadServiceTest {
 
     @Test
     fun `should successfully search by probation practitioner name for offender on probation`() {
-      whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull())).thenReturn(
+      whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), any())).thenReturn(
         PageImpl(emptyList()),
       )
       whenever(licenceCaseRepository.findLicenceCases(PrisonQuery.statusCodes, ProbationQuery.prisonCodes)).thenReturn(
@@ -2036,7 +2037,7 @@ class CaCaseloadServiceTest {
       }
 
       whenever(prisonerSearchApiClient.searchPrisonersByNomisIds(any())).thenReturn(prisoners)
-      whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull())).thenReturn(
+      whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), any())).thenReturn(
         PageImpl(emptyList()),
       )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/caseload/timeServed/TimeServedCaseloadServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/caseload/timeServed/TimeServedCaseloadServiceTest.kt
@@ -41,7 +41,7 @@ class TimeServedCaseloadServiceTest {
       conditionalReleaseDate = today,
     )
 
-    whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull()))
+    whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull()))
       .thenReturn(PageImpl(listOf(prisoner)))
 
     val result = service.getCases("ABC")
@@ -64,7 +64,7 @@ class TimeServedCaseloadServiceTest {
       conditionalReleaseDateOverrideDate = today,
     )
 
-    whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull()))
+    whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull()))
       .thenReturn(PageImpl(listOf(prisoner)))
 
     val result = service.getCases("XYZ")
@@ -87,7 +87,7 @@ class TimeServedCaseloadServiceTest {
       conditionalReleaseDateOverrideDate = today,
     )
 
-    whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull()))
+    whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull()))
       .thenReturn(PageImpl(listOf(prisoner)))
 
     val result = service.getCases("MDI")
@@ -109,7 +109,7 @@ class TimeServedCaseloadServiceTest {
       conditionalReleaseDate = today,
     )
 
-    whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull()))
+    whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull()))
       .thenReturn(PageImpl(listOf(prisoner)))
 
     val result = service.getCases("MDI")
@@ -131,7 +131,7 @@ class TimeServedCaseloadServiceTest {
       conditionalReleaseDate = today,
     )
 
-    whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull()))
+    whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull()))
       .thenReturn(PageImpl(listOf(prisoner)))
 
     val result = service.getCases("MDI")
@@ -155,7 +155,7 @@ class TimeServedCaseloadServiceTest {
       conditionalReleaseDate = today,
     )
 
-    whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull()))
+    whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull()))
       .thenReturn(PageImpl(listOf(prisoner)))
     whenever(releaseDateService.isTimeServed(prisoner)).thenReturn(true)
 
@@ -178,7 +178,7 @@ class TimeServedCaseloadServiceTest {
       conditionalReleaseDateOverrideDate = today,
     )
 
-    whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull()))
+    whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull()))
       .thenReturn(PageImpl(listOf(prisoner)))
     whenever(releaseDateService.isTimeServed(prisoner)).thenReturn(true)
 
@@ -201,7 +201,7 @@ class TimeServedCaseloadServiceTest {
       conditionalReleaseDate = today,
     )
 
-    whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull()))
+    whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull()))
       .thenReturn(PageImpl(listOf(prisoner)))
 
     val result = service.getCases("MDI")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/caseload/timeServed/TimeServedCaseloadServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/caseload/timeServed/TimeServedCaseloadServiceTest.kt
@@ -41,7 +41,7 @@ class TimeServedCaseloadServiceTest {
       conditionalReleaseDate = today,
     )
 
-    whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull()))
+    whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), any()))
       .thenReturn(PageImpl(listOf(prisoner)))
 
     val result = service.getCases("ABC")
@@ -64,7 +64,7 @@ class TimeServedCaseloadServiceTest {
       conditionalReleaseDateOverrideDate = today,
     )
 
-    whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull()))
+    whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), any()))
       .thenReturn(PageImpl(listOf(prisoner)))
 
     val result = service.getCases("XYZ")
@@ -87,7 +87,7 @@ class TimeServedCaseloadServiceTest {
       conditionalReleaseDateOverrideDate = today,
     )
 
-    whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull()))
+    whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), any()))
       .thenReturn(PageImpl(listOf(prisoner)))
 
     val result = service.getCases("MDI")
@@ -109,7 +109,7 @@ class TimeServedCaseloadServiceTest {
       conditionalReleaseDate = today,
     )
 
-    whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull()))
+    whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), any()))
       .thenReturn(PageImpl(listOf(prisoner)))
 
     val result = service.getCases("MDI")
@@ -131,7 +131,7 @@ class TimeServedCaseloadServiceTest {
       conditionalReleaseDate = today,
     )
 
-    whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull()))
+    whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), any()))
       .thenReturn(PageImpl(listOf(prisoner)))
 
     val result = service.getCases("MDI")
@@ -155,7 +155,7 @@ class TimeServedCaseloadServiceTest {
       conditionalReleaseDate = today,
     )
 
-    whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull()))
+    whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), any()))
       .thenReturn(PageImpl(listOf(prisoner)))
     whenever(releaseDateService.isTimeServed(prisoner)).thenReturn(true)
 
@@ -178,7 +178,7 @@ class TimeServedCaseloadServiceTest {
       conditionalReleaseDateOverrideDate = today,
     )
 
-    whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull()))
+    whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), any()))
       .thenReturn(PageImpl(listOf(prisoner)))
     whenever(releaseDateService.isTimeServed(prisoner)).thenReturn(true)
 
@@ -201,7 +201,7 @@ class TimeServedCaseloadServiceTest {
       conditionalReleaseDate = today,
     )
 
-    whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), anyOrNull()))
+    whenever(prisonerSearchApiClient.searchPrisonersByReleaseDate(any(), any(), any(), anyOrNull(), any()))
       .thenReturn(PageImpl(listOf(prisoner)))
 
     val result = service.getCases("MDI")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/jobs/promptingCom/PromptComServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/jobs/promptingCom/PromptComServiceTest.kt
@@ -44,7 +44,7 @@ class PromptComServiceTest {
 
   @Test
   fun noRecords() {
-    whenever(prisonerSearchApiClient.getAllByReleaseDate(start, end)).thenReturn(emptyList())
+    whenever(prisonerSearchApiClient.getAllByReleaseDate(start, end, includeRestrictedPatients = false)).thenReturn(emptyList())
 
     val emails = promptComService.getCases(clock)
 
@@ -53,7 +53,7 @@ class PromptComServiceTest {
 
   @Test
   fun recordsProcessed() {
-    whenever(prisonerSearchApiClient.getAllByReleaseDate(start, end)).thenReturn(cases)
+    whenever(prisonerSearchApiClient.getAllByReleaseDate(start, end, includeRestrictedPatients = false)).thenReturn(cases)
 
     whenever(promptComListBuilder.excludeInflightLicences(any())).thenReturn(cases)
 
@@ -82,7 +82,7 @@ class PromptComServiceTest {
     assertThat(emails).containsExactly(com)
 
     inOrder(prisonerSearchApiClient, promptComListBuilder) {
-      verify(prisonerSearchApiClient).getAllByReleaseDate(start, end)
+      verify(prisonerSearchApiClient).getAllByReleaseDate(start, end, includeRestrictedPatients = false)
 
       verify(promptComListBuilder).excludeInflightLicences(cases)
 
@@ -106,7 +106,7 @@ class PromptComServiceTest {
 
   @Test
   fun sendNotifications() {
-    whenever(prisonerSearchApiClient.getAllByReleaseDate(start, end)).thenReturn(cases)
+    whenever(prisonerSearchApiClient.getAllByReleaseDate(start, end, includeRestrictedPatients = false)).thenReturn(cases)
     whenever(promptComListBuilder.excludeIneligibleCases(any(), any())).thenReturn(casesWithDeliusData)
     whenever(promptComListBuilder.excludeInflightLicences(any())).thenReturn(cases)
     whenever(cvlRecordService.getCvlRecords(any())).thenReturn(cvlRecords)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/prison/PrisonerSearchApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/prison/PrisonerSearchApiClientTest.kt
@@ -48,7 +48,7 @@ class PrisonerSearchApiClientTest {
     val foundResults =
       List(foundRecordsOnThisPage) { i -> prisonerSearchResult().copy(bookingId = "$pageNumber-$i") }
     wiremock.stubFor(
-      post("/prisoner-search/release-date-by-prison?size=$pageSize&page=$pageNumber")
+      post("/prisoner-search/release-date-by-prison?size=$pageSize&page=$pageNumber&includeSupportedByPrisons=false")
         .willReturn(
           aResponse().withHeader("Content-Type", "application/json").withBody(
             """

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/prison/PrisonerSearchApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/prison/PrisonerSearchApiClientTest.kt
@@ -32,23 +32,23 @@ class PrisonerSearchApiClientTest {
 
   @Test
   fun `search by teams endpoint not called if no teams`() {
-    stubPage(pageNumber = 0, foundRecordsOnThisPage = 4, pageSize = 4, totalElements = 10)
-    stubPage(pageNumber = 1, foundRecordsOnThisPage = 4, pageSize = 4, totalElements = 10)
-    stubPage(pageNumber = 2, foundRecordsOnThisPage = 2, pageSize = 4, totalElements = 10)
+    stubPage(pageNumber = 0, foundRecordsOnThisPage = 4, pageSize = 4, totalElements = 10, includeRestrictedPatients = false)
+    stubPage(pageNumber = 1, foundRecordsOnThisPage = 4, pageSize = 4, totalElements = 10, includeRestrictedPatients = false)
+    stubPage(pageNumber = 2, foundRecordsOnThisPage = 2, pageSize = 4, totalElements = 10, includeRestrictedPatients = false)
 
     val response =
-      prisonerSearchApiClient.getAllByReleaseDate(LocalDate.now(), LocalDate.now().plusWeeks(4), pageSize = 4)
+      prisonerSearchApiClient.getAllByReleaseDate(LocalDate.now(), LocalDate.now().plusWeeks(4), pageSize = 4, includeRestrictedPatients = false)
 
     assertThat(response).hasSize(10)
     assertThat(response).extracting<String> { it.bookingId }
       .isEqualTo(listOf("0-0", "0-1", "0-2", "0-3", "1-0", "1-1", "1-2", "1-3", "2-0", "2-1"))
   }
 
-  private fun stubPage(pageNumber: Int, foundRecordsOnThisPage: Int, pageSize: Int, totalElements: Int) {
+  private fun stubPage(pageNumber: Int, foundRecordsOnThisPage: Int, pageSize: Int, totalElements: Int, includeRestrictedPatients: Boolean) {
     val foundResults =
       List(foundRecordsOnThisPage) { i -> prisonerSearchResult().copy(bookingId = "$pageNumber-$i") }
     wiremock.stubFor(
-      post("/prisoner-search/release-date-by-prison?size=$pageSize&page=$pageNumber&includeSupportedByPrisons=false")
+      post("/prisoner-search/release-date-by-prison?size=$pageSize&page=$pageNumber&includeSupportedByPrisons=$includeRestrictedPatients")
         .willReturn(
           aResponse().withHeader("Content-Type", "application/json").withBody(
             """

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -119,7 +119,7 @@ feature:
     standardRecalls:
       enabled: true
     restrictedPatients:
-      enabled: true
+      enabled: false
     isr:
       repeal:
         date: "2026-05-16"


### PR DESCRIPTION
This PR is to amend the existing places where the prisoner search endpoint is used to include the new flag. This is currently defaulted to false. 