### PR TITLE
CVSL-4228 increase memory size

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/config/WebClientConfiguration.kt
@@ -13,7 +13,7 @@ import uk.gov.justice.hmpps.kotlin.auth.service.GlobalPrincipalOAuth2AuthorizedC
 
 private const val HMPPS_AUTH = "hmpps-auth"
 private const val MAX_IN_MEMORY_SIZE = 10485760 // 10 MB
-private const val MAX_IN_MEMORY_PRISONER_SEARCH_SIZE = 12582912 // 12 MB
+private const val MAX_IN_MEMORY_SIZE_EXTENDED = 12582912 // 12 MB
 
 @Configuration
 class WebClientConfiguration(
@@ -71,7 +71,7 @@ class WebClientConfiguration(
     prisonerSearchApiUrl,
     authorizedClientManagerCvl,
     builder,
-    maxInMemorySize = MAX_IN_MEMORY_PRISONER_SEARCH_SIZE,
+    maxInMemorySize = MAX_IN_MEMORY_SIZE_EXTENDED,
   )
 
   @Bean
@@ -84,7 +84,7 @@ class WebClientConfiguration(
   fun oauthDeliusApiClient(
     authorizedClientManagerCvl: OAuth2AuthorizedClientManager,
     builder: WebClient.Builder,
-  ): WebClient = getWebClient(deliusApiUrl, authorizedClientManagerCvl, builder)
+  ): WebClient = getWebClient(deliusApiUrl, authorizedClientManagerCvl, builder, maxInMemorySize = MAX_IN_MEMORY_SIZE_EXTENDED)
 
   @Bean
   fun oauthWorkLoadApiClient(


### PR DESCRIPTION
This PR increases the maximum in memory size for the Delius client from 10MB to 12MB to stop alerts around a DataBufferLimitException and exceeding the maximum size.