### PR TITLE
CVSL-4090 HDC - CVL Migration : prevent duplicate licences being HDC …

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/migration/MigrationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/migration/MigrationService.kt
@@ -69,6 +69,14 @@ class MigrationService(
     hdcLicence: HdcLicence,
   ) {
     request.conditions.additional.forEach { hdcCondition ->
+
+      migrationRepository.saveMetaData(
+        hdcLicence.id,
+        request.licence.licenceId,
+        request.licence.licenceVersion,
+        request.licence.varyVersion,
+      )
+
       val saveCondition = hdcLicence.bespokeConditions.findLast { it.conditionText == hdcCondition.text }!!
       migrationRepository.saveConditionMetaData(
         licenceId = hdcLicence.id,
@@ -77,12 +85,6 @@ class MigrationService(
         hdcCondition.conditionsVersion,
       )
     }
-    migrationRepository.saveMetaData(
-      hdcLicence.id,
-      request.licence.licenceId,
-      request.licence.licenceVersion,
-      request.licence.varyVersion,
-    )
   }
 
   fun MigrateFromHdcToCvlRequest.toHdcLicence(): HdcLicence {

--- a/src/main/resources/migration/common/V74__create_hdc_meta_migration_constraint.sql
+++ b/src/main/resources/migration/common/V74__create_hdc_meta_migration_constraint.sql
@@ -1,0 +1,1 @@
+ALTER TABLE hdc_migration_meta_data ADD CONSTRAINT uq_hdc_licence_id UNIQUE (hdcLicence_id);

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -104,7 +104,7 @@ hmpps:
       attachments-expected: true
       # When changing expected schema version this should act as a prompt to consider whether SAR requires updating
       # check with the rest of the team to see if this is required
-      expected-flyway-schema-version: 73
+      expected-flyway-schema-version: 74
       expected-jpa-entity-schema:
         path: /sar/entity-schema.json
       expected-api-response:


### PR DESCRIPTION
HDC - CVL Migration : prevent duplicate licences being HDC to CVL MIGRATION committed at the same time due to race condition. Idea is it will cause a role back in one of the threads report the error back to HDC api,.. might have to find the exception type and make it none retry able..
