### PR TITLE
CVSL-4096 remove log statement as no longer needed

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/domainEvents/PrisonerUpdatedHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/domainEvents/PrisonerUpdatedHandler.kt
@@ -84,8 +84,6 @@ class PrisonerUpdatedHandler(
 
       val prisonInformation = prisonApiClient.getPrisonInformation(nomisRecord.supportingPrisonId!!)
 
-      log.info("Updating supporting prison information for ${licences.size} licences for nomisId: $nomsId with prison code: ${prisonInformation.prisonId}, description: ${prisonInformation.description}, telephone: ${prisonInformation.getPrisonContactNumber()}")
-
       updateLicences(licences, prisonInformation)
 
       log.info("Processed prisoner updated event for nomis id: $nomsId")


### PR DESCRIPTION
Remove log statement after debugging testing issues for the supporting prison event consumption. 