### PR TITLE
CVSL-4407 - change exceptions when missing com to not retry

### DIFF
--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -45,8 +45,10 @@
     <ID>ReturnCount:EligibilityService.kt:EligibilityService$private fun isEligibleIfOnAnExtendedDeterminateSentence: Boolean</ID>
     <ID>ReturnCount:EligibilityService.kt:EligibilityService$private fun isRecallCase: Boolean</ID>
     <ID>ReturnCount:EligibilityService.kt:EligibilityService$private fun isRecallEligibleIfOnAnExtendedDeterminateSentence: Boolean</ID>
+    <ID>ReturnCount:LicenceCreationService.kt:LicenceCreationService$fun getOrCreateCom: CommunityOffenderManager?</ID>
     <ID>ReturnCount:LsdRecalculationService.kt:LsdRecalculationService$@Transactional fun batchUpdateLicenceStartDate: Long</ID>
     <ID>ReturnCount:NotifyService.kt:NotifyService$private fun sendEmail: Boolean</ID>
+    <ID>SwallowedException:MigrationService.kt:MigrationService$e: IllegalStateException</ID>
     <ID>TooGenericExceptionCaught:ComAllocatedHandler.kt:ComAllocatedHandler$e: Exception</ID>
     <ID>TooGenericExceptionCaught:UploadFileConditionsService.kt:UploadFileConditionsService$e: Exception</ID>
     <ID>TooManyFunctions:AuditService.kt:AuditService</ID>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/config/ControllerAdvice.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/config/ControllerAdvice.kt
@@ -18,6 +18,7 @@ import org.springframework.web.client.RestClientResponseException
 import org.springframework.web.method.annotation.HandlerMethodValidationException
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.migration.noRetryExceptions.ExistingCvlLicenceException
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.migration.noRetryExceptions.LicenceAlreadyMigratedException
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.migration.noRetryExceptions.MissingStaffException
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.migration.noRetryExceptions.OffenderManagerNotFoundException
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.InvalidStateException
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.resource.ResourceAlreadyExistsException
@@ -219,6 +220,7 @@ class ControllerAdvice {
     ExistingCvlLicenceException::class,
     LicenceAlreadyMigratedException::class,
     OffenderManagerNotFoundException::class,
+    MissingStaffException::class,
   )
   fun handleNoRetryMigrationLicenceException(e: Exception): ResponseEntity<ErrorResponse> {
     log.info("NoRetryMigrationLicenceException: {}", e.message)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/migration/MigrationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/migration/MigrationService.kt
@@ -138,7 +138,7 @@ class MigrationService(
   fun MigrateFromHdcToCvlRequest.toHdcLicence(): HdcLicence {
     val offenderManager = getOffenderManager(prisoner.prisonerNumber)
     val probationTeam = offenderManager.team
-    val responsibleCom = getResponsibleCom(offenderManager.id)
+    val responsibleCom = getCommunityOffenderManager(offenderManager.id)
 
     val prisonInformation = prisonService.getPrisonInformation(prison.prisonCode)
 
@@ -302,7 +302,7 @@ class MigrationService(
   ): CommunityOffenderManager = coms.firstOrNull { it.username == userName }
     ?: licenceCreationService.getOrCreateCom(userName) ?: throw MissingStaffException("Missing Com using username '$userName'")
 
-  private fun getResponsibleCom(staffId: Long): CommunityOffenderManager {
+  private fun getCommunityOffenderManager(staffId: Long): CommunityOffenderManager {
     try {
       return licenceCreationService.getOrCreateCom(staffId)
     } catch (e: IllegalStateException) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/migration/MigrationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/migration/MigrationService.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.address.Addr
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.entity.address.hdc.HdcCurfewAddress
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.migration.noRetryExceptions.ExistingCvlLicenceException
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.migration.noRetryExceptions.LicenceAlreadyMigratedException
+import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.migration.noRetryExceptions.MissingStaffException
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.migration.noRetryExceptions.OffenderManagerNotFoundException
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.migration.repository.MigrationRepository
 import uk.gov.justice.digital.hmpps.createandvaryalicenceapi.migration.request.MigrateAppointmentAddress
@@ -137,7 +138,7 @@ class MigrationService(
   fun MigrateFromHdcToCvlRequest.toHdcLicence(): HdcLicence {
     val offenderManager = getOffenderManager(prisoner.prisonerNumber)
     val probationTeam = offenderManager.team
-    val responsibleCom = licenceCreationService.getOrCreateCom(offenderManager.id)
+    val responsibleCom = getResponsibleCom(offenderManager.id)
 
     val prisonInformation = prisonService.getPrisonInformation(prison.prisonCode)
 
@@ -299,7 +300,15 @@ class MigrationService(
     userName: String,
     coms: Set<CommunityOffenderManager>,
   ): CommunityOffenderManager = coms.firstOrNull { it.username == userName }
-    ?: licenceCreationService.getOrCreateCom(userName)
+    ?: licenceCreationService.getOrCreateCom(userName) ?: throw MissingStaffException("Missing Com using username '$userName'")
+
+  private fun getResponsibleCom(staffId: Long): CommunityOffenderManager {
+    try {
+      return licenceCreationService.getOrCreateCom(staffId)
+    } catch (e: IllegalStateException) {
+      throw MissingStaffException("Missing Com using staffId $staffId")
+    }
+  }
 
   companion object {
     val log: Logger = LoggerFactory.getLogger(this::class.java)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/migration/noRetryExceptions/MissingStaffException.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/migration/noRetryExceptions/MissingStaffException.kt
@@ -1,0 +1,3 @@
+package uk.gov.justice.digital.hmpps.createandvaryalicenceapi.migration.noRetryExceptions
+
+class MissingStaffException(message: String) : Exception(message)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceCreationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/createandvaryalicenceapi/service/LicenceCreationService.kt
@@ -299,19 +299,19 @@ class LicenceCreationService(
     )
   }
 
-  fun getOrCreateCom(userName: String): CommunityOffenderManager {
+  fun getOrCreateCom(userName: String): CommunityOffenderManager? {
     log.info("Searching for persisted COM with userName: $userName")
     val staff = staffRepository.findACommunityOffenderManagerIgnoreCase(userName)
     if (staff != null) {
       return staff
     }
     log.info("Creating COM record for staff with userName: $userName")
-    val user = deliusApiClient.getStaffByUserName(userName) ?: missing(userName, "record in delius")
+    val user = deliusApiClient.getStaffByUserName(userName) ?: return null
     return staffRepository.saveAndFlush(
       CommunityOffenderManager(
         staffIdentifier = user.id,
         staffCode = user.code,
-        username = user.username?.uppercase() ?: missing(userName, "username"),
+        username = userName,
         email = user.email,
         firstName = user.name.forename,
         lastName = user.name.surname,
@@ -320,8 +320,6 @@ class LicenceCreationService(
   }
 
   private fun missing(staffId: Long, field: String): Nothing = error("staff with staff identifier: '$staffId', missing $field")
-
-  private fun missing(username: String, field: String): Nothing = error("staff with staff username: '$username', missing $field")
 
   private fun getPrisonInformation(nomisRecord: PrisonerSearchPrisoner): Prison {
     val prisonCode = if (nomisRecord.isRestrictedPatient()) nomisRecord.supportingPrisonId!! else nomisRecord.prisonId!!


### PR DESCRIPTION
Changed exception type to not retry when missing com, most of the com issues are an issue with preprod,.. and if they occur in live we dont want them to push the message on DLQ